### PR TITLE
U6 — braid-cli + CI manifest-widening gate (#2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: build · test · lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      # //why scoped to braid-cli, not --all: the pre-extraction crates were
+      # committed without a rustfmt pass, so a workspace fmt gate would fail on
+      # code U6 didn't touch. Formatting the whole workspace is its own
+      # deliberate PR (tracked follow-up), not smuggled into U6.
+      - name: format (braid-cli)
+        run: cargo fmt -p braid-cli -- --check
+      - name: clippy (warnings are errors)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: test
+        run: cargo test --workspace
+
+  cli-loop:
+    name: scenario #12 + T12 widening gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: build braid binary
+        run: cargo build --release -p braid-cli
+      # The human-reconstructable loop, driven through the real binary, with
+      # every exit code asserted — including the manifest-widening gate firing
+      # on a seeded widening (T12) and a laundering capsule rejected at taint.
+      - name: CLI-only loop
+        run: ./scripts/cli-loop.sh target/release/braid

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "braid-cli"
+version = "0.1.0"
+dependencies = [
+ "braid-capability",
+ "braid-ir",
+ "braid-render",
+ "braid-sdk",
+ "braid-verify",
+ "hex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "braid-ir"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/braid-verify",
     "crates/braid-render",
     "crates/braid-sdk",
+    "crates/braid-cli",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -24,16 +24,18 @@ for exactly what changed in the move.
 | `crates/braid-verify` | Independent strict decoder + fail-closed admission pipeline; zero shared serialization code with `braid-ir` (D9 anti-trusting-trust) (U3–U5 #560). |
 | `crates/braid-render` | CID-bound manifest, deterministic text rendering, widening/narrowing diff, DOT graph export (U2 #559). |
 | `crates/braid-sdk` | Typed authoring builder over `braid-ir`; reproduces reference CIDs byte-for-byte (U10). |
+| `crates/braid-cli` | The `braid` binary: `encode`/`decode`/`verify`/`render`/`diff` — the human-reconstructable loop (no AI, no Rust). `encode` reads JSON-of-IR (D19) through the SDK (U6 #2). |
 | `crates/braid-capability` | **Vendored** kernel capability contract — a verbatim mirror of `canvas-protocol::Capability` on the kernel `origin/main` (the single type that crosses the ADR-088 D3 boundary). |
 | `spec/braid/` | PRD, decision register (`DECISIONS.md`), threat model, unit plan, KAT vectors. **Start here: `spec/braid/README.md`.** |
-| `docs/` | ADR-088 (ratified doctrine + locked invariants). |
+| `docs/` | ADR-088 (ratified doctrine + locked invariants); `authoring-cli.md` (hand-author a capsule). |
 
 ## Build & test
 
 ```bash
 cargo check --workspace
-cargo test --workspace      # 68 tests
+cargo test --workspace      # 79 tests
 cargo clippy --workspace --all-targets
+./scripts/cli-loop.sh       # scenario #12 end-to-end (also a CI job)
 ```
 
 ## Boundary

--- a/crates/braid-cli/Cargo.toml
+++ b/crates/braid-cli/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "braid-cli"
+version = "0.1.0"
+edition = "2021"
+description = "Braid CLI — the human-reconstructable encode/decode/verify/render/diff loop (ADR-088 G6/L7, U6 #2)"
+
+[[bin]]
+name = "braid"
+path = "src/main.rs"
+
+# //why braid-cli sits OUTSIDE the boundary-conformance allowlist (which scans
+# only braid-ir/-verify/-render — the verified core): like braid-sdk, the CLI is
+# an authoring/operator convenience, not part of the trust base. It may use a
+# third-party JSON parser (D19 JSON-of-IR transport) because it never decides
+# admission — it routes author input through the SDK Builder and the canonical
+# encoder, then hands bytes to the same braid-verify the SDK path uses.
+[dependencies]
+braid-ir = { workspace = true }
+braid-verify = { workspace = true }
+braid-render = { workspace = true }
+braid-sdk = { path = "../braid-sdk" }
+braid-capability = { workspace = true }
+serde = { workspace = true }
+serde_json = "1.0.140"
+
+[dev-dependencies]
+hex = { workspace = true }

--- a/crates/braid-cli/src/main.rs
+++ b/crates/braid-cli/src/main.rs
@@ -1,0 +1,392 @@
+//! # braid — the human-reconstructable CLI loop (ADR-088 G6/L7, U6 #2)
+//!
+//! `encode | decode | verify | render | diff` — the same admission loop the
+//! Rust SDK drives, reachable by a human with no AI and no Rust toolchain
+//! (scenario #12, threat T13). The CLI is NOT a second verifier: `encode`
+//! routes author input through the `braid-sdk` Builder + the canonical
+//! encoder, and `verify` calls the one `braid-verify` the SDK path uses. The
+//! CLI adds zero authority and zero admission semantics.
+//!
+//! ## `encode` input — JSON-of-IR (D19, Director-selected 2026-06-14)
+//!
+//! A 1:1 data transcription of the IR — NOT a surface grammar (the PRD
+//! non-goal D17 keeps gated). Grants are derived from the terms used;
+//! `vocab_version`/`registry_cid`/`ir_version` come from the pinned registry,
+//! never hand-typed. So the CLI path is byte-identical to the SDK path and
+//! reproduces the pinned reference CIDs.
+//!
+//! ```json
+//! {
+//!   "intent": "Edit landing section and render preview (reversible)",
+//!   "budget": 20,
+//!   "confirm": "none",
+//!   "evidence": ["fact.cid"],
+//!   "strands": [
+//!     {"term": "lit.entity", "inputs": []},
+//!     {"term": "lit.text", "inputs": []},
+//!     {"term": "cms.edit_section", "inputs": [0, 1]},
+//!     {"term": "view.section", "inputs": [1]}
+//!   ],
+//!   "outputs": [2, 3]
+//! }
+//! ```
+//! `budget`, `confirm`, `evidence` are optional (budget defaults to the
+//! composed cost; a dangerous capsule with no `confirm` is refused at author
+//! time, fail-closed). Unknown keys are rejected.
+
+use std::process::ExitCode;
+
+use braid_ir::registry_v0;
+use braid_ir::{Capsule, ConfirmPolicy};
+use braid_render::{has_widening, manifest, manifest_diff, render_text, DeltaKind};
+use braid_sdk::Builder;
+use braid_verify::{verify, Verdict};
+use serde::{Deserialize, Serialize};
+
+// ── JSON-of-IR author form (D19). `deny_unknown_fields` mirrors the IR's
+//    require_only_keys anti-smuggling discipline: an unrecognized key is a
+//    rejected author input, never silently dropped. ──
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct JsonCapsule {
+    intent: String,
+    #[serde(default)]
+    budget: Option<u64>,
+    #[serde(default)]
+    confirm: Option<String>,
+    #[serde(default)]
+    evidence: Vec<String>,
+    strands: Vec<JsonStrand>,
+    outputs: Vec<u32>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct JsonStrand {
+    term: String,
+    inputs: Vec<u32>,
+}
+
+#[derive(Serialize)]
+struct JsonCapsuleOut {
+    intent: String,
+    budget: u64,
+    confirm: String,
+    evidence: Vec<String>,
+    strands: Vec<JsonStrand>,
+    outputs: Vec<u32>,
+}
+
+/// Operator error (usage / IO / malformed input / author-time reject). Distinct
+/// from a *policy-negative* outcome (verifier Reject, diff Widening), which is
+/// a successful run reporting a deny and uses exit code 1.
+type CliResult = Result<(), String>;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let cmd = match args.first() {
+        Some(c) => c.as_str(),
+        None => {
+            eprintln!("{USAGE}");
+            return ExitCode::from(2);
+        }
+    };
+    let rest = &args[1..];
+    let outcome = match cmd {
+        "encode" => cmd_encode(rest),
+        "decode" => cmd_decode(rest),
+        "verify" => cmd_verify(rest),
+        "render" => cmd_render(rest),
+        "diff" => cmd_diff(rest),
+        "-h" | "--help" | "help" => {
+            println!("{USAGE}");
+            return ExitCode::SUCCESS;
+        }
+        other => Err(format!("unknown command `{other}`\n\n{USAGE}")),
+    };
+    match outcome {
+        Ok(()) => ExitCode::SUCCESS,
+        // Policy-negative: a clean run that ends in a deny. Exit 1 so CI gates
+        // and shell `&&` chains treat it as a failure, distinct from operator
+        // error (exit 2).
+        Err(e) if e == POLICY_NEGATIVE => ExitCode::from(1),
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+/// Sentinel: the command ran correctly and the answer is "denied" (reject /
+/// widening). Carried as an Err so `main` can map it to exit 1, but it is NOT
+/// an operator error — the human-readable verdict was already printed.
+const POLICY_NEGATIVE: &str = "\0policy-negative";
+
+const USAGE: &str = "\
+braid — machine-first capsule loop (ADR-088 U6)
+
+USAGE:
+    braid encode <input.json> [-o <out.braid>]   author JSON-of-IR -> canonical bytes (+ CID)
+    braid decode <capsule.braid>                 canonical bytes -> JSON-of-IR (inverse of encode)
+    braid verify <capsule.braid> [--grant <cap>] run the admission pipeline (exit 1 on Reject)
+    braid render <capsule.braid>                 the human-review manifest
+    braid diff <old.braid> <new.braid>           manifest delta (exit 1 on any Widening)
+
+EXIT CODES: 0 ok · 1 policy-negative (Reject / Widening) · 2 operator error
+
+`verify --grant` may repeat; it sets the ambient authority the principal holds.
+Default ambient = the capsule's own declared grants (the happy-path check).";
+
+// ───────────────────────────────── encode ─────────────────────────────────
+
+fn cmd_encode(args: &[String]) -> CliResult {
+    let mut input: Option<&str> = None;
+    let mut out: Option<&str> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-o" | "--out" => {
+                out = Some(args.get(i + 1).ok_or("`-o` needs a path")?.as_str());
+                i += 2;
+            }
+            p if !p.starts_with('-') && input.is_none() => {
+                input = Some(p);
+                i += 1;
+            }
+            other => return Err(format!("unexpected arg `{other}` (encode)")),
+        }
+    }
+    let path = input.ok_or("encode needs <input.json>")?;
+    let text = read_text(path)?;
+    let jc: JsonCapsule =
+        serde_json::from_str(&text).map_err(|e| format!("{path}: invalid JSON-of-IR: {e}"))?;
+
+    let capsule = build_from_json(jc)?;
+    let bytes = capsule.to_bytes();
+    let cid = capsule.cid();
+
+    match out {
+        Some(p) => {
+            std::fs::write(p, &bytes).map_err(|e| format!("write {p}: {e}"))?;
+            // CID to stderr so stdout stays clean for piping; the artifact is
+            // the file. A human can re-derive this CID from the bytes alone.
+            eprintln!("wrote {p} ({} bytes)\ncid {}", bytes.len(), cid.to_hex());
+        }
+        None => {
+            use std::io::Write;
+            std::io::stdout()
+                .write_all(&bytes)
+                .map_err(|e| format!("stdout: {e}"))?;
+            eprintln!("cid {}", cid.to_hex());
+        }
+    }
+    Ok(())
+}
+
+/// Route JSON-of-IR through the SDK Builder (D19). The Builder derives grants,
+/// pins the registry, and runs the author-time checks the verifier repeats —
+/// so a CLI-authored capsule is byte-identical to an SDK-authored one.
+fn build_from_json(jc: JsonCapsule) -> Result<Capsule, String> {
+    let registry = registry_v0();
+    let mut b = Builder::new(&registry, jc.intent);
+
+    let mut handles = Vec::with_capacity(jc.strands.len());
+    for (i, js) in jc.strands.iter().enumerate() {
+        let mut inputs = Vec::with_capacity(js.inputs.len());
+        for &idx in &js.inputs {
+            // A handle exists only for an already-placed strand. A forward /
+            // self reference is unrepresentable in the IR (acyclicity is
+            // structural); reject it here with a clear author message instead
+            // of indexing out of bounds.
+            let h = handles.get(idx as usize).ok_or_else(|| {
+                format!(
+                    "strand {i} `{}` references input strand {idx}, which is not defined before it \
+                     (inputs must reference strictly earlier strands)",
+                    js.term
+                )
+            })?;
+            inputs.push(*h);
+        }
+        let h = b
+            .strand(&js.term, &inputs)
+            .map_err(|e| format!("strand {i} `{}`: {e:?}", js.term))?;
+        handles.push(h);
+    }
+
+    for &o in &jc.outputs {
+        let h = handles
+            .get(o as usize)
+            .ok_or_else(|| format!("output references strand {o}, which does not exist"))?;
+        b.output(*h);
+    }
+    if let Some(bud) = jc.budget {
+        b.budget(bud);
+    }
+    if let Some(c) = &jc.confirm {
+        b.confirm(parse_confirm(c)?);
+    }
+    for e in jc.evidence {
+        b.evidence(e);
+    }
+    b.build().map_err(|e| format!("author-time reject: {e:?}"))
+}
+
+// ───────────────────────────────── decode ─────────────────────────────────
+
+fn cmd_decode(args: &[String]) -> CliResult {
+    let path = single_path(args, "decode")?;
+    let capsule = read_capsule(path)?;
+    let out = JsonCapsuleOut {
+        intent: capsule.intent.clone(),
+        budget: capsule.budget,
+        confirm: confirm_str(capsule.confirm).to_string(),
+        evidence: capsule.evidence.clone(),
+        strands: capsule
+            .braid
+            .strands
+            .iter()
+            .map(|s| JsonStrand {
+                term: s.term.clone(),
+                inputs: s.inputs.clone(),
+            })
+            .collect(),
+        outputs: capsule.braid.outputs.clone(),
+    };
+    let json = serde_json::to_string_pretty(&out).map_err(|e| format!("serialize: {e}"))?;
+    println!("{json}");
+    Ok(())
+}
+
+// ───────────────────────────────── verify ─────────────────────────────────
+
+fn cmd_verify(args: &[String]) -> CliResult {
+    let mut path: Option<&str> = None;
+    let mut grants: Vec<braid_capability::Capability> = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--grant" => {
+                let name = args.get(i + 1).ok_or("`--grant` needs a capability")?;
+                let cap = name
+                    .parse()
+                    .map_err(|_| format!("unknown capability `{name}`"))?;
+                grants.push(cap);
+                i += 2;
+            }
+            p if !p.starts_with('-') && path.is_none() => {
+                path = Some(p);
+                i += 1;
+            }
+            other => return Err(format!("unexpected arg `{other}` (verify)")),
+        }
+    }
+    let path = path.ok_or("verify needs <capsule.braid>")?;
+    let bytes = read_bytes(path)?;
+
+    // Default ambient = the capsule's own declared grants (a principal
+    // authorized for exactly what it requests) — the happy-path admission
+    // check. `--grant` overrides to model a narrower (or wider) principal,
+    // e.g. to demonstrate the attenuation reject.
+    let ambient = if grants.is_empty() {
+        read_capsule(path)?.grants
+    } else {
+        grants
+    };
+
+    let registry = registry_v0();
+    match verify(&bytes, &registry, &ambient) {
+        Verdict::Admit { capsule_cid } => {
+            println!("ADMIT  cid {}", capsule_cid.to_hex());
+            Ok(())
+        }
+        Verdict::Reject { stage, reason } => {
+            println!("REJECT [{stage:?}] {reason}");
+            Err(POLICY_NEGATIVE.to_string())
+        }
+    }
+}
+
+// ───────────────────────────────── render ─────────────────────────────────
+
+fn cmd_render(args: &[String]) -> CliResult {
+    let path = single_path(args, "render")?;
+    let capsule = read_capsule(path)?;
+    let registry = registry_v0();
+    let m = manifest(&capsule, &registry).map_err(|e| format!("render: {e:?}"))?;
+    print!("{}", render_text(&m));
+    Ok(())
+}
+
+// ────────────────────────────────── diff ──────────────────────────────────
+
+fn cmd_diff(args: &[String]) -> CliResult {
+    if args.len() != 2 {
+        return Err("diff needs <old.braid> <new.braid>".into());
+    }
+    let registry = registry_v0();
+    let old = read_capsule(&args[0])?;
+    let new = read_capsule(&args[1])?;
+    let m_old = manifest(&old, &registry).map_err(|e| format!("render old: {e:?}"))?;
+    let m_new = manifest(&new, &registry).map_err(|e| format!("render new: {e:?}"))?;
+    let deltas = manifest_diff(&m_old, &m_new);
+
+    if deltas.is_empty() {
+        println!("no change");
+        return Ok(());
+    }
+    for d in &deltas {
+        let tag = match d.kind {
+            DeltaKind::Widening => "WIDENING",
+            DeltaKind::Narrowing => "narrowing",
+            DeltaKind::Neutral => "neutral",
+        };
+        println!("{tag:9} {}: {}", d.field, d.detail);
+    }
+    // The CI gate's one-bit answer (T12): any widening fails the run.
+    if has_widening(&deltas) {
+        Err(POLICY_NEGATIVE.to_string())
+    } else {
+        Ok(())
+    }
+}
+
+// ───────────────────────────────── helpers ─────────────────────────────────
+
+fn parse_confirm(s: &str) -> Result<ConfirmPolicy, String> {
+    match s {
+        "none" => Ok(ConfirmPolicy::None),
+        "human-confirm" => Ok(ConfirmPolicy::HumanConfirm),
+        other => Err(format!(
+            "invalid confirm `{other}` (expected `none` or `human-confirm`)"
+        )),
+    }
+}
+
+fn confirm_str(c: ConfirmPolicy) -> &'static str {
+    match c {
+        ConfirmPolicy::None => "none",
+        ConfirmPolicy::HumanConfirm => "human-confirm",
+    }
+}
+
+fn single_path<'a>(args: &'a [String], cmd: &str) -> Result<&'a str, String> {
+    match args {
+        [p] if !p.starts_with('-') => Ok(p.as_str()),
+        _ => Err(format!("{cmd} needs exactly one <path>")),
+    }
+}
+
+fn read_text(path: &str) -> Result<String, String> {
+    std::fs::read_to_string(path).map_err(|e| format!("read {path}: {e}"))
+}
+
+fn read_bytes(path: &str) -> Result<Vec<u8>, String> {
+    std::fs::read(path).map_err(|e| format!("read {path}: {e}"))
+}
+
+/// Strict-decode a capsule file (bijection-guarded canonical bytes only).
+fn read_capsule(path: &str) -> Result<Capsule, String> {
+    let bytes = read_bytes(path)?;
+    Capsule::from_bytes(&bytes).map_err(|e| format!("{path}: not a canonical capsule: {e:?}"))
+}

--- a/crates/braid-cli/tests/cli_loop.rs
+++ b/crates/braid-cli/tests/cli_loop.rs
@@ -1,0 +1,242 @@
+//! U6 acceptance — the CLI-only loop (scenario #12, threats T12/T13).
+//!
+//! These drive the REAL binary (`CARGO_BIN_EXE_braid`) so the contract under
+//! test includes exit codes — the bit CI and shell `&&` chains depend on:
+//!   0 = ok · 1 = policy-negative (Reject / Widening) · 2 = operator error.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn braid() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_braid"))
+}
+
+fn fixtures() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+fn tmp(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_TARGET_TMPDIR")).join(name)
+}
+
+fn run(args: &[&str]) -> Output {
+    braid().args(args).output().expect("braid binary runs")
+}
+
+/// `encode <fixture> -o <out>` and return the out path + the CID printed to
+/// stderr (`cid <hex>`).
+fn encode(fixture: &str, out_name: &str) -> (PathBuf, String) {
+    let src = fixtures().join(fixture);
+    let out = tmp(out_name);
+    let o = run(&["encode", src.to_str().unwrap(), "-o", out.to_str().unwrap()]);
+    assert!(
+        o.status.success(),
+        "encode {fixture} failed: {}",
+        String::from_utf8_lossy(&o.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&o.stderr);
+    let cid = stderr
+        .lines()
+        .find_map(|l| l.strip_prefix("cid "))
+        .expect("encode prints `cid <hex>`")
+        .trim()
+        .to_string();
+    (out, cid)
+}
+
+/// T13 — the CLI authoring path is byte-identical to the SDK path: encoding the
+/// edit-section fixture reproduces the PINNED reference CID (the same KAT the
+/// braid-ir/braid-sdk paths pin). The CLI is not a second, drifting authoring
+/// surface.
+#[test]
+fn encode_reproduces_pinned_reference_cid() {
+    let (_, cid) = encode("edit_section.json", "edit_kat.braid");
+    assert_eq!(
+        cid, "8221c8b58bceea6a4f9129260fa1eb8c6179c7206f37a769d45a542a4f1fe130",
+        "CLI-authored edit_section CID drifted from the pinned KAT — CLI path != SDK path"
+    );
+}
+
+/// Scenario #12 — a human, no AI, CLI only: author -> verify -> render, same
+/// verdict and artifact as the AI/SDK path.
+#[test]
+fn cli_only_loop_admits_and_renders() {
+    let (out, cid) = encode("edit_section.json", "loop.braid");
+
+    let v = run(&["verify", out.to_str().unwrap()]);
+    assert!(v.status.success(), "verify should ADMIT");
+    let vout = String::from_utf8_lossy(&v.stdout);
+    assert!(vout.contains("ADMIT"), "got: {vout}");
+    assert!(vout.contains(&cid), "verdict binds the same CID");
+
+    let r = run(&["render", out.to_str().unwrap()]);
+    assert!(r.status.success());
+    let manifest = String::from_utf8_lossy(&r.stdout);
+    assert!(
+        manifest.contains(&cid),
+        "manifest is bound to the capsule CID"
+    );
+    assert!(manifest.contains("capabilities: signal.emit"));
+}
+
+/// `decode` is the inverse of `encode`: decoding then re-encoding reproduces
+/// byte-identical canonical bytes (same CID).
+#[test]
+fn decode_round_trips_to_identical_bytes() {
+    let (out, cid) = encode("edit_section.json", "rt.braid");
+
+    let d = run(&["decode", out.to_str().unwrap()]);
+    assert!(d.status.success());
+    let json_path = tmp("rt_decoded.json");
+    std::fs::write(&json_path, &d.stdout).unwrap();
+
+    let re = run(&[
+        "encode",
+        json_path.to_str().unwrap(),
+        "-o",
+        tmp("rt2.braid").to_str().unwrap(),
+    ]);
+    assert!(re.status.success(), "re-encode of decoded JSON failed");
+    let cid2 = String::from_utf8_lossy(&re.stderr)
+        .lines()
+        .find_map(|l| l.strip_prefix("cid ").map(|s| s.trim().to_string()))
+        .unwrap();
+    assert_eq!(
+        cid, cid2,
+        "encode∘decode is not identity-preserving on the CID"
+    );
+}
+
+/// T12 — the manifest-widening gate. A capsule that grows authority/effect is
+/// flagged WIDENING and the command exits non-zero (the CI gate's one bit).
+///
+/// MUTATION: this is the red-team test. Make `braid_render::has_widening`
+/// always return false (or reclassify Widening as Neutral) and this goes RED —
+/// the gate has teeth.
+#[test]
+fn diff_flags_widening_and_exits_nonzero() {
+    let (base, _) = encode("edit_section.json", "w_base.braid");
+    let (wide, _) = encode("edit_section_widened.json", "w_wide.braid");
+
+    let d = run(&["diff", base.to_str().unwrap(), wide.to_str().unwrap()]);
+    assert_eq!(
+        d.status.code(),
+        Some(1),
+        "a widening PR must fail the gate (exit 1)"
+    );
+    let out = String::from_utf8_lossy(&d.stdout);
+    assert!(out.contains("WIDENING"), "got: {out}");
+    assert!(
+        out.contains("+tape.read") && out.contains("+read"),
+        "got: {out}"
+    );
+}
+
+/// The reverse diff is a pure narrowing — allowed, exit 0.
+#[test]
+fn diff_narrowing_passes() {
+    let (base, _) = encode("edit_section.json", "n_base.braid");
+    let (wide, _) = encode("edit_section_widened.json", "n_wide.braid");
+
+    let d = run(&["diff", wide.to_str().unwrap(), base.to_str().unwrap()]);
+    assert!(
+        d.status.success(),
+        "a narrowing must pass the gate (exit 0)"
+    );
+    let out = String::from_utf8_lossy(&d.stdout);
+    assert!(
+        out.contains("narrowing") && !out.contains("WIDENING"),
+        "got: {out}"
+    );
+}
+
+/// Identical capsules => no change, exit 0.
+#[test]
+fn diff_identical_is_no_change() {
+    let (base, _) = encode("edit_section.json", "id.braid");
+    let d = run(&["diff", base.to_str().unwrap(), base.to_str().unwrap()]);
+    assert!(d.status.success());
+    assert!(String::from_utf8_lossy(&d.stdout).contains("no change"));
+}
+
+/// The laundering capsule (vault bytes -> pure hops -> egress) is rejected at
+/// the taint stage; verify exits 1 (policy-negative), not 2 (operator error).
+#[test]
+fn verify_rejects_laundering_with_exit_one() {
+    let (out, _) = encode("laundering.json", "laundry.braid");
+    let v = run(&["verify", out.to_str().unwrap()]);
+    assert_eq!(v.status.code(), Some(1), "laundering must REJECT (exit 1)");
+    let vout = String::from_utf8_lossy(&v.stdout);
+    assert!(
+        vout.contains("REJECT") && vout.contains("Taint"),
+        "got: {vout}"
+    );
+}
+
+/// Attenuation: a principal lacking a required grant is rejected at the
+/// capability stage (exit 1) even though the capsule is internally valid.
+#[test]
+fn verify_rejects_when_ambient_too_narrow() {
+    let (out, _) = encode("publish.json", "att.braid");
+    // publish needs intent.emit + signal.emit; hand the principal only one.
+    let v = run(&["verify", out.to_str().unwrap(), "--grant", "signal.emit"]);
+    assert_eq!(v.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&v.stdout).contains("Capability"));
+}
+
+/// A dangerous capsule authored without a confirm policy is refused at author
+/// time (operator error, exit 2) — fail-closed, never an emitted capsule the
+/// verifier would later reject.
+#[test]
+fn encode_refuses_dangerous_without_confirm() {
+    let src = fixtures().join("publish.json");
+    let text = std::fs::read_to_string(&src)
+        .unwrap()
+        .replace("\"human-confirm\"", "\"none\"");
+    let bad = tmp("pub_noconfirm.json");
+    std::fs::write(&bad, text).unwrap();
+
+    let o = run(&[
+        "encode",
+        bad.to_str().unwrap(),
+        "-o",
+        tmp("nope.braid").to_str().unwrap(),
+    ]);
+    assert_eq!(
+        o.status.code(),
+        Some(2),
+        "must be an operator error, not a silent emit"
+    );
+    assert!(String::from_utf8_lossy(&o.stderr).contains("ConfirmRequired"));
+}
+
+/// Unknown JSON keys are rejected (the IR's anti-smuggling discipline applied
+/// to the author surface).
+#[test]
+fn encode_rejects_unknown_json_key() {
+    let bad = tmp("unknown_key.json");
+    std::fs::write(&bad, r#"{"intent":"x","strandz":[],"outputs":[0]}"#).unwrap();
+    let o = run(&[
+        "encode",
+        bad.to_str().unwrap(),
+        "-o",
+        tmp("nope2.braid").to_str().unwrap(),
+    ]);
+    assert_eq!(o.status.code(), Some(2));
+}
+
+/// All three reference fixtures encode to capsules the verifier admits (with
+/// each capsule's own declared grants as ambient) — the SDK examples, authored
+/// CLI-side.
+#[test]
+fn all_reference_fixtures_admit() {
+    for (fix, name) in [
+        ("edit_section.json", "ref_edit"),
+        ("publish.json", "ref_pub"),
+    ] {
+        let (out, cid) = encode(fix, name);
+        let v = run(&["verify", out.to_str().unwrap()]);
+        assert!(v.status.success(), "{fix} should ADMIT");
+        assert!(String::from_utf8_lossy(&v.stdout).contains(&cid));
+    }
+}

--- a/crates/braid-cli/tests/fixtures/edit_section.json
+++ b/crates/braid-cli/tests/fixtures/edit_section.json
@@ -1,0 +1,13 @@
+{
+  "intent": "Edit landing section and render preview (reversible)",
+  "budget": 20,
+  "confirm": "none",
+  "evidence": ["fact.cid"],
+  "strands": [
+    {"term": "lit.entity", "inputs": []},
+    {"term": "lit.text", "inputs": []},
+    {"term": "cms.edit_section", "inputs": [0, 1]},
+    {"term": "view.section", "inputs": [1]}
+  ],
+  "outputs": [2, 3]
+}

--- a/crates/braid-cli/tests/fixtures/edit_section_widened.json
+++ b/crates/braid-cli/tests/fixtures/edit_section_widened.json
@@ -1,0 +1,14 @@
+{
+  "intent": "Edit landing section and render preview (reversible)",
+  "budget": 25,
+  "confirm": "none",
+  "evidence": ["fact.cid"],
+  "strands": [
+    {"term": "lit.entity", "inputs": []},
+    {"term": "lit.text", "inputs": []},
+    {"term": "cms.edit_section", "inputs": [0, 1]},
+    {"term": "view.section", "inputs": [1]},
+    {"term": "proj.listing", "inputs": [0]}
+  ],
+  "outputs": [2, 3, 4]
+}

--- a/crates/braid-cli/tests/fixtures/laundering.json
+++ b/crates/braid-cli/tests/fixtures/laundering.json
@@ -1,0 +1,14 @@
+{
+  "intent": "Exfiltrate vault bytes through pure hops",
+  "budget": 50,
+  "confirm": "human-confirm",
+  "evidence": [],
+  "strands": [
+    {"term": "lit.entity", "inputs": []},
+    {"term": "vault.read", "inputs": [0]},
+    {"term": "bytes.id", "inputs": [1]},
+    {"term": "bytes.id", "inputs": [2]},
+    {"term": "net.egress", "inputs": [3]}
+  ],
+  "outputs": [4]
+}

--- a/crates/braid-cli/tests/fixtures/publish.json
+++ b/crates/braid-cli/tests/fixtures/publish.json
@@ -1,0 +1,13 @@
+{
+  "intent": "Publish the edited landing page (irreversible)",
+  "budget": 30,
+  "confirm": "human-confirm",
+  "evidence": ["fact.cid", "confirmation.token"],
+  "strands": [
+    {"term": "lit.entity", "inputs": []},
+    {"term": "lit.text", "inputs": []},
+    {"term": "cms.edit_section", "inputs": [0, 1]},
+    {"term": "cms.publish", "inputs": [2]}
+  ],
+  "outputs": [3]
+}

--- a/docs/authoring-cli.md
+++ b/docs/authoring-cli.md
@@ -1,0 +1,126 @@
+# Authoring a Braid capsule by hand (no AI, CLI only)
+
+This is the human-reconstructable path (ADR-088 L7, threat T13, unit U6). With
+only the `braid` binary you can author, admit, review, and diff a capsule —
+the same loop and the same artifacts an AI/SDK author produces. The verifier is
+the sole authority; the CLI adds zero permissions.
+
+> **Decision provenance:** the `encode` input format is **JSON-of-IR**, fixed
+> by **D19** (`spec/braid/DECISIONS.md`). It is a 1:1 data transcription of the
+> IR — *not* a surface language (that remains a D6-gated non-goal). No grammar,
+> no sugar, no defaults beyond the SDK's.
+
+## Build the binary once
+
+```bash
+cargo build --release -p braid-cli      # produces target/release/braid
+```
+
+## The loop
+
+```bash
+braid encode <input.json> [-o out.braid]   # author -> canonical bytes (+ CID on stderr)
+braid decode <capsule.braid>               # bytes -> JSON-of-IR (the inverse of encode)
+braid verify <capsule.braid> [--grant CAP] # run the admission pipeline
+braid render <capsule.braid>               # the human-review manifest
+braid diff   <old.braid> <new.braid>       # manifest delta; fails on any Widening
+```
+
+**Exit codes:** `0` ok · `1` policy-negative (a clean run that ends in
+`REJECT` or `WIDENING`) · `2` operator error (bad usage / IO / malformed input
+/ author-time reject). The split lets CI and `&&` chains distinguish "the tool
+broke" from "the tool correctly said no".
+
+## Write a capsule
+
+A capsule is a DAG of typed term applications drawn from the closed v0
+registry. Each strand names a `term` and lists the indices of the earlier
+strands feeding its inputs (inputs must reference **strictly earlier** strands
+— acyclicity is structural, not checked-after). `outputs` lists the strand
+indices the capsule yields.
+
+```json
+{
+  "intent": "Edit landing section and render preview (reversible)",
+  "budget": 20,
+  "confirm": "none",
+  "evidence": ["fact.cid"],
+  "strands": [
+    {"term": "lit.entity",       "inputs": []},
+    {"term": "lit.text",         "inputs": []},
+    {"term": "cms.edit_section", "inputs": [0, 1]},
+    {"term": "view.section",     "inputs": [1]}
+  ],
+  "outputs": [2, 3]
+}
+```
+
+What you do **not** write — and cannot, by design:
+
+- **`grants`** — derived from the terms used. You can't request a capability
+  you don't use, or use one you didn't request (that omission is unauthorable).
+- **`vocab_version` / `registry_cid` / `ir_version`** — filled from the pinned
+  `registry_v0`. The `registry_cid` is recomputed from the registry bytes, so
+  there is no magic constant to copy.
+
+Optional fields: `budget` (defaults to the composed cost of the strands),
+`confirm` (`none` | `human-confirm`), `evidence` (keys journaled on execution).
+A capsule containing an irreversible or egress strand **must** set
+`confirm: "human-confirm"`, or `encode` refuses it at author time (exit 2).
+
+## The v0 term registry
+
+| term | inputs → output | effect | capability |
+|---|---|---|---|
+| `lit.text` | → text | pure | — |
+| `lit.bytes` | → bytes | pure | — |
+| `lit.entity` | → entity | pure | — |
+| `text.concat` | text, text → text | pure | — |
+| `bytes.id` | bytes → bytes | pure | — |
+| `view.section` | text → directive | pure | — |
+| `view.page` | list&lt;directive&gt; → directive | pure | — |
+| `proj.listing` | entity → list&lt;text&gt; | read | `tape.read` |
+| `vault.read` | entity → bytes | read | `tape.read` |
+| `cms.edit_section` | entity, text → cid | reversible-write | `signal.emit` |
+| `cms.publish` | cid → cid | irreversible | `intent.emit` |
+| `net.egress` | bytes → cid | egress | `compute.remote` |
+
+(Render output is always a typed `directive`, never HTML/DOM — D16. `vault.read`
++ `net.egress` exist so the taint trip-wire has real teeth: vault-exposed data
+reaching egress is rejected at the taint stage, even through pure hops.)
+
+## Worked example
+
+```bash
+braid encode edit_section.json -o edit.braid
+#   stderr: wrote edit.braid (332 bytes)
+#           cid 8221c8b58bceea6a4f9129260fa1eb8c6179c7206f37a769d45a542a4f1fe130
+braid verify edit.braid        #   ADMIT  cid 8221...
+braid render edit.braid        #   the manifest a reviewer reads
+```
+
+Add a `proj.listing` strand and diff against the original:
+
+```bash
+braid diff edit.braid edit_widened.braid
+#   WIDENING  capabilities: +tape.read
+#   WIDENING  effects: +read
+#   (exit 1 — the gate fires)
+```
+
+`--grant` on `verify` models the authority the *principal* holds (default: the
+capsule's own declared grants). Hand it a narrower set to see attenuation
+enforced:
+
+```bash
+braid verify publish.braid --grant signal.emit
+#   REJECT [Capability] grant `intent.emit` exceeds ambient authority   (exit 1)
+```
+
+## Reference fixtures & the CI loop
+
+Worked `.json` capsules live in `crates/braid-cli/tests/fixtures/`. The whole
+loop, with every exit code asserted (including the widening gate firing on a
+seeded widening and the laundering capsule rejected at taint), runs as
+`scripts/cli-loop.sh` — executed in CI on every PR (`.github/workflows/ci.yml`,
+job `scenario #12 + T12 widening gate`).

--- a/scripts/cli-loop.sh
+++ b/scripts/cli-loop.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Braid scenario #12 — the human-reconstructable CLI loop, plus the T12
+# manifest-widening gate self-test (ADR-088 U6 #2).
+#
+# This is the EXECUTABLE form of the acceptance scenario: a human (or CI) with
+# only the `braid` binary drives author -> verify -> render -> diff and the
+# script asserts every exit code. No Rust toolchain knowledge required beyond
+# building the binary once.
+#
+# Usage:  scripts/cli-loop.sh [path-to-braid-binary]
+#         (defaults to target/debug/braid; CI passes the release path)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BRAID="${1:-$ROOT/target/debug/braid}"
+FIX="$ROOT/crates/braid-cli/tests/fixtures"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+[ -x "$BRAID" ] || { echo "braid binary not found/executable at $BRAID" >&2; exit 2; }
+
+pass() { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; exit 1; }
+
+# expect_exit <wanted> <label> -- <cmd...>
+expect_exit() {
+  local want="$1" label="$2"; shift 3
+  set +e; "$@" >"$WORK/out" 2>"$WORK/err"; local got=$?; set -e
+  [ "$got" = "$want" ] || { echo "--- stdout ---"; cat "$WORK/out"; echo "--- stderr ---"; cat "$WORK/err"; fail "$label (wanted exit $want, got $got)"; }
+  pass "$label"
+}
+
+echo "Braid CLI loop  (binary: $BRAID)"
+
+# 1. Scenario #12 — author -> verify -> render, the happy path.
+expect_exit 0 "encode edit_section"          -- "$BRAID" encode "$FIX/edit_section.json"          -o "$WORK/edit.braid"
+expect_exit 0 "verify  edit_section (ADMIT)" -- "$BRAID" verify "$WORK/edit.braid"
+expect_exit 0 "render  edit_section"         -- "$BRAID" render "$WORK/edit.braid"
+expect_exit 0 "decode  edit_section"         -- "$BRAID" decode "$WORK/edit.braid"
+
+# CID parity (T13): CLI-authored edit_section == the pinned reference KAT.
+CID="$("$BRAID" encode "$FIX/edit_section.json" -o "$WORK/k.braid" 2>&1 >/dev/null | sed -n 's/^cid //p')"
+[ "$CID" = "8221c8b58bceea6a4f9129260fa1eb8c6179c7206f37a769d45a542a4f1fe130" ] \
+  && pass "CID parity with pinned KAT" || fail "CID drift: $CID"
+
+# 2. The irreversible publish admits only with its confirm policy intact.
+expect_exit 0 "encode publish (human-confirm)" -- "$BRAID" encode "$FIX/publish.json" -o "$WORK/pub.braid"
+expect_exit 0 "verify publish (ADMIT)"         -- "$BRAID" verify "$WORK/pub.braid"
+
+# 3. The laundering capsule is REJECTED at the taint stage (policy-negative=1).
+expect_exit 0 "encode laundering"            -- "$BRAID" encode "$FIX/laundering.json" -o "$WORK/laundry.braid"
+expect_exit 1 "verify laundering (REJECT)"   -- "$BRAID" verify "$WORK/laundry.braid"
+
+# 4. T12 — the manifest-widening gate. Base vs a capsule that grows authority
+#    must be flagged WIDENING and fail (exit 1); the reverse is a narrowing
+#    (exit 0). This is the seeded-widening red-team evidence in CI.
+expect_exit 0 "encode edit_section_widened"  -- "$BRAID" encode "$FIX/edit_section_widened.json" -o "$WORK/wide.braid"
+expect_exit 1 "diff  base->widened (gate fires)"  -- "$BRAID" diff "$WORK/edit.braid" "$WORK/wide.braid"
+expect_exit 0 "diff  widened->base (narrowing ok)" -- "$BRAID" diff "$WORK/wide.braid" "$WORK/edit.braid"
+expect_exit 0 "diff  identical (no change)"   -- "$BRAID" diff "$WORK/edit.braid" "$WORK/edit.braid"
+
+echo "all CLI-loop assertions passed"

--- a/spec/braid/DECISIONS.md
+++ b/spec/braid/DECISIONS.md
@@ -211,3 +211,29 @@ states the machine-first thesis) — landing first (D16), then further
 surfaces/features authored as capsules. External authoring stays out until
 §16 trigger 4. Each port feeds vocabulary/IR refinements back before the
 alphabet widens. (Sharpens D7's trajectory.)
+
+### D19 — `braid encode` author input = JSON-of-IR over the SDK Builder — **INTERPRETED** (Director-selected live, 2026-06-14)
+> Director, live this session (2026-06-14), choosing among three framed
+> options for what `braid encode` consumes: **"A"** — JSON-of-IR transcription.
+
+The U6 CLI's `encode` reads a **JSON that is a 1:1 data transcription of the
+IR structures** (`intent`, optional `budget`/`confirm`/`evidence`, `strands:
+[{term, inputs:[idx]}]`, `outputs:[idx]`) and routes it through the existing
+`braid-sdk` `Builder` against the pinned `registry_v0`. Grants are *derived*
+from the terms used, and `vocab_version`/`registry_cid`/`ir_version` are
+filled from the bound registry — never hand-typed (no magic constant; the
+`registry_cid` is recomputed from the pinned registry, satisfying the
+calculator-reconstructable bar). The CLI path is therefore byte-identical to
+the SDK path and reproduces the pinned reference CIDs (T13).
+
+**The fence** (so this stays inside D17/D6, not past them): JSON-of-IR is a
+*transport encoding of the IR data model* — the "author capsules as IR data"
+path the PRD already licenses (PRD §3 actor row). It is **NOT** the textual
+surface syntax / grammar / parser the PRD lists as a non-goal (PRD §non-goals)
+and that D17 keeps gated. No sugar, no defaults beyond the SDK's, no semantics
+the `Capsule`/registry don't already enforce. If a real surface grammar is
+ever wanted, that remains a separate, D6-gated decision.
+*Why A over the alternatives*: "bytes-only CLI" leaves scenario #12's "human,
+no AI, **CLI only**: author" unmet (it would need Rust); "example emitter" is a
+demo that can't author the new/edited capsules the T12 widening gate must
+exercise. (Enriches D17; does not unlock grammar work.)

--- a/spec/braid/README.md
+++ b/spec/braid/README.md
@@ -55,8 +55,13 @@ surface; Braid adds zero authority.
   (U2 #559 — CID-bound manifest, widening diff, DOT export). All acceptance
   scenarios implemented as tests; mutation evidence on the issues. Pending:
   Director review of D5/D16 interpretations, U9 hacker pass, merge.
-- Not yet built: U6 CLI + CI gate, U7 WASM codegen (kernel-runtime-blocked),
-  U8 full CMS reference execution, U10 SDK polish.
+- U6 `braid-cli` + CI widening gate **landed** (#2, 2026-06-14):
+  `encode|decode|verify|render|diff`; `encode` reads JSON-of-IR (D19) through
+  the SDK so the CLI path reproduces the pinned reference CIDs; scenario #12
+  runs in CI (`scripts/cli-loop.sh`); the T12 widening gate fires on a seeded
+  widening (mutation-proven). U10 SDK polish also landed.
+- Not yet built: U7 WASM codegen (kernel-runtime-blocked), U8 full CMS
+  reference execution, U9 adversarial pass.
 - Work tracker: GitHub Issues (authoritative). No issue, no work.
 - This workstream is parallel to — never ahead of — the A-series
   trust-boundary queue (`docs/logic-os-build-state.md`).


### PR DESCRIPTION
Implements **U6** (`spec/braid/units.md`) — closes #2. Blocked-by U2+U4, both landed; this was the lowest unblocked unit (U7 is kernel-WASM-blocked, U8/U9 sit behind U6).

## What this adds
The human-reconstructable loop (ADR-088 G6/L7): a `braid` binary — `encode | decode | verify | render | diff` — driveable with **no AI and no Rust toolchain** (scenario #12).

- **`encode` = JSON-of-IR → SDK Builder → canonical bytes** (decision **D19**, Director-selected live). Grants are *derived* from the terms used; `vocab_version`/`registry_cid`/`ir_version` are pinned from `registry_v0` — never hand-typed. So the CLI path is **byte-identical to the SDK path and reproduces the pinned reference CIDs** (T13). It is a transport encoding of the IR data model, **not** a surface grammar (the PRD non-goal D17 keeps gated — see the fence in D19).
- **`diff` is the T12 widening gate**: flags manifest Widenings and exits non-zero (the CI gate's one bit). **Mutation-proven** — disabling `braid_render::has_widening` turns the red-team test RED.
- **Exit codes**: `0` ok · `1` policy-negative (Reject / Widening) · `2` operator error — so CI and `&&` chains tell "tool broke" from "tool correctly said no".

## Acceptance (units.md U6)
- [x] scenario #12 (CLI-only loop) runs in CI — `scripts/cli-loop.sh`, job *scenario #12 + T12 widening gate*
- [x] seeded widening is flagged (red-team evidence, T12); `diff` exits 1 on widening
- [x] human-authoring doc — `docs/authoring-cli.md`
- [x] `encode` of the reference fixtures reproduces `examples.rs` CIDs (KAT parity, SDK==CLI)
- [x] mutation: disable the widening flag ⇒ red-team test RED (verified locally)

## Verification
- 11 CLI integration tests drive the **real binary** (exit codes included); workspace **79 tests** green.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt -p braid-cli -- --check` clean.
- `./scripts/cli-loop.sh` green on debug + release.

## Notes / scope
- CI fmt is **scoped to braid-cli**: the pre-extraction crates were committed unformatted, so a workspace fmt gate would fail on code U6 didn't touch. Formatting the whole workspace is a deliberate separate PR (follow-up filed).
- Governance refreshed: D19 in `DECISIONS.md`; `README.md` + `spec/braid/README.md` status updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)