### PR TITLE
U9 harden CLI review path and format workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,8 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
-      # //why scoped to braid-cli, not --all: the pre-extraction crates were
-      # committed without a rustfmt pass, so a workspace fmt gate would fail on
-      # code U6 didn't touch. Formatting the whole workspace is its own
-      # deliberate PR (tracked follow-up), not smuggled into U6.
-      - name: format (braid-cli)
-        run: cargo fmt -p braid-cli -- --check
+      - name: format
+        run: cargo fmt --all --check
       - name: clippy (warnings are errors)
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: test

--- a/crates/braid-cli/src/main.rs
+++ b/crates/braid-cli/src/main.rs
@@ -313,6 +313,7 @@ fn cmd_render(args: &[String]) -> CliResult {
     let path = single_path(args, "render")?;
     let capsule = read_capsule(path)?;
     let registry = registry_v0();
+    require_admit_for_review(path, &capsule, &registry)?;
     let m = manifest(&capsule, &registry).map_err(|e| format!("render: {e:?}"))?;
     print!("{}", render_text(&m));
     Ok(())
@@ -327,6 +328,8 @@ fn cmd_diff(args: &[String]) -> CliResult {
     let registry = registry_v0();
     let old = read_capsule(&args[0])?;
     let new = read_capsule(&args[1])?;
+    require_admit_for_review(&args[0], &old, &registry)?;
+    require_admit_for_review(&args[1], &new, &registry)?;
     let m_old = manifest(&old, &registry).map_err(|e| format!("render old: {e:?}"))?;
     let m_new = manifest(&new, &registry).map_err(|e| format!("render new: {e:?}"))?;
     let deltas = manifest_diff(&m_old, &m_new);
@@ -389,4 +392,21 @@ fn read_bytes(path: &str) -> Result<Vec<u8>, String> {
 fn read_capsule(path: &str) -> Result<Capsule, String> {
     let bytes = read_bytes(path)?;
     Capsule::from_bytes(&bytes).map_err(|e| format!("{path}: not a canonical capsule: {e:?}"))
+}
+
+/// Human-review outputs are projections of admitted artifacts, not a parallel
+/// path around the verifier. Use the capsule's declared grants as the ambient
+/// authority, matching `verify`'s default happy-path check.
+fn require_admit_for_review(
+    path: &str,
+    capsule: &Capsule,
+    registry: &braid_ir::TermRegistry,
+) -> CliResult {
+    let bytes = capsule.to_bytes();
+    match verify(&bytes, registry, &capsule.grants) {
+        Verdict::Admit { .. } => Ok(()),
+        Verdict::Reject { stage, reason } => Err(format!(
+            "{path}: not admitted for review [{stage:?}] {reason}"
+        )),
+    }
 }

--- a/crates/braid-cli/tests/cli_loop.rs
+++ b/crates/braid-cli/tests/cli_loop.rs
@@ -159,6 +159,59 @@ fn diff_identical_is_no_change() {
     assert!(String::from_utf8_lossy(&d.stdout).contains("no change"));
 }
 
+/// U9/T4/T6 — rendering is a human-review projection of an ADMITTED artifact,
+/// not a side door around the verifier. A canonical capsule with a stale
+/// registry pin must be refused before any manifest text is emitted.
+#[test]
+fn render_refuses_version_skewed_capsule() {
+    let (base, _) = encode("edit_section.json", "render_bad_version_base.braid");
+    let mut capsule = braid_ir::Capsule::from_bytes(&std::fs::read(&base).unwrap()).unwrap();
+    capsule.vocab_version += 1;
+    let bad = tmp("render_bad_version.braid");
+    std::fs::write(&bad, capsule.to_bytes()).unwrap();
+
+    let r = run(&["render", bad.to_str().unwrap()]);
+    assert_eq!(
+        r.status.code(),
+        Some(2),
+        "render must refuse verifier-rejected capsules"
+    );
+    assert!(r.stdout.is_empty(), "must not emit a manifest");
+    let err = String::from_utf8_lossy(&r.stderr);
+    assert!(
+        err.contains("not admitted for review") && err.contains("VersionPin"),
+        "got: {err}"
+    );
+}
+
+/// Same fail-closed rule for the manifest-diff gate: an invalid new artifact
+/// must not be classed as "no change" or "neutral" just because its renderable
+/// fields happen to look harmless.
+#[test]
+fn diff_refuses_version_skewed_capsule() {
+    let (base, _) = encode("edit_section.json", "diff_bad_version_base.braid");
+    let mut capsule = braid_ir::Capsule::from_bytes(&std::fs::read(&base).unwrap()).unwrap();
+    capsule.registry_cid = braid_ir::Cid([0u8; 32]);
+    let bad = tmp("diff_bad_version.braid");
+    std::fs::write(&bad, capsule.to_bytes()).unwrap();
+
+    let d = run(&["diff", base.to_str().unwrap(), bad.to_str().unwrap()]);
+    assert_eq!(
+        d.status.code(),
+        Some(2),
+        "diff must refuse verifier-rejected capsules"
+    );
+    assert!(
+        !String::from_utf8_lossy(&d.stdout).contains("no change"),
+        "invalid artifact must not be presented as an ordinary diff"
+    );
+    let err = String::from_utf8_lossy(&d.stderr);
+    assert!(
+        err.contains("not admitted for review") && err.contains("VersionPin"),
+        "got: {err}"
+    );
+}
+
 /// The laundering capsule (vault bytes -> pure hops -> egress) is rejected at
 /// the taint stage; verify exits 1 (policy-negative), not 2 (operator error).
 #[test]

--- a/crates/braid-ir/src/braid.rs
+++ b/crates/braid-ir/src/braid.rs
@@ -26,7 +26,10 @@ pub struct Braid {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BraidError {
     /// An input/output references a strand index ≥ its own position / len.
-    ForwardReference { strand: usize, index: u32 },
+    ForwardReference {
+        strand: usize,
+        index: u32,
+    },
     OutputOutOfRange(u32),
     Empty,
     NoOutputs,
@@ -42,7 +45,10 @@ impl Braid {
         for (i, s) in self.strands.iter().enumerate() {
             for &inp in &s.inputs {
                 if inp as usize >= i {
-                    return Err(BraidError::ForwardReference { strand: i, index: inp });
+                    return Err(BraidError::ForwardReference {
+                        strand: i,
+                        index: inp,
+                    });
                 }
             }
         }
@@ -72,7 +78,10 @@ impl Braid {
             })
             .collect();
         Value::map(vec![
-            ("outputs", Value::List(self.outputs.iter().map(|&o| Value::Int(o as i64)).collect())),
+            (
+                "outputs",
+                Value::List(self.outputs.iter().map(|&o| Value::Int(o as i64)).collect()),
+            ),
             ("strands", Value::List(strands)),
         ])
     }

--- a/crates/braid-ir/src/canon.rs
+++ b/crates/braid-ir/src/canon.rs
@@ -46,7 +46,9 @@ pub enum CanonError {
 /// deterministic encoding order for definite-length text keys (the length is
 /// in the head byte(s), so encoded-byte comparison sees it first).
 pub fn key_cmp(a: &str, b: &str) -> std::cmp::Ordering {
-    a.len().cmp(&b.len()).then_with(|| a.as_bytes().cmp(b.as_bytes()))
+    a.len()
+        .cmp(&b.len())
+        .then_with(|| a.as_bytes().cmp(b.as_bytes()))
 }
 
 // ───────────────────────────── encoder ─────────────────────────────

--- a/crates/braid-ir/src/capsule.rs
+++ b/crates/braid-ir/src/capsule.rs
@@ -64,7 +64,15 @@ impl Capsule {
         Value::map(vec![
             ("braid", self.braid.to_canon()),
             ("budget", Value::Int(self.budget as i64)),
-            ("grants", Value::List(self.grants.iter().map(|c| Value::Text(c.to_string())).collect())),
+            (
+                "grants",
+                Value::List(
+                    self.grants
+                        .iter()
+                        .map(|c| Value::Text(c.to_string()))
+                        .collect(),
+                ),
+            ),
             ("intent", Value::Text(self.intent.clone())),
             (
                 "confirm",
@@ -76,7 +84,15 @@ impl Capsule {
                     .into(),
                 ),
             ),
-            ("evidence", Value::List(self.evidence.iter().map(|e| Value::Text(e.clone())).collect())),
+            (
+                "evidence",
+                Value::List(
+                    self.evidence
+                        .iter()
+                        .map(|e| Value::Text(e.clone()))
+                        .collect(),
+                ),
+            ),
             ("ir_version", Value::Int(self.ir_version as i64)),
             ("registry_cid", Value::Bytes(self.registry_cid.0.to_vec())),
             ("vocab_version", Value::Int(self.vocab_version as i64)),
@@ -159,8 +175,15 @@ impl Capsule {
         // Allowlist (not a bare count) so a new field can never silently widen
         // the gate; the required keys above already enforce presence.
         if !v.require_only_keys(&[
-            "braid", "budget", "grants", "intent", "confirm", "evidence", "ir_version",
-            "registry_cid", "vocab_version",
+            "braid",
+            "budget",
+            "grants",
+            "intent",
+            "confirm",
+            "evidence",
+            "ir_version",
+            "registry_cid",
+            "vocab_version",
         ]) {
             return Err(CapsuleError::Malformed("capsule: unknown field"));
         }

--- a/crates/braid-ir/src/registry_v0.rs
+++ b/crates/braid-ir/src/registry_v0.rs
@@ -50,10 +50,28 @@ pub fn registry_v0() -> TermRegistry {
         t("lit.text", vec![], Text, None, Pure, Public, None, 1),
         t("lit.bytes", vec![], Bytes, None, Pure, Public, None, 1),
         t("lit.entity", vec![], Entity, None, Pure, Public, None, 1),
-        t("text.concat", vec![Text, Text], Text, None, Pure, Public, None, 1),
+        t(
+            "text.concat",
+            vec![Text, Text],
+            Text,
+            None,
+            Pure,
+            Public,
+            None,
+            1,
+        ),
         t("bytes.id", vec![Bytes], Bytes, None, Pure, Public, None, 1),
         // ── pure render (output is a typed Directive, never DOM — D16) ──
-        t("view.section", vec![Text], Directive, None, Pure, Public, None, 2),
+        t(
+            "view.section",
+            vec![Text],
+            Directive,
+            None,
+            Pure,
+            Public,
+            None,
+            2,
+        ),
         t(
             "view.page",
             vec![List(Box::new(Directive))],
@@ -121,7 +139,8 @@ pub fn registry_v0() -> TermRegistry {
 
     let mut reg = TermRegistry::new(VOCAB_VERSION);
     for spec in specs {
-        reg.insert(spec).expect("registry_v0 specs are statically valid");
+        reg.insert(spec)
+            .expect("registry_v0 specs are statically valid");
     }
     reg
 }

--- a/crates/braid-ir/src/term.rs
+++ b/crates/braid-ir/src/term.rs
@@ -251,7 +251,12 @@ fn term_to_canon(t: &TermSpec) -> Value {
         ("id", Value::Text(t.id.clone())),
         (
             "inputs",
-            Value::List(t.inputs.iter().map(|i| Value::Text(type_to_text(i))).collect()),
+            Value::List(
+                t.inputs
+                    .iter()
+                    .map(|i| Value::Text(type_to_text(i)))
+                    .collect(),
+            ),
         ),
         ("output", Value::Text(type_to_text(&t.output))),
         ("effect", Value::Text(effect_to_text(t.effect).into())),
@@ -274,7 +279,14 @@ fn term_from_canon(v: &Value) -> Result<TermSpec, RegistryError> {
     // `capability` and `ceiling` are optional; the rest required. The allowed
     // set is the exhaustive key universe — any other key is a smuggled field.
     if !v.require_only_keys(&[
-        "id", "inputs", "output", "effect", "exposure", "cost", "capability", "ceiling",
+        "id",
+        "inputs",
+        "output",
+        "effect",
+        "exposure",
+        "cost",
+        "capability",
+        "ceiling",
     ]) {
         return Err(RegistryError::Malformed("term: unknown field"));
     }

--- a/crates/braid-ir/tests/boundary_conformance.rs
+++ b/crates/braid-ir/tests/boundary_conformance.rs
@@ -29,7 +29,15 @@ const ALLOWED_DEV: &[&str] = &["hex", "proptest", "braid-ir", "braid-render"];
 
 /// First path segment allowlist for `use` statements in src/**.
 const ALLOWED_USE_ROOTS: &[&str] = &[
-    "crate", "super", "self", "std", "core", "alloc", "blake3", "braid_capability", "braid_ir",
+    "crate",
+    "super",
+    "self",
+    "std",
+    "core",
+    "alloc",
+    "blake3",
+    "braid_capability",
+    "braid_ir",
 ];
 
 fn toml_section_keys(toml: &str, section: &str) -> Vec<String> {
@@ -94,7 +102,9 @@ fn src_use_statements_stay_inside_the_boundary() {
             let src = fs::read_to_string(&f).unwrap();
             for (ln, line) in src.lines().enumerate() {
                 let t = line.trim();
-                let Some(rest) = t.strip_prefix("use ").or_else(|| t.strip_prefix("pub use "))
+                let Some(rest) = t
+                    .strip_prefix("use ")
+                    .or_else(|| t.strip_prefix("pub use "))
                 else {
                     continue;
                 };

--- a/crates/braid-ir/tests/malleability.rs
+++ b/crates/braid-ir/tests/malleability.rs
@@ -27,7 +27,10 @@ fn floats_do_not_exist() {
         let mut bytes = vec![head];
         bytes.extend([0u8; 8]);
         assert!(
-            matches!(decode_strict(&bytes), Err(CanonError::ForbiddenForm(_)) | Err(CanonError::TrailingBytes)),
+            matches!(
+                decode_strict(&bytes),
+                Err(CanonError::ForbiddenForm(_)) | Err(CanonError::TrailingBytes)
+            ),
             "float head {head:#x} must be rejected"
         );
     }
@@ -35,9 +38,18 @@ fn floats_do_not_exist() {
 
 #[test]
 fn tags_and_null_rejected() {
-    assert!(matches!(decode_strict(&[0xc0, 0x00]), Err(CanonError::ForbiddenForm(_)))); // tag
-    assert!(matches!(decode_strict(&[0xf6]), Err(CanonError::ForbiddenForm(_)))); // null
-    assert!(matches!(decode_strict(&[0xf7]), Err(CanonError::ForbiddenForm(_)))); // undefined
+    assert!(matches!(
+        decode_strict(&[0xc0, 0x00]),
+        Err(CanonError::ForbiddenForm(_))
+    )); // tag
+    assert!(matches!(
+        decode_strict(&[0xf6]),
+        Err(CanonError::ForbiddenForm(_))
+    )); // null
+    assert!(matches!(
+        decode_strict(&[0xf7]),
+        Err(CanonError::ForbiddenForm(_))
+    )); // undefined
 }
 
 #[test]
@@ -98,7 +110,10 @@ fn invalid_utf8_text_rejected() {
 fn encode_decode_is_identity_on_canonical_values() {
     let v = Value::map(vec![
         ("a", Value::Int(-42)),
-        ("b", Value::List(vec![Value::Bool(true), Value::Bytes(vec![1, 2, 3])])),
+        (
+            "b",
+            Value::List(vec![Value::Bool(true), Value::Bytes(vec![1, 2, 3])]),
+        ),
         ("cc", Value::Text("héllo".into())),
     ]);
     let bytes = encode(&v);
@@ -149,7 +164,10 @@ fn assert_nested_smuggle_rejected(mutate: impl Fn(&mut braid_ir::Value)) {
     mutate(&mut v);
     let bytes = braid_ir::canon::encode(&v);
     // Bytes are still individually canonical (the Value round-trips)…
-    assert!(braid_ir::decode_strict(&bytes).is_ok(), "value-level canonical");
+    assert!(
+        braid_ir::decode_strict(&bytes).is_ok(),
+        "value-level canonical"
+    );
     // …but the capsule projection must REJECT the unknown nested field.
     assert!(
         Capsule::from_bytes(&bytes).is_err(),

--- a/crates/braid-render/src/lib.rs
+++ b/crates/braid-render/src/lib.rs
@@ -103,7 +103,14 @@ pub fn render_text(m: &Manifest) -> String {
     line("ir_version", m.ir_version.to_string());
     line("vocab_version", m.vocab_version.to_string());
     line("registry", m.registry_cid.to_hex());
-    line("capabilities", if m.capabilities.is_empty() { "(none)".into() } else { m.capabilities.join(", ") });
+    line(
+        "capabilities",
+        if m.capabilities.is_empty() {
+            "(none)".into()
+        } else {
+            m.capabilities.join(", ")
+        },
+    );
     line("effects", m.effects.join(", "));
     line("irreversible_strands", m.irreversible_strands.to_string());
     line("egress_strands", m.egress_strands.to_string());
@@ -116,7 +123,14 @@ pub fn render_text(m: &Manifest) -> String {
             ConfirmPolicy::HumanConfirm => "human-confirm".into(),
         },
     );
-    line("evidence", if m.evidence.is_empty() { "(none)".into() } else { m.evidence.join(", ") });
+    line(
+        "evidence",
+        if m.evidence.is_empty() {
+            "(none)".into()
+        } else {
+            m.evidence.join(", ")
+        },
+    );
     out
 }
 
@@ -141,29 +155,52 @@ pub struct Delta {
 /// facts the gate computes, never impressions a tired reviewer forms.
 pub fn manifest_diff(old: &Manifest, new: &Manifest) -> Vec<Delta> {
     let mut deltas = Vec::new();
-    let set =
-        |v: &[String]| -> BTreeSet<String> { v.iter().cloned().collect() };
+    let set = |v: &[String]| -> BTreeSet<String> { v.iter().cloned().collect() };
 
     let (old_caps, new_caps) = (set(&old.capabilities), set(&new.capabilities));
     for added in new_caps.difference(&old_caps) {
-        deltas.push(Delta { kind: DeltaKind::Widening, field: "capabilities", detail: format!("+{added}") });
+        deltas.push(Delta {
+            kind: DeltaKind::Widening,
+            field: "capabilities",
+            detail: format!("+{added}"),
+        });
     }
     for removed in old_caps.difference(&new_caps) {
-        deltas.push(Delta { kind: DeltaKind::Narrowing, field: "capabilities", detail: format!("-{removed}") });
+        deltas.push(Delta {
+            kind: DeltaKind::Narrowing,
+            field: "capabilities",
+            detail: format!("-{removed}"),
+        });
     }
 
     let (old_fx, new_fx) = (set(&old.effects), set(&new.effects));
     for added in new_fx.difference(&old_fx) {
-        deltas.push(Delta { kind: DeltaKind::Widening, field: "effects", detail: format!("+{added}") });
+        deltas.push(Delta {
+            kind: DeltaKind::Widening,
+            field: "effects",
+            detail: format!("+{added}"),
+        });
     }
     for removed in old_fx.difference(&new_fx) {
-        deltas.push(Delta { kind: DeltaKind::Narrowing, field: "effects", detail: format!("-{removed}") });
+        deltas.push(Delta {
+            kind: DeltaKind::Narrowing,
+            field: "effects",
+            detail: format!("-{removed}"),
+        });
     }
 
     if new.budget > old.budget {
-        deltas.push(Delta { kind: DeltaKind::Widening, field: "budget", detail: format!("{} -> {}", old.budget, new.budget) });
+        deltas.push(Delta {
+            kind: DeltaKind::Widening,
+            field: "budget",
+            detail: format!("{} -> {}", old.budget, new.budget),
+        });
     } else if new.budget < old.budget {
-        deltas.push(Delta { kind: DeltaKind::Narrowing, field: "budget", detail: format!("{} -> {}", old.budget, new.budget) });
+        deltas.push(Delta {
+            kind: DeltaKind::Narrowing,
+            field: "budget",
+            detail: format!("{} -> {}", old.budget, new.budget),
+        });
     }
 
     // Dropping human confirmation is the sharpest widening there is — but
@@ -172,16 +209,28 @@ pub fn manifest_diff(old: &Manifest, new: &Manifest) -> Vec<Delta> {
     if old.confirm == ConfirmPolicy::HumanConfirm && new.confirm == ConfirmPolicy::None {
         let still_dangerous = new.irreversible_strands + new.egress_strands > 0;
         deltas.push(Delta {
-            kind: if still_dangerous { DeltaKind::Widening } else { DeltaKind::Neutral },
+            kind: if still_dangerous {
+                DeltaKind::Widening
+            } else {
+                DeltaKind::Neutral
+            },
             field: "confirm",
             detail: "human-confirm -> none".into(),
         });
     } else if old.confirm == ConfirmPolicy::None && new.confirm == ConfirmPolicy::HumanConfirm {
-        deltas.push(Delta { kind: DeltaKind::Narrowing, field: "confirm", detail: "none -> human-confirm".into() });
+        deltas.push(Delta {
+            kind: DeltaKind::Narrowing,
+            field: "confirm",
+            detail: "none -> human-confirm".into(),
+        });
     }
 
     if old.intent != new.intent {
-        deltas.push(Delta { kind: DeltaKind::Neutral, field: "intent", detail: "changed".into() });
+        deltas.push(Delta {
+            kind: DeltaKind::Neutral,
+            field: "intent",
+            detail: "changed".into(),
+        });
     }
     deltas
 }

--- a/crates/braid-render/tests/render.rs
+++ b/crates/braid-render/tests/render.rs
@@ -23,7 +23,11 @@ fn manifest_rendering_is_deterministic() {
 
 #[test]
 fn manifest_surfaces_the_dangerous_facts() {
-    let m = manifest(&publish_capsule(ConfirmPolicy::HumanConfirm), &registry_v0()).unwrap();
+    let m = manifest(
+        &publish_capsule(ConfirmPolicy::HumanConfirm),
+        &registry_v0(),
+    )
+    .unwrap();
     assert_eq!(m.irreversible_strands, 1);
     assert!(m.effects.contains(&"irreversible".to_string()));
     let text = render_text(&m);
@@ -34,20 +38,28 @@ fn manifest_surfaces_the_dangerous_facts() {
 #[test]
 fn capability_addition_is_a_widening() {
     let old = manifest(&edit_section_capsule(), &registry_v0()).unwrap();
-    let new = manifest(&publish_capsule(ConfirmPolicy::HumanConfirm), &registry_v0()).unwrap();
+    let new = manifest(
+        &publish_capsule(ConfirmPolicy::HumanConfirm),
+        &registry_v0(),
+    )
+    .unwrap();
     let deltas = manifest_diff(&old, &new);
     assert!(has_widening(&deltas));
-    assert!(deltas
-        .iter()
-        .any(|d| d.kind == DeltaKind::Widening && d.field == "capabilities" && d.detail == "+intent.emit"));
-    assert!(deltas
-        .iter()
-        .any(|d| d.kind == DeltaKind::Widening && d.field == "effects" && d.detail == "+irreversible"));
+    assert!(deltas.iter().any(|d| d.kind == DeltaKind::Widening
+        && d.field == "capabilities"
+        && d.detail == "+intent.emit"));
+    assert!(deltas.iter().any(|d| d.kind == DeltaKind::Widening
+        && d.field == "effects"
+        && d.detail == "+irreversible"));
 }
 
 #[test]
 fn dropping_confirmation_is_a_widening() {
-    let old = manifest(&publish_capsule(ConfirmPolicy::HumanConfirm), &registry_v0()).unwrap();
+    let old = manifest(
+        &publish_capsule(ConfirmPolicy::HumanConfirm),
+        &registry_v0(),
+    )
+    .unwrap();
     let new = manifest(&publish_capsule(ConfirmPolicy::None), &registry_v0()).unwrap();
     let deltas = manifest_diff(&old, &new);
     assert!(deltas
@@ -57,7 +69,11 @@ fn dropping_confirmation_is_a_widening() {
 
 #[test]
 fn narrowing_is_not_flagged_as_widening() {
-    let old = manifest(&publish_capsule(ConfirmPolicy::HumanConfirm), &registry_v0()).unwrap();
+    let old = manifest(
+        &publish_capsule(ConfirmPolicy::HumanConfirm),
+        &registry_v0(),
+    )
+    .unwrap();
     let new = manifest(&edit_section_capsule(), &registry_v0()).unwrap();
     let deltas = manifest_diff(&old, &new);
     assert!(!has_widening(&deltas));

--- a/crates/braid-sdk/src/lib.rs
+++ b/crates/braid-sdk/src/lib.rs
@@ -17,10 +17,10 @@
 //!
 //! Boundary (D3): depends only on `braid-ir` + `braid-capability`.
 
+use braid_capability::Capability;
 use braid_ir::braid::{Braid, Strand as IrStrand};
 use braid_ir::term::TypeTag;
 use braid_ir::{Capsule, ConfirmPolicy, EffectClass, TermRegistry, IR_VERSION};
-use braid_capability::Capability;
 
 /// A typed reference to a strand already placed in the braid. Carries its
 /// output type so wiring is type-checked the moment it is used as an input.
@@ -46,12 +46,24 @@ struct TypeTagId(usize);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BuildError {
     UnknownTerm(String),
-    Arity { term: String, expected: usize, got: usize },
-    TypeMismatch { term: String, slot: usize, expected: TypeTag, got: TypeTag },
+    Arity {
+        term: String,
+        expected: usize,
+        got: usize,
+    },
+    TypeMismatch {
+        term: String,
+        slot: usize,
+        expected: TypeTag,
+        got: TypeTag,
+    },
     NoOutputs,
     /// A declared budget below the composed cost (the SDK refuses to author an
     /// over-budget capsule rather than emit one the verifier will reject).
-    BudgetTooLow { needed: u64, set: u64 },
+    BudgetTooLow {
+        needed: u64,
+        set: u64,
+    },
     /// Irreversible/egress term used without a confirm policy set.
     ConfirmRequired,
 }
@@ -184,7 +196,10 @@ impl<'r> Builder<'r> {
         }
         let budget = self.budget.unwrap_or(self.cost);
         if budget < self.cost {
-            return Err(BuildError::BudgetTooLow { needed: self.cost, set: budget });
+            return Err(BuildError::BudgetTooLow {
+                needed: self.cost,
+                set: budget,
+            });
         }
         let confirm = match self.confirm {
             Some(c) => c,

--- a/crates/braid-sdk/tests/authoring.rs
+++ b/crates/braid-sdk/tests/authoring.rs
@@ -2,11 +2,11 @@
 //! reference CIDs byte-for-byte, (b) are admitted by the independent verifier,
 //! and (c) reject illegal compositions at author time.
 
+use braid_capability::Capability;
 use braid_ir::examples::{edit_section_capsule, publish_capsule};
 use braid_ir::{registry_v0, ConfirmPolicy};
 use braid_sdk::{BuildError, Builder};
 use braid_verify::{verify, Verdict};
-use braid_capability::Capability;
 
 fn ambient() -> Vec<Capability> {
     vec![
@@ -51,7 +51,9 @@ fn sdk_built_capsule_is_admitted() {
     let capsule = b.build().unwrap();
     assert_eq!(
         verify(&capsule.to_bytes(), &reg, &ambient()),
-        Verdict::Admit { capsule_cid: capsule.cid() }
+        Verdict::Admit {
+            capsule_cid: capsule.cid()
+        }
     );
 }
 
@@ -89,14 +91,24 @@ fn arity_mismatch_is_an_author_time_error() {
     let mut b = Builder::new(&reg, "x");
     let txt = b.strand("lit.text", &[]).unwrap();
     let err = b.strand("cms.edit_section", &[txt]).unwrap_err();
-    assert!(matches!(err, BuildError::Arity { expected: 2, got: 1, .. }));
+    assert!(matches!(
+        err,
+        BuildError::Arity {
+            expected: 2,
+            got: 1,
+            ..
+        }
+    ));
 }
 
 #[test]
 fn unknown_term_is_an_author_time_error() {
     let reg = registry_v0();
     let mut b = Builder::new(&reg, "x");
-    assert!(matches!(b.strand("eval", &[]), Err(BuildError::UnknownTerm(_))));
+    assert!(matches!(
+        b.strand("eval", &[]),
+        Err(BuildError::UnknownTerm(_))
+    ));
 }
 
 #[test]
@@ -119,7 +131,10 @@ fn over_budget_refused_at_author_time() {
     let txt = b.strand("lit.text", &[]).unwrap(); // cost 1
     b.output(txt);
     b.budget(0);
-    assert!(matches!(b.build().unwrap_err(), BuildError::BudgetTooLow { .. }));
+    assert!(matches!(
+        b.build().unwrap_err(),
+        BuildError::BudgetTooLow { .. }
+    ));
 }
 
 #[test]
@@ -143,5 +158,10 @@ fn budget_tight_sizes_to_cost() {
     b.budget_tight();
     let capsule = b.build().unwrap();
     assert_eq!(capsule.budget, 3); // 1 + 2
-    assert_eq!(verify(&capsule.to_bytes(), &reg, &ambient()), Verdict::Admit { capsule_cid: capsule.cid() });
+    assert_eq!(
+        verify(&capsule.to_bytes(), &reg, &ambient()),
+        Verdict::Admit {
+            capsule_cid: capsule.cid()
+        }
+    );
 }

--- a/crates/braid-verify/src/decode.rs
+++ b/crates/braid-verify/src/decode.rs
@@ -73,7 +73,9 @@ impl<'a> Cursor<'a> {
             }
             27 => {
                 let v = u64::from_be_bytes(self.slice(8)?.try_into().unwrap());
-                (v > 0xffff_ffff).then_some(v).ok_or(DecodeError::NonMinimal)
+                (v > 0xffff_ffff)
+                    .then_some(v)
+                    .ok_or(DecodeError::NonMinimal)
             }
             _ => Err(DecodeError::Forbidden("reserved/indefinite")),
         }
@@ -101,7 +103,9 @@ impl<'a> Cursor<'a> {
         }
         let n = self.arg(first)?;
         match major {
-            0 => i64::try_from(n).map(Value::Int).map_err(|_| DecodeError::IntRange),
+            0 => i64::try_from(n)
+                .map(Value::Int)
+                .map_err(|_| DecodeError::IntRange),
             1 => i64::try_from(n)
                 .map(|x| Value::Int(-1 - x))
                 .map_err(|_| DecodeError::IntRange),

--- a/crates/braid-verify/src/lib.rs
+++ b/crates/braid-verify/src/lib.rs
@@ -11,9 +11,9 @@
 
 pub mod decode;
 
+use braid_capability::Capability;
 use braid_ir::term::{EffectClass, Exposure};
 use braid_ir::{Capsule, Cid, ConfirmPolicy, TermRegistry, TypeTag, IR_VERSION};
-use braid_capability::Capability;
 
 /// Pipeline stages, in locked order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,7 +73,10 @@ pub fn verify(bytes: &[u8], registry: &TermRegistry, ambient: &[Capability]) -> 
     for (i, s) in capsule.braid.strands.iter().enumerate() {
         let Some(spec) = registry.get(&s.term) else {
             // Unknown = deny, never "best effort" (L9 / scenario #14).
-            return reject(Stage::Structure, format!("unknown term `{}` at strand {i}", s.term));
+            return reject(
+                Stage::Structure,
+                format!("unknown term `{}` at strand {i}", s.term),
+            );
         };
         if spec.inputs.len() != s.inputs.len() {
             return reject(
@@ -107,7 +110,10 @@ pub fn verify(bytes: &[u8], registry: &TermRegistry, ambient: &[Capability]) -> 
     // Stage 5 — capability (strand ⊆ grants ⊆ ambient; attenuation-only).
     for g in &capsule.grants {
         if !ambient.contains(g) {
-            return reject(Stage::Capability, format!("grant `{g}` exceeds ambient authority"));
+            return reject(
+                Stage::Capability,
+                format!("grant `{g}` exceeds ambient authority"),
+            );
         }
     }
     for (i, s) in capsule.braid.strands.iter().enumerate() {
@@ -116,7 +122,10 @@ pub fn verify(bytes: &[u8], registry: &TermRegistry, ambient: &[Capability]) -> 
             if !capsule.grants.contains(cap) {
                 return reject(
                     Stage::Capability,
-                    format!("strand {i} `{}` requires undeclared capability `{cap}`", s.term),
+                    format!(
+                        "strand {i} `{}` requires undeclared capability `{cap}`",
+                        s.term
+                    ),
                 );
             }
         }

--- a/crates/braid-verify/tests/acceptance.rs
+++ b/crates/braid-verify/tests/acceptance.rs
@@ -1,10 +1,10 @@
 //! PRD §7 acceptance scenarios — the framework's contract, as tests.
 //! Numbering follows `spec/braid/PRD.md`.
 
+use braid_capability::Capability;
 use braid_ir::examples::{edit_section_capsule, laundering_capsule, publish_capsule};
 use braid_ir::{registry_v0, ConfirmPolicy};
 use braid_verify::{verify, Stage, Verdict};
-use braid_capability::Capability;
 
 fn full_ambient() -> Vec<Capability> {
     vec![
@@ -26,20 +26,33 @@ fn expect_reject(v: Verdict, stage: Stage) {
 fn scenario_1_reversible_edit_admits() {
     let c = edit_section_capsule();
     let v = verify(&c.to_bytes(), &registry_v0(), &full_ambient());
-    assert_eq!(v, Verdict::Admit { capsule_cid: c.cid() });
+    assert_eq!(
+        v,
+        Verdict::Admit {
+            capsule_cid: c.cid()
+        }
+    );
 }
 
 #[test]
 fn scenario_2_irreversible_without_confirm_rejected() {
     let c = publish_capsule(ConfirmPolicy::None);
-    expect_reject(verify(&c.to_bytes(), &registry_v0(), &full_ambient()), Stage::Effect);
+    expect_reject(
+        verify(&c.to_bytes(), &registry_v0(), &full_ambient()),
+        Stage::Effect,
+    );
 }
 
 #[test]
 fn scenario_2b_irreversible_with_confirm_admits() {
     let c = publish_capsule(ConfirmPolicy::HumanConfirm);
     let v = verify(&c.to_bytes(), &registry_v0(), &full_ambient());
-    assert_eq!(v, Verdict::Admit { capsule_cid: c.cid() });
+    assert_eq!(
+        v,
+        Verdict::Admit {
+            capsule_cid: c.cid()
+        }
+    );
 }
 
 #[test]
@@ -47,7 +60,10 @@ fn scenario_4_grant_exceeding_ambient_rejected() {
     // Ambient lacks SignalEmit — the capsule's request must not survive.
     let c = edit_section_capsule();
     let ambient = vec![Capability::TapeRead];
-    expect_reject(verify(&c.to_bytes(), &registry_v0(), &ambient), Stage::Capability);
+    expect_reject(
+        verify(&c.to_bytes(), &registry_v0(), &ambient),
+        Stage::Capability,
+    );
 }
 
 #[test]
@@ -55,7 +71,10 @@ fn scenario_4b_strand_with_undeclared_capability_rejected() {
     // Grants omit SignalEmit but the braid uses cms.edit_section.
     let mut c = edit_section_capsule();
     c.grants = vec![];
-    expect_reject(verify(&c.to_bytes(), &registry_v0(), &full_ambient()), Stage::Capability);
+    expect_reject(
+        verify(&c.to_bytes(), &registry_v0(), &full_ambient()),
+        Stage::Capability,
+    );
 }
 
 /// T5 — the trip-wire. THE test of this suite: vault → pure → pure → egress
@@ -64,7 +83,10 @@ fn scenario_4b_strand_with_undeclared_capability_rejected() {
 #[test]
 fn scenario_5_path_taint_catches_multihop_laundering() {
     let c = laundering_capsule();
-    expect_reject(verify(&c.to_bytes(), &registry_v0(), &full_ambient()), Stage::Taint);
+    expect_reject(
+        verify(&c.to_bytes(), &registry_v0(), &full_ambient()),
+        Stage::Taint,
+    );
 }
 
 #[test]
@@ -72,18 +94,27 @@ fn scenario_6_malleable_bytes_rejected() {
     // Append a junk byte to otherwise-admissible canonical bytes.
     let mut bytes = edit_section_capsule().to_bytes();
     bytes.push(0x00);
-    expect_reject(verify(&bytes, &registry_v0(), &full_ambient()), Stage::CanonicalForm);
+    expect_reject(
+        verify(&bytes, &registry_v0(), &full_ambient()),
+        Stage::CanonicalForm,
+    );
 }
 
 #[test]
 fn scenario_7_version_skew_rejected() {
     let mut c = edit_section_capsule();
     c.vocab_version += 1;
-    expect_reject(verify(&c.to_bytes(), &registry_v0(), &full_ambient()), Stage::VersionPin);
+    expect_reject(
+        verify(&c.to_bytes(), &registry_v0(), &full_ambient()),
+        Stage::VersionPin,
+    );
 
     let mut c2 = edit_section_capsule();
     c2.registry_cid = braid_ir::Cid([0u8; 32]);
-    expect_reject(verify(&c2.to_bytes(), &registry_v0(), &full_ambient()), Stage::VersionPin);
+    expect_reject(
+        verify(&c2.to_bytes(), &registry_v0(), &full_ambient()),
+        Stage::VersionPin,
+    );
 }
 
 #[test]
@@ -91,14 +122,20 @@ fn scenario_8_float_rejected_at_the_byte_gate() {
     // An f64 head — there is no path by which a float reaches a type check;
     // it dies at canonical form.
     let bytes = [0xfb, 0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18];
-    expect_reject(verify(&bytes, &registry_v0(), &full_ambient()), Stage::CanonicalForm);
+    expect_reject(
+        verify(&bytes, &registry_v0(), &full_ambient()),
+        Stage::CanonicalForm,
+    );
 }
 
 #[test]
 fn scenario_9_budget_exceeded_rejected() {
     let mut c = edit_section_capsule();
     c.budget = 3; // strands cost 1+1+8+2 = 12
-    expect_reject(verify(&c.to_bytes(), &registry_v0(), &full_ambient()), Stage::Bounds);
+    expect_reject(
+        verify(&c.to_bytes(), &registry_v0(), &full_ambient()),
+        Stage::Bounds,
+    );
 }
 
 #[test]
@@ -106,7 +143,10 @@ fn scenario_14_unknown_term_rejected() {
     let mut c = edit_section_capsule();
     c.braid.strands[3].term = "eval".into();
     c.braid.strands[3].inputs = vec![1];
-    expect_reject(verify(&c.to_bytes(), &registry_v0(), &full_ambient()), Stage::Structure);
+    expect_reject(
+        verify(&c.to_bytes(), &registry_v0(), &full_ambient()),
+        Stage::Structure,
+    );
 }
 
 #[test]
@@ -114,14 +154,20 @@ fn type_mismatch_rejected() {
     // Feed an Entity into view.section (expects Text).
     let mut c = edit_section_capsule();
     c.braid.strands[3].inputs = vec![0];
-    expect_reject(verify(&c.to_bytes(), &registry_v0(), &full_ambient()), Stage::Types);
+    expect_reject(
+        verify(&c.to_bytes(), &registry_v0(), &full_ambient()),
+        Stage::Types,
+    );
 }
 
 #[test]
 fn arity_mismatch_rejected() {
     let mut c = edit_section_capsule();
     c.braid.strands[3].inputs = vec![1, 1];
-    expect_reject(verify(&c.to_bytes(), &registry_v0(), &full_ambient()), Stage::Structure);
+    expect_reject(
+        verify(&c.to_bytes(), &registry_v0(), &full_ambient()),
+        Stage::Structure,
+    );
 }
 
 #[test]
@@ -129,7 +175,10 @@ fn forward_reference_rejected() {
     // A strand consuming its own output — the cycle that cannot be typed.
     let mut c = edit_section_capsule();
     c.braid.strands[1].inputs = vec![3];
-    expect_reject(verify(&c.to_bytes(), &registry_v0(), &full_ambient()), Stage::Structure);
+    expect_reject(
+        verify(&c.to_bytes(), &registry_v0(), &full_ambient()),
+        Stage::Structure,
+    );
 }
 
 #[test]
@@ -146,8 +195,14 @@ fn egress_below_ceiling_with_confirm_admits() {
         grants: vec![Capability::RemoteCompute],
         braid: Braid {
             strands: vec![
-                Strand { term: "lit.bytes".into(), inputs: vec![] },
-                Strand { term: "net.egress".into(), inputs: vec![0] },
+                Strand {
+                    term: "lit.bytes".into(),
+                    inputs: vec![],
+                },
+                Strand {
+                    term: "net.egress".into(),
+                    inputs: vec![0],
+                },
             ],
             outputs: vec![1],
         },
@@ -156,7 +211,12 @@ fn egress_below_ceiling_with_confirm_admits() {
         evidence: vec!["provider.receipt".into()],
     };
     let v = verify(&c.to_bytes(), &registry_v0(), &full_ambient());
-    assert_eq!(v, Verdict::Admit { capsule_cid: c.cid() });
+    assert_eq!(
+        v,
+        Verdict::Admit {
+            capsule_cid: c.cid()
+        }
+    );
 }
 
 /// U9 finding regression: a capsule with a key smuggled into the nested braid
@@ -174,5 +234,8 @@ fn scenario_6b_nested_submap_smuggle_rejected() {
     }
     let dirty = braid_ir::canon::encode(&v);
     assert_ne!(dirty, clean.to_bytes());
-    expect_reject(verify(&dirty, &registry_v0(), &full_ambient()), Stage::CanonicalForm);
+    expect_reject(
+        verify(&dirty, &registry_v0(), &full_ambient()),
+        Stage::CanonicalForm,
+    );
 }

--- a/crates/braid-verify/tests/parity.rs
+++ b/crates/braid-verify/tests/parity.rs
@@ -52,9 +52,18 @@ fn parity_on_the_pinned_kat_vector() {
 #[test]
 fn verify_decoder_rejects_the_malleability_set() {
     use braid_verify::decode::DecodeError;
-    assert_eq!(decode_canonical(&[0x18, 0x05]), Err(DecodeError::NonMinimal));
-    assert!(matches!(decode_canonical(&[0xf6]), Err(DecodeError::Forbidden(_))));
-    assert!(matches!(decode_canonical(&[0xfb, 0, 0, 0, 0, 0, 0, 0, 0]), Err(DecodeError::Forbidden(_))));
+    assert_eq!(
+        decode_canonical(&[0x18, 0x05]),
+        Err(DecodeError::NonMinimal)
+    );
+    assert!(matches!(
+        decode_canonical(&[0xf6]),
+        Err(DecodeError::Forbidden(_))
+    ));
+    assert!(matches!(
+        decode_canonical(&[0xfb, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Err(DecodeError::Forbidden(_))
+    ));
     assert_eq!(decode_canonical(&[0x01, 0x00]), Err(DecodeError::Trailing));
     let unordered = [0xa2, 0x61, b'b', 0x01, 0x61, b'a', 0x02];
     assert_eq!(decode_canonical(&unordered), Err(DecodeError::KeyOrder));

--- a/docs/authoring-cli.md
+++ b/docs/authoring-cli.md
@@ -26,6 +26,12 @@ braid render <capsule.braid>               # the human-review manifest
 braid diff   <old.braid> <new.braid>       # manifest delta; fails on any Widening
 ```
 
+`render` and `diff` are human-review projections of **admitted** artifacts.
+They first run the verifier using the capsule's declared grants as ambient
+authority, matching `verify`'s default happy-path check. A canonical but
+verifier-rejected capsule (for example, stale `vocab_version` or
+`registry_cid`) is refused before manifest text is emitted.
+
 **Exit codes:** `0` ok · `1` policy-negative (a clean run that ends in
 `REJECT` or `WIDENING`) · `2` operator error (bad usage / IO / malformed input
 / author-time reject). The split lets CI and `&&` chains distinguish "the tool

--- a/spec/braid/threat-model.md
+++ b/spec/braid/threat-model.md
@@ -61,6 +61,16 @@ human approves a manifest that doesn't describe what runs.
 admission record binds (capsule CID, manifest CID, artifact CID); runtime
 re-derives the manifest at load and refuses on mismatch (acceptance #10).
 **Pinned by**: U2 binding tests; U7 load-time re-verification.
+**U9 finding (closed, Medium)**: the operator CLI's `render`/`diff` path
+strict-decoded canonical capsules but did not require a verifier `ADMIT`
+before emitting human-review output. A stale-version or bogus-registry capsule
+was rejected by `verify` yet could still be rendered or diffed as an ordinary
+manifest, weakening the review gate's fail-closed story. Fixed by making
+`render` and `diff` call the verifier first (ambient = declared grants, same
+as `verify`'s default) and refuse verifier-rejected capsules before manifest
+text is emitted. Regression: `crates/braid-cli/tests/cli_loop.rs`
+(`render_refuses_version_skewed_capsule`,
+`diff_refuses_version_skewed_capsule`).
 
 ## T5 — Capability/effect laundering via composition
 Every strand passes its local check; the *path* exceeds: vault-read → pure →


### PR DESCRIPTION
## Summary
- format the full Rust workspace and update CI to enforce `cargo fmt --all --check`
- make `braid render` and `braid diff` require verifier ADMIT before emitting human-review output
- add regressions for canonical but version-skewed capsules being refused by render/diff
- document the fail-closed review behavior and record the closed T4 finding

## Verification
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build -p braid-cli && ./scripts/cli-loop.sh target/debug/braid`

Closes #4
Refs #1