### PR TITLE
U9 show neutral artifact changes in manifest diffs

### DIFF
--- a/crates/braid-cli/tests/cli_loop.rs
+++ b/crates/braid-cli/tests/cli_loop.rs
@@ -159,6 +159,30 @@ fn diff_identical_is_no_change() {
     assert!(String::from_utf8_lossy(&d.stdout).contains("no change"));
 }
 
+/// T12/U9 — `no change` must mean the same admitted artifact, not merely "no
+/// new capability/effect." A neutral evidence-policy change should pass the
+/// widening gate but still produce an explicit diff.
+#[test]
+fn diff_neutral_artifact_change_is_not_no_change() {
+    let (base, _) = encode("edit_section.json", "neutral_base.braid");
+    let mut capsule = braid_ir::Capsule::from_bytes(&std::fs::read(&base).unwrap()).unwrap();
+    capsule.evidence.push("audit.extra".into());
+    let changed = tmp("neutral_changed.braid");
+    std::fs::write(&changed, capsule.to_bytes()).unwrap();
+
+    let d = run(&["diff", base.to_str().unwrap(), changed.to_str().unwrap()]);
+    assert!(
+        d.status.success(),
+        "neutral changes pass the widening gate (exit 0)"
+    );
+    let out = String::from_utf8_lossy(&d.stdout);
+    assert!(!out.contains("no change"), "got: {out}");
+    assert!(
+        out.contains("neutral") && out.contains("capsule") && out.contains("evidence"),
+        "got: {out}"
+    );
+}
+
 /// U9/T4/T6 — rendering is a human-review projection of an ADMITTED artifact,
 /// not a side door around the verifier. A canonical capsule with a stale
 /// registry pin must be refused before any manifest text is emitted.

--- a/crates/braid-render/src/lib.rs
+++ b/crates/braid-render/src/lib.rs
@@ -157,6 +157,18 @@ pub fn manifest_diff(old: &Manifest, new: &Manifest) -> Vec<Delta> {
     let mut deltas = Vec::new();
     let set = |v: &[String]| -> BTreeSet<String> { v.iter().cloned().collect() };
 
+    if old.capsule_cid != new.capsule_cid {
+        deltas.push(Delta {
+            kind: DeltaKind::Neutral,
+            field: "capsule",
+            detail: format!(
+                "{} -> {}",
+                old.capsule_cid.to_hex(),
+                new.capsule_cid.to_hex()
+            ),
+        });
+    }
+
     let (old_caps, new_caps) = (set(&old.capabilities), set(&new.capabilities));
     for added in new_caps.difference(&old_caps) {
         deltas.push(Delta {
@@ -229,6 +241,44 @@ pub fn manifest_diff(old: &Manifest, new: &Manifest) -> Vec<Delta> {
         deltas.push(Delta {
             kind: DeltaKind::Neutral,
             field: "intent",
+            detail: "changed".into(),
+        });
+    }
+    if old.strand_count != new.strand_count {
+        deltas.push(Delta {
+            kind: DeltaKind::Neutral,
+            field: "strands",
+            detail: format!("{} -> {}", old.strand_count, new.strand_count),
+        });
+    }
+    if old.total_cost != new.total_cost {
+        deltas.push(Delta {
+            kind: DeltaKind::Neutral,
+            field: "cost",
+            detail: format!("{} -> {}", old.total_cost, new.total_cost),
+        });
+    }
+    if old.irreversible_strands != new.irreversible_strands {
+        deltas.push(Delta {
+            kind: DeltaKind::Neutral,
+            field: "irreversible_strands",
+            detail: format!(
+                "{} -> {}",
+                old.irreversible_strands, new.irreversible_strands
+            ),
+        });
+    }
+    if old.egress_strands != new.egress_strands {
+        deltas.push(Delta {
+            kind: DeltaKind::Neutral,
+            field: "egress_strands",
+            detail: format!("{} -> {}", old.egress_strands, new.egress_strands),
+        });
+    }
+    if old.evidence != new.evidence {
+        deltas.push(Delta {
+            kind: DeltaKind::Neutral,
+            field: "evidence",
             detail: "changed".into(),
         });
     }

--- a/crates/braid-render/tests/render.rs
+++ b/crates/braid-render/tests/render.rs
@@ -87,6 +87,27 @@ fn identical_manifests_produce_no_deltas() {
 }
 
 #[test]
+fn changed_artifact_is_not_reported_as_no_change() {
+    let old = edit_section_capsule();
+    let mut new = old.clone();
+    new.evidence.push("audit.extra".into());
+    assert_ne!(old.cid(), new.cid());
+
+    let deltas = manifest_diff(
+        &manifest(&old, &registry_v0()).unwrap(),
+        &manifest(&new, &registry_v0()).unwrap(),
+    );
+    assert!(!deltas.is_empty());
+    assert!(!has_widening(&deltas));
+    assert!(deltas.iter().any(|d| d.kind == DeltaKind::Neutral
+        && d.field == "capsule"
+        && d.detail.contains(&new.cid().to_hex())));
+    assert!(deltas
+        .iter()
+        .any(|d| d.kind == DeltaKind::Neutral && d.field == "evidence"));
+}
+
+#[test]
 fn unknown_term_renders_nothing() {
     // A manifest must not exist for an unverifiable capsule (fail-closed).
     let mut c = edit_section_capsule();

--- a/docs/authoring-cli.md
+++ b/docs/authoring-cli.md
@@ -114,6 +114,11 @@ braid diff edit.braid edit_widened.braid
 #   (exit 1 — the gate fires)
 ```
 
+Non-widening artifact changes are still shown. `no change` is reserved for the
+same admitted capsule/manifest, not merely "same authority." For example, an
+evidence-policy-only change exits `0` but prints neutral `capsule` and
+`evidence` deltas.
+
 `--grant` on `verify` models the authority the *principal* holds (default: the
 capsule's own declared grants). Hand it a narrower set to see attenuation
 enforced:

--- a/spec/braid/threat-model.md
+++ b/spec/braid/threat-model.md
@@ -144,6 +144,17 @@ security-review label; narrowing/no-change diffs are visually distinct.
 Red-team requirement: a deliberate widening PR must be caught before v0 ships
 (success metric).
 **Pinned by**: U6; acceptance #11.
+**U9 finding (closed, Medium)**: `manifest_diff` could return an empty delta
+set for two different admitted capsules when the changed fields did not alter
+capabilities, effect classes, budget, confirmation, or intent. The CLI then
+printed `no change`, even though the capsule CID and review-visible evidence
+policy had changed. Fixed by emitting neutral deltas for capsule CID and other
+review-visible non-widening fields (strand count, cost, irreversible/egress
+counts, evidence), so only identical manifests produce `no change`; the
+widening gate's exit semantics remain unchanged. Regression:
+`braid-render/tests/render.rs::changed_artifact_is_not_reported_as_no_change`
+and
+`braid-cli/tests/cli_loop.rs::diff_neutral_artifact_change_is_not_no_change`.
 
 ## T13 — AI-only path dependence (sovereignty failure)
 The pipeline quietly grows steps only an AI can perform (unwritten knowledge,


### PR DESCRIPTION
## Summary
- make manifest diffs emit neutral deltas when the admitted capsule CID changes
- include neutral deltas for review-visible non-widening fields like strand count, cost, egress/irreversible counts, and evidence
- add renderer and CLI regressions so `no change` only means the same admitted manifest
- document the CLI behavior and record the closed T12 finding

## Verification
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build -p braid-cli && ./scripts/cli-loop.sh target/debug/braid`

Refs #1