### PR TITLE
U-SA: Braid safety-assurance CI via Keel (D32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,33 @@ jobs:
       # on a seeded widening (T12) and a laundering capsule rejected at taint.
       - name: CLI-only loop
         run: ./scripts/cli-loop.sh target/release/braid
+
+  tier2-semantic:
+    name: Keel safety-assurance floor (NotSlop)
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: checkout Keel
+        uses: actions/checkout@v4
+        with:
+          repository: srinji-kaggss/keel
+          path: keel
+      - name: Tier-1 evidence (cargo test + clippy)
+        run: cargo test --workspace
+      - name: Keel semantic floor
+        env:
+          KEEL_ROOT: ./keel
+        run: ./scripts/keel-floor.sh
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: braid-ci-evidence
+          path: .ci-runs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: checkout Keel
-        uses: actions/checkout@v4
-        with:
-          repository: srinji-kaggss/keel
-          path: keel
       - name: Tier-1 evidence (cargo test + clippy)
         run: cargo test --workspace
       - name: Keel semantic floor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   test:
     name: build · test · lint
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -29,7 +29,7 @@ jobs:
 
   cli-loop:
     name: scenario #12 + T12 widening gate
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -44,7 +44,7 @@ jobs:
 
   tier2-semantic:
     name: Keel safety-assurance floor (NotSlop)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: [test]
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock.orig
 .DS_Store
+.keel/

--- a/braid.profile.json
+++ b/braid.profile.json
@@ -1,0 +1,132 @@
+{
+  "_comment": "Braid safety-assurance profile (U-SA, D32). Binds Keel's 20 evidence atoms to Braid's Tier-1 tools. Gate concept: NotSlop. Graded atoms without mechanical numeric extraction are left unbound (unknown). Workspace-wide commands (cargo test, clippy) run once at the workspace level; per-crate tests bind individually.",
+  "target": {
+    "name": "braid",
+    "root": ".",
+    "ecosystem": "rust"
+  },
+  "units": [
+    {
+      "unit": "crate",
+      "discover": {
+        "type": "literal",
+        "values": ["."]
+      }
+    }
+  ],
+  "bindings": [
+    {
+      "atom": "referential_truth",
+      "unit": "crate",
+      "evidence": {
+        "tool": "cargo",
+        "argv": ["check", "--workspace"],
+        "ok_when": "exit==0"
+      }
+    },
+    {
+      "atom": "type_soundness",
+      "unit": "crate",
+      "evidence": {
+        "tool": "cargo",
+        "argv": ["clippy", "--workspace", "--all-targets", "--", "-D", "warnings"],
+        "ok_when": "exit==0"
+      }
+    },
+    {
+      "atom": "specification_fidelity",
+      "unit": "crate",
+      "evidence": {
+        "tool": "cargo",
+        "argv": ["test", "--workspace"],
+        "ok_when": "exit==0"
+      }
+    },
+    {
+      "atom": "precondition_correctness",
+      "unit": "crate",
+      "evidence": {
+        "tool": "cargo",
+        "argv": ["test", "-p", "braid-verify", "--", "--test-threads=1"],
+        "ok_when": "exit==0"
+      }
+    },
+    {
+      "atom": "postcondition_correctness",
+      "unit": "crate",
+      "evidence": {
+        "tool": "cargo",
+        "argv": ["test", "-p", "braid-verify", "-p", "braid-render"],
+        "ok_when": "exit==0"
+      }
+    },
+    {
+      "atom": "invariant_preservation",
+      "unit": "crate",
+      "evidence": {
+        "tool": "cargo",
+        "argv": ["test", "-p", "braid-ir"],
+        "ok_when": "exit==0"
+      }
+    },
+    {
+      "atom": "totality_or_controlled_partiality",
+      "unit": "crate",
+      "evidence": {
+        "tool": "cargo",
+        "argv": ["clippy", "--workspace", "--all-targets", "--", "-D", "warnings"],
+        "ok_when": "exit==0"
+      }
+    },
+    {
+      "atom": "data_model_truth",
+      "unit": "crate",
+      "evidence": {
+        "tool": "cargo",
+        "argv": ["test", "-p", "braid-ir"],
+        "ok_when": "exit==0"
+      }
+    },
+    {
+      "atom": "error_semantics",
+      "unit": "crate",
+      "evidence": {
+        "tool": "cargo",
+        "argv": ["test", "-p", "braid-verify", "-p", "braid-ir", "-p", "braid-sdk"],
+        "ok_when": "exit==0"
+      }
+    },
+    {
+      "atom": "security_by_construction",
+      "unit": "crate",
+      "evidence": {
+        "tool": "cargo",
+        "argv": ["test", "-p", "braid-verify"],
+        "ok_when": "exit==0"
+      }
+    },
+    {
+      "atom": "testability_falsifiability",
+      "unit": "crate",
+      "evidence": {
+        "tool": "cargo",
+        "argv": ["test", "--workspace"],
+        "ok_when": "exit==0"
+      }
+    },
+    {
+      "atom": "change_locality",
+      "unit": "crate",
+      "evidence": {
+        "tool": "cargo",
+        "argv": ["test", "--workspace"],
+        "ok_when": "exit==0"
+      }
+    }
+  ],
+  "gate_concept": "NotSlop",
+  "execution_policy": {
+    "allow": ["cargo", "bash", "node"],
+    "env_passthrough": ["HOME", "CARGO_HOME", "RUSTUP_HOME", "USER"]
+  }
+}

--- a/keel/README.md
+++ b/keel/README.md
@@ -1,0 +1,121 @@
+# Keel
+
+**A standalone, deterministic verification authority for code authored by AI.**
+
+A keel is the structural spine along the bottom of a hull. Everything is built on it;
+without it the vessel cannot hold a heading. Keel is that spine for a codebase: a
+restrictive, content-addressed **floor** of correctness and confinement that an
+AI author cannot argue past, over which the rest of the system grows naturally.
+
+## What it is, in one paragraph
+
+Keel treats the code generator — today an LLM — as an **untrusted, possibly
+incoherent author**. It does not review code the way a senior engineer advises a
+junior; it **gates** code with independent, deterministic, reconstructable evidence. The verdict
+is produced by deterministic measurement and symbolic composition — **never by a
+second AI**. Keel runs with no network and no CI service (it was built because
+GitHub Actions was billing-blocked and we needed an authority that does not depend
+on anyone's servers), and it is designed to be lifted whole into any codebase and
+**tailored by an AI through schema, not code edits**.
+
+## The three properties that define it
+
+1. **Deterministic floor, not advice.** Keel owns a *floor* of correctness and
+   confinement-safety. Humans own architecture and intent *above* the floor. The
+   floor is enforced by measurement, so the prose rulebook above it can shrink
+   toward two lines. (See `docs/00-thesis.md`.)
+2. **Content-addressed and stale-proof by construction.** Every verifiable thing is
+   a node in a Merkle DAG, named by the hash of its content and its inputs' hashes.
+   When source moves — and AI moves thousands of lines an hour — only the nodes whose
+   content actually changed recompute; stale verdicts are *unreadable by
+   construction*, not chased after the fact. (See `docs/01-architecture.md`.)
+3. **Restrictive schema, AI-tailorable.** The set of obligations is a closed,
+   restrictive schema. An AI adapts Keel to a new codebase by *filling the schema*,
+   not by rewriting the engine. Degrees of freedom are the enemy of verifiability and
+   the source of staleness; the schema is deliberately tight even when that costs the
+   authoring AI extra effort. (See `docs/03-schema-and-tailoring.md`.)
+
+## Two-tier acceptance
+
+- **Tier 1 — operational acceptance.** The traditional gate: it compiles, types,
+  lints, tests, builds. These tools do not *judge*; they *produce evidence*.
+- **Tier 2 — semantic acceptance.** Evidence is compiled into the twenty axioms of
+  the *Excellent Code Framework* (`docs/02-axioms.md`) and a verdict is read off a
+  deterministic theorem (`Excellent ⇒ ¬Hallucinated`). The semantic layer never
+  judges inline — it *compiles evidence and packages it separately*; the verdict is a
+  mechanical implication over instantiated predicates.
+
+## Mission
+
+Keel aims to be a portable verification spine for AI-authored software, owned as a public-good style
+artifact rather than a project-local convention. This repository is its standalone origin.
+
+## Status
+
+First pass. See `docs/` for the complete scientific specification and the issue
+ledger for what is deferred. Keel is a *specification with a running seed*, not a
+finished product — by design, the basement is poured before the house.
+
+## Reviewing Keel
+
+If you are an independent AI or auditor, **`docs/08-review-walkthrough.md` is the entry
+point.** It lets you verify every claim below from a cold checkout — each with the file that
+implements it and the command that proves it. Trust nothing the prose says; run the command:
+
+```bash
+node src/selftest.mjs          # algebra + hashing + concurrency + lean-proof-node identity
+node src/qualify.mjs           # DO-330 tool qualification vs fixtures/known-bad/ (+ lean machine-check)
+node src/qualify.mjs --self-test                       # the auditor-of-the-auditor
+node src/run.mjs --profile examples/keel.profile.json  # Keel verifies itself → GO
+(cd lean && lake build)        # machine-check the framework skeleton (needs elan/lake; else qualify SKIPs)
+```
+
+## The finite-outcome crossing (docs/07)
+
+A codebase's outcomes are **finite, given its structure** — the decision space, the mutation
+space, the input space, the failure space, the platform matrix. Verification is **crossing
+that space to completion**, not sampling it: you find failure by exercising the declared
+envelope and by loading every structural joint. Keel crosses the activation
+set **concurrently** (the verdict is a pure function of content, so parallelism changes
+throughput, never the result), composes with three-valued ∧ (one red *or* unknown point
+dominates), and reports crossing coverage honestly (an uncrossed point is reported, never
+assumed green).
+
+## Safety-critical CI contract (docs/11)
+
+`docs/11-safety-critical-ci.md` maps Keel's deterministic gates to the public FAA/RTCA/ISO shape of
+DO-178B, DO-178C, DO-331, DO-330, and ISO 26262. The matching `safety_case` profile block makes those
+claims machine-checkable: DAL/ASIL source, hazard analysis, requirements traceability, independence,
+coverage, tool qualification, configuration index, and model-based evidence all become restrictive
+schema fields. This is not a certification claim; it is the CI discipline future agents must satisfy
+before touching life-impact code.
+
+## CI/CD operations (docs/12)
+
+`scripts/ci/run.mjs` is the portable CI surface for Keel itself: JSON sanity, overclaim scanning,
+self-test, known-bad qualification, qualification-harness self-test, and the self-hosting profile
+run. `.github/workflows/ci.yml` runs that surface and uploads `.ci-runs/` evidence. Future agents
+should start with `docs/guides/agent-navigation.md`, then use the local skills under `skills/` for
+CI architecture, safety-profile authoring, and release gating.
+
+For internal audit runs, use `scripts/ci/vm-run.mjs` (see `docs/13-vm-soc-audit-runner.md`). GitHub
+Actions is an optional projection; the SOC-style authority is a VM-backed run that stages the checkout
+into a writable guest workspace, runs CI there, pulls evidence back, records guest identity/toolchain
+state/logs/manifest hashes, and writes an audit seal. On the current workstation:
+
+```bash
+node scripts/ci/vm-run.mjs --provider lima --instance keel-ci
+```
+
+Host runs are marked `host-dev-only` and are never release evidence.
+
+## Layout
+
+```
+docs/    scientific specification (00 thesis … 06 productization; 07 concurrency+crossing; 08 review walkthrough; 11 safety-critical CI; 12 CI/CD; 13 VM audit)
+skills/  local agent skills for CI architecture, safety profiles, and release gates
+schema/  the restrictive ontology: atoms (evidence), concepts (formulas), the tailoring profile
+src/     the running seed: anchor, concurrency pool, atom evaluators, concept algebra, projections, runners, qualify
+fixtures/ known-bad corpus — one planted case per core guarantee (DO-330 tool qualification)
+examples/ a worked tailoring profile
+```

--- a/keel/schema/atoms.json
+++ b/keel/schema/atoms.json
@@ -1,0 +1,26 @@
+{
+  "schema": "keel.atoms/v0",
+  "note": "The twenty evidence atoms of the Excellent Code Framework, intent-stripped. Each atom is INSTANTIATED by a real Tier-1 tool; Keel never asserts an atom true without evidence. kind: boolean|graded. tier: commit|soak|sim. unit: the code-unit type the atom binds to (auto-activation). An atom with no bound evidence source evaluates to 'unknown', never 'true'.",
+  "atoms": [
+    { "id": "referential_truth", "n": 1, "formal": "∀s∈Symbols(P), Resolve_E(s)≠∅", "evidence": "compiler/import/API/schema resolution", "kind": "boolean", "tier": "commit", "unit": "crate", "core": true },
+    { "id": "specification_fidelity", "n": 2, "formal": "∀x∈D, ⟦P⟧_E(x)=S(x)", "evidence": "spec tests/proofs/review", "kind": "boolean", "tier": "commit", "unit": "crate", "core": true },
+    { "id": "type_soundness", "n": 3, "formal": "e:T ⇒ eval(e)∈T or defined error", "evidence": "type checker/static analysis", "kind": "boolean", "tier": "commit", "unit": "crate", "core": true },
+    { "id": "precondition_correctness", "n": 4, "formal": "Pre(x) ⇒ P valid on x", "evidence": "contracts/input validation", "kind": "boolean", "tier": "commit", "unit": "module" },
+    { "id": "postcondition_correctness", "n": 5, "formal": "Pre(x)∧P(x)=y ⇒ Post(x,y)", "evidence": "contracts/assertions/tests", "kind": "boolean", "tier": "commit", "unit": "module" },
+    { "id": "invariant_preservation", "n": 6, "formal": "I(s)∧step(s,a)=s′ ⇒ I(s′)", "evidence": "state-machine proof/property tests", "kind": "boolean", "tier": "commit", "unit": "module" },
+    { "id": "totality_or_controlled_partiality", "n": 7, "formal": "∀x∈D, P(x)∈Out∪defined-error", "evidence": "exhaustive error handling", "kind": "boolean", "tier": "commit", "unit": "crate", "core": true },
+    { "id": "boundary_completeness", "n": 8, "formal": "domain partitioned; boundaries tested", "evidence": "boundary tests/domain partition", "kind": "graded", "tier": "commit", "unit": "module" },
+    { "id": "compositionality", "n": 9, "formal": "module contracts hold; no hidden effects", "evidence": "module contracts/effect analysis", "kind": "boolean", "tier": "commit", "unit": "module" },
+    { "id": "minimal_sufficient_complexity", "n": 10, "formal": "complexity/coupling ≤ bound", "evidence": "complexity/coupling review", "kind": "graded", "tier": "commit", "unit": "module" },
+    { "id": "algorithmic_efficiency", "n": 11, "formal": "cost ≤ declared bound", "evidence": "complexity analysis/benchmarks", "kind": "graded", "tier": "soak", "unit": "crate" },
+    { "id": "state_minimization", "n": 12, "formal": "reachable state count controlled", "evidence": "state count/control", "kind": "graded", "tier": "commit", "unit": "module" },
+    { "id": "data_model_truth", "n": 13, "formal": "schema constraints model the domain", "evidence": "domain model review/schema constraints", "kind": "boolean", "tier": "commit", "unit": "crate" },
+    { "id": "error_semantics", "n": 14, "formal": "errors typed; recovery defined", "evidence": "typed errors/recovery plan", "kind": "boolean", "tier": "commit", "unit": "module" },
+    { "id": "security_by_construction", "n": 15, "formal": "authz + invariants hold by structure", "evidence": "authorization/invariant checks", "kind": "boolean", "tier": "commit", "unit": "crate" },
+    { "id": "idempotence", "n": 16, "formal": "retried effects safe where declared", "evidence": "idempotency keys/transaction tests", "kind": "boolean", "tier": "sim", "unit": "service" },
+    { "id": "concurrency_correctness", "n": 17, "formal": "chosen consistency condition preserved", "evidence": "locks/transactions/linearizability tests", "kind": "boolean", "tier": "sim", "unit": "service" },
+    { "id": "observability", "n": 18, "formal": "runtime diagnosable", "evidence": "diagnostic coverage", "kind": "graded", "tier": "commit", "unit": "service" },
+    { "id": "testability_falsifiability", "n": 19, "formal": "claims refutable by tests/proofs", "evidence": "unit/property/integration tests", "kind": "boolean", "tier": "commit", "unit": "crate" },
+    { "id": "change_locality", "n": 20, "formal": "local requirement change ⇒ local code change", "evidence": "coupling/modularity analysis", "kind": "graded", "tier": "commit", "unit": "crate" }
+  ]
+}

--- a/keel/schema/concepts.json
+++ b/keel/schema/concepts.json
@@ -1,0 +1,234 @@
+{
+  "schema": "keel.concepts/v0",
+  "note": "A concept is a named formula over atom ids. Closed grammar: a formula is an atom id (string), or {all:[...]}, {any:[...]}, {not: formula}. No free text, no code. The three 'framework' concepts MUST match lean/ExcellentCode/Framework.lean exactly and are checked by ORG.selftest. All others are user space \u2014 the Director may add one in a single entry, any day, with no engine change.",
+  "grammar": {
+    "formula": "atomId | {all: formula[]} | {any: formula[]} | {not: formula}",
+    "value": "true | false | unknown (three-valued; unknown over a gated atom => block)"
+  },
+  "concepts": [
+    {
+      "id": "CoreGroundedCorrect",
+      "origin": "framework",
+      "formal": "referential_truth \u2227 type_soundness \u2227 totality_or_controlled_partiality \u2227 specification_fidelity",
+      "formula": {
+        "all": [
+          "referential_truth",
+          "type_soundness",
+          "totality_or_controlled_partiality",
+          "specification_fidelity"
+        ]
+      }
+    },
+    {
+      "id": "Hallucinated",
+      "origin": "framework",
+      "formal": "\u00ac CoreGroundedCorrect",
+      "formula": {
+        "not": {
+          "all": [
+            "referential_truth",
+            "type_soundness",
+            "totality_or_controlled_partiality",
+            "specification_fidelity"
+          ]
+        }
+      }
+    },
+    {
+      "id": "Excellent",
+      "origin": "framework",
+      "formal": "\u22c0 all twenty atoms",
+      "formula": {
+        "all": [
+          "referential_truth",
+          "specification_fidelity",
+          "type_soundness",
+          "precondition_correctness",
+          "postcondition_correctness",
+          "invariant_preservation",
+          "totality_or_controlled_partiality",
+          "boundary_completeness",
+          "compositionality",
+          "minimal_sufficient_complexity",
+          "algorithmic_efficiency",
+          "state_minimization",
+          "data_model_truth",
+          "error_semantics",
+          "security_by_construction",
+          "idempotence",
+          "concurrency_correctness",
+          "observability",
+          "testability_falsifiability",
+          "change_locality"
+        ]
+      }
+    },
+    {
+      "id": "sound",
+      "origin": "user",
+      "formal": "conservative always-on floor",
+      "formula": {
+        "all": [
+          "referential_truth",
+          "type_soundness",
+          "totality_or_controlled_partiality",
+          "testability_falsifiability"
+        ]
+      }
+    },
+    {
+      "id": "did",
+      "origin": "user",
+      "formal": "defence-in-depth surface",
+      "formula": {
+        "all": [
+          "security_by_construction",
+          "error_semantics",
+          "observability",
+          "concurrency_correctness"
+        ]
+      }
+    },
+    {
+      "id": "stat_sound",
+      "origin": "user",
+      "formal": "statistically/quantitatively grounded",
+      "formula": {
+        "all": [
+          "boundary_completeness",
+          "algorithmic_efficiency",
+          "testability_falsifiability",
+          "specification_fidelity"
+        ]
+      }
+    },
+    {
+      "id": "buildable",
+      "origin": "user",
+      "formal": "symbols resolve AND claims are tested \u2014 the minimal demonstrable floor",
+      "formula": {
+        "all": [
+          "referential_truth",
+          "testability_falsifiability"
+        ]
+      }
+    },
+    {
+      "id": "resilient",
+      "origin": "user",
+      "formal": "holds under fault \u2014 the RESILIENCE crossing (docs/07 \u00a77.3): what fault-injection crosses",
+      "note": "Instantiated by crossing the failure space (OOM/IO-fail-at-N, partial writes, concurrent contention) and asserting the invariants still hold. 'Where the bridge fails' \u2014 find the load at which it does, prove it is past the envelope.",
+      "formula": {
+        "all": [
+          "error_semantics",
+          "totality_or_controlled_partiality",
+          "invariant_preservation",
+          "concurrency_correctness"
+        ]
+      }
+    },
+    {
+      "id": "well_crossed",
+      "origin": "user",
+      "formal": "the finite decision/boundary outcome space is crossed to completion (docs/07 \u00a77.1)",
+      "note": "Instantiated by MC/DC (every decision's conditions crossed), mutation (every structural perturbation killed), and fuzz (the input space crossed). The codebase's outcomes are finite given its structure; this concept asks whether the verifier crossed them.",
+      "formula": {
+        "all": [
+          "boundary_completeness",
+          "precondition_correctness",
+          "postcondition_correctness",
+          "testability_falsifiability"
+        ]
+      }
+    },
+    {
+      "id": "spec_validated",
+      "origin": "user",
+      "formal": "system output matches validated reference data within tolerance (docs/10 A6)",
+      "note": "Instantiated by the input-envelope simulator in REFERENCE mode (src/run-simulate.mjs): the system-under-test output is compared to a declared reference table within tolerance. Truth traces to reference DATA, not the harness author's intuition (A6 validated_aircraft_correlation) \u2014 this is the honest binding of specification_fidelity.",
+      "formula": {
+        "all": [
+          "specification_fidelity"
+        ]
+      }
+    },
+    {
+      "id": "latency_bounded",
+      "origin": "user",
+      "formal": "measured latency/jitter \u2264 cited budget across samples (docs/10 A5)",
+      "note": "Instantiated by the latency tier (src/run-latency.mjs): the operation's measured latency is aggregated (max/p99/jitter) and crossed against a CITED budget. Measurement is empirical (sensor); the budget decision is deterministic. A5: latency and jitter are first-order verdict variables.",
+      "formula": {
+        "all": [
+          "algorithmic_efficiency"
+        ]
+      }
+    },
+    {
+      "id": "concurrent_safe",
+      "origin": "user",
+      "formal": "the consistency oracle holds across every enumerated interleaving (docs/04 \u00a74.5, A1/A7)",
+      "note": "Instantiated by the multi-actor sim tier (src/run-sim.mjs): Keel enumerates the order-preserving interleavings of concurrent actors and crosses the consistency oracle over all of them. The system is concurrent_safe iff no interleaving exhibits a race.",
+      "formula": {
+        "all": [
+          "concurrency_correctness"
+        ]
+      }
+    },
+    {
+      "id": "requirements_based",
+      "origin": "user",
+      "formal": "requirements are traceable to executable checks and reference-data oracles",
+      "note": "DO-178C and ISO 26262 both punish untraceable testing. This concept is the evidence substance: specification fidelity, boundary/pre/post behavior, and falsifiability all carry runnable evidence.",
+      "formula": {
+        "all": [
+          "specification_fidelity",
+          "precondition_correctness",
+          "postcondition_correctness",
+          "boundary_completeness",
+          "testability_falsifiability"
+        ]
+      }
+    },
+    {
+      "id": "safety_critical_floor",
+      "origin": "user",
+      "formal": "strict life-impact floor: buildable, requirements-based, robust, observable, secure, and concurrency-safe",
+      "note": "For DAL A/B/C or ASIL C/D style internal assurance, use this as the enforced gate and assert assurance_claim=Excellent only when every atom has evidence. This concept does not certify; it refuses to accept code that lacks the core evidence shape expected of safety-critical CI.",
+      "formula": {
+        "all": [
+          "referential_truth",
+          "type_soundness",
+          "totality_or_controlled_partiality",
+          "specification_fidelity",
+          "precondition_correctness",
+          "postcondition_correctness",
+          "invariant_preservation",
+          "boundary_completeness",
+          "error_semantics",
+          "security_by_construction",
+          "concurrency_correctness",
+          "observability",
+          "testability_falsifiability"
+        ]
+      }
+    },
+    {
+      "id": "NotSlop",
+      "origin": "user",
+      "formal": "Braid floor: CoreGroundedCorrect + invariant_preservation + security_by_construction + testability_falsifiability + change_locality",
+      "note": "Braid's minimum gate — the Director's 'stop slop' as a formula. Stricter than CoreGroundedCorrect (adds invariant, security, falsifiability, locality) and weaker than Excellent (does not require all 20). A PR that fails NotSlop is REJECTED.",
+      "formula": {
+        "all": [
+          "referential_truth",
+          "type_soundness",
+          "totality_or_controlled_partiality",
+          "specification_fidelity",
+          "invariant_preservation",
+          "security_by_construction",
+          "testability_falsifiability",
+          "change_locality"
+        ]
+      }
+    }
+  ]
+}

--- a/keel/schema/profile.schema.json
+++ b/keel/schema/profile.schema.json
@@ -1,0 +1,483 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "keel.profile/v0",
+  "title": "Keel tailoring profile",
+  "description": "The per-codebase document an AI fills to point Keel at a target. RESTRICTIVE by design: a fill is mechanically validated before any verification runs. Atom IDENTITY is fixed by schema/atoms.json; a profile may only choose units, bind atoms to concrete tools for this toolchain, pick the gate concept, declare an envelope, and set thresholds. It may NOT redefine an atom or a framework concept.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["target", "units", "bindings", "gate_concept"],
+  "properties": {
+    "_comment": { "type": "string", "description": "Optional human/AI annotation — the ONLY free-text field a RESTRICTIVE profile may carry. Documentation only; never read by the engine." },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string" },
+        "root": { "type": "string", "description": "filesystem root of the target codebase" },
+        "ecosystem": { "type": "string", "enum": ["rust", "typescript", "python", "go", "shell", "mixed"] }
+      }
+    },
+    "units": {
+      "type": "array",
+      "description": "How to enumerate code units. Each rule yields units of one type.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["unit", "discover"],
+        "properties": {
+          "unit": { "type": "string", "enum": ["crate", "module", "package", "service"] },
+          "discover": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+              "type": { "type": "string", "enum": ["glob", "manifest", "literal"] },
+              "pattern": { "type": "string" },
+              "values": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        }
+      }
+    },
+    "bindings": {
+      "type": "array",
+      "description": "Bind an atom to the concrete Tier-1 tool that instantiates it for THIS toolchain. Atom id must exist in schema/atoms.json.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["atom", "evidence"],
+        "properties": {
+          "atom": { "type": "string" },
+          "unit": { "type": "string", "enum": ["crate", "module", "package", "service"] },
+          "evidence": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["tool", "argv", "ok_when"],
+            "properties": {
+              "tool": { "type": "string" },
+              "argv": { "type": "array", "items": { "type": "string" } },
+              "cwd": { "type": "string" },
+              "env": { "type": "object", "additionalProperties": { "type": "string" }, "description": "extra environment for the tool process (merged over the inherited env)" },
+              "needs": { "type": "array", "items": { "type": "string" }, "description": "binaries that must be present, else atom is 'unknown' (skip), never 'false'" },
+              "scope": { "type": "array", "items": { "type": "string" }, "description": "file globs (relative to the unit root) this evidence depends on (#647). The bound atom's staleness fingerprint covers ONLY these files, so an edit outside the scope does not recompute it (symbol-granular incremental seam, docs/01 §1.3). Verdict-invariant: scope changes what is watched, not how the tool runs. Absent => whole-unit (coarse)." },
+              "ok_when": { "type": "string", "enum": ["exit==0"] },
+              "score": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["from"],
+                "description": "GRADED atoms only (docs/02 §2.5): how to read a numeric score from the tool. The tool RUN produces the score (content-addressed/cached); the score crosses to boolean against profile.thresholds[atom] in the runner post-process — so changing the bar never re-runs the tool. exit!=0 / no number / timeout => no score => 'unknown' (never a silent pass).",
+                "properties": {
+                  "from": { "type": "string", "enum": ["stdout-last-number", "stdout-first-number"], "description": "extract the last/first number printed on stdout" },
+                  "max": { "type": "number", "minimum": 0, "description": "if set, normalise score := raw/max into [0,1] (e.g. a 0-100 coverage percent with max:100)" }
+                }
+              },
+              "timeout_ms": { "type": "number", "minimum": 0, "description": "per-point wall-clock bound; a tool that exceeds it is 'unknown' (timed out), never a pass (docs/07; H1)" },
+              "cross": {
+                "type": "array",
+                "description": "Finite-outcome crossing matrix (docs/07 §7.2): the SAME obligation held across N declared points (platform/config/edge). The atom is true only if EVERY point is true (Kleene AND). Absent => a single 'base' point.",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "One crossed point. Each field overrides the parent evidence for this point; argv/cwd/env/timeout_ms default to the evidence's.",
+                  "properties": {
+                    "label": { "type": "string" },
+                    "argv": { "type": "array", "items": { "type": "string" } },
+                    "cwd": { "type": "string" },
+                    "env": { "type": "object", "additionalProperties": { "type": "string" } },
+                    "timeout_ms": { "type": "number", "minimum": 0 }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gate_concept": {
+      "type": "string",
+      "description": "Concept id (from schema/concepts.json) the always-on gate enforces. Default 'sound'."
+    },
+    "assurance_claim": {
+      "type": "string",
+      "description": "Concept id this profile ASSERTS the codebase meets (docs/09). Its atoms are activated and evaluated alongside the gate; the CLAIM-COHERENCE gate BLOCKS if any claimed atom lacks evidence (unrun/unbound) — you may claim only what you demonstrate. Fires only when set; an honest unknown you never claimed does not block."
+    },
+    "trust_anchor": {
+      "type": "string",
+      "description": "A6 authenticity: path (relative to target.root) to an ed25519 PUBLIC KEY (PEM/SPKI). Reference files that ship a signature_file are verified against this key — a valid signature means the reference was attested by a holder of the private key OUTSIDE the AI authorship loop (the external trust root). Without it, signed references cannot be authenticated and unsigned references are recorded as self_asserted."
+    },
+    "envelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Declared operating target for quantitative atoms / soak tier (docs/04).",
+      "properties": {
+        "target": { "type": "object", "additionalProperties": { "type": "number" } },
+        "slo": { "type": "object", "additionalProperties": { "type": "number" } },
+        "margin": { "type": "number", "minimum": 1.0 }
+      }
+    },
+    "thresholds": {
+      "type": "object",
+      "description": "Where graded atoms cross to boolean. atom id -> minimum score [0,1].",
+      "additionalProperties": { "type": "number", "minimum": 0, "maximum": 1 }
+    },
+    "execution_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Confinement for profile-provided evidence commands (Open Risk #3). `allow` is the allowlist of tool binaries Keel may spawn — a binding/harness/tool-qualification tool NOT in the list is refused at load (no run). `env_passthrough` is the ONLY ambient environment variables an evidence run inherits (plus a minimal PATH/LANG base); everything else (host secrets, tokens) is scrubbed.",
+      "properties": {
+        "allow": { "type": "array", "items": { "type": "string" }, "description": "Permitted evidence tool binaries (e.g. cargo, bash, python3). Empty/absent => no allowlist enforced." },
+        "env_passthrough": { "type": "array", "items": { "type": "string" }, "description": "Ambient env var names an evidence run may inherit; all others are absent inside the harness." }
+      }
+    },
+    "safety_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Safety-critical CI assurance metadata. This is not a certification claim; it is a restrictive checklist that prevents an AI from asserting DO-178B/C, DO-331, or ISO 26262 style rigor without traceable process evidence.",
+      "required": ["standards", "certification_intent"],
+      "properties": {
+        "standards": {
+          "type": "array",
+	          "items": { "type": "string", "enum": ["DO-178B", "DO-178C", "DO-331", "ISO-26262", "IEC-61508", "ISO-21448"] },
+          "description": "Standards or supplements whose discipline this profile is intentionally mapping to. DO-331 is a supplement and requires DO-178C in this schema."
+        },
+        "certification_intent": {
+          "type": "string",
+          "enum": ["none", "inspired", "internal-assurance", "certification-support"],
+          "description": "The claim level. 'certification-support' means the profile is collecting evidence that could support a formal program, not that Keel certifies anything."
+        },
+	        "aviation_level": { "type": "string", "enum": ["A", "B", "C", "D", "E"], "description": "DO-178 software level/DAL when an aviation standard is selected." },
+	        "automotive_asil": { "type": "string", "enum": ["QM", "A", "B", "C", "D"], "description": "ISO 26262 ASIL when ISO-26262 is selected." },
+	        "iec_sil": { "type": "string", "enum": ["SIL1", "SIL2", "SIL3", "SIL4"], "description": "IEC 61508 safety integrity level when IEC-61508 is selected." },
+        "safety_plan_ref": { "type": "string", "description": "Plan for safety/software aspects: PSAC/SVP/SQA/SCM equivalent or ISO 26262 safety plan." },
+        "hazard_analysis_ref": { "type": "string", "description": "System hazard analysis / FHA / HARA source that assigns DAL or ASIL." },
+        "requirements_traceability_ref": { "type": "string", "description": "Bidirectional requirements-to-code-to-test/proof trace data source." },
+        "verification_plan_ref": { "type": "string", "description": "Verification plan defining reviews, analyses, tests, coverage, independence, and pass/fail criteria." },
+        "configuration_index_ref": { "type": "string", "description": "Configuration index or baselined artifact list that pins sources, tools, generated code, models, tests, and reference data." },
+        "independence": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Independence evidence for verification, review, quality assurance, and approval. For AI work, this must identify the non-author authority or external oracle, not another untrusted authoring prompt.",
+          "properties": {
+            "verifier": { "type": "string" },
+            "reviewer": { "type": "string" },
+            "evidence_ref": { "type": "string" }
+          }
+        },
+        "structural_coverage": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Declared structural coverage achieved by requirements-based tests. Keel's validator applies a strict DAL/ASIL floor over this declaration.",
+	          "properties": {
+	            "statement": { "type": "boolean" },
+	            "decision": { "type": "boolean" },
+	            "mcdc": { "type": "boolean" },
+	            "scope": {
+	              "type": "array",
+	              "items": { "type": "string", "enum": ["source_code", "generated_code", "model_training_code", "learned_model"] },
+	              "description": "What the structural coverage report covers. Learned models are not source control-flow; neural coverage cannot be counted as statement/decision/MC/DC coverage."
+	            },
+	            "source_ref": { "type": "string" }
+	          }
+	        },
+        "trust_anchor": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "External trust root for reference signatures (Open Risk #1): a PEM ed25519 public key file, held OUTSIDE the AI authoring loop, that signed safety-case references verify against. This is the externality that supplies the independence the verdict otherwise lacks.",
+          "properties": {
+            "public_key_file": { "type": "string" }
+          }
+        },
+        "reference_integrity": {
+          "type": "object",
+          "description": "Per-reference integrity (Open Risk #1): bind a safety-case reference to a content hash and/or detached signature, so a string ref cannot silently point at nothing or at altered content. Keys are reference field names: safety_plan_ref, hazard_analysis_ref, requirements_traceability_ref, verification_plan_ref, configuration_index_ref, independence_evidence_ref, structural_coverage_source_ref.",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "hash": { "type": "string", "description": "Expected sha256 (hex) of the referenced file." },
+              "signature_file": { "type": "string", "description": "Detached ed25519 signature over the referenced file, verified against trust_anchor.public_key_file." }
+            }
+          }
+        },
+        "tool_qualification": {
+          "type": "array",
+          "description": "Every CI evidence-producing tool used under a safety_case must be listed. This includes shells, compilers, test runners, coverage tools, model/code generators, Keel runners, and validators.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["tool", "standard", "role", "qualification_ref"],
+            "properties": {
+              "tool": { "type": "string" },
+              "role": { "type": "string", "enum": ["compiler", "test-runner", "coverage", "static-analysis", "model-tool", "code-generator", "ci-runner", "verification", "shell", "other"] },
+              "standard": { "type": "string", "enum": ["DO-330", "ISO-26262-8", "self-qualified", "unqualified"] },
+              "tql": { "type": "string", "enum": ["TQL-1", "TQL-2", "TQL-3", "TQL-4", "TQL-5"] },
+              "tcl": { "type": "string", "enum": ["TCL1", "TCL2", "TCL3"] },
+              "qualification_ref": { "type": "string" },
+              "fixture": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Executable qualification (Open Risk #2): Keel RUNS the named tool against a planted-defective input it MUST flag (detects, exit!=0) and a clean input it MUST pass (accepts, exit==0). A self-qualified tool that cannot pass its own fixture is not qualified — qualification is demonstrated, not declared.",
+                "required": ["detects", "accepts"],
+                "properties": {
+                  "detects": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["argv"],
+                    "properties": {
+                      "argv": { "type": "array", "items": { "type": "string" } },
+                      "needs": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "accepts": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["argv"],
+                    "properties": {
+                      "argv": { "type": "array", "items": { "type": "string" } },
+                      "needs": { "type": "array", "items": { "type": "string" } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+	        "model_based": {
+	          "type": "object",
+	          "additionalProperties": false,
+	          "description": "Required when DO-331 is selected. Models are requirements/design artifacts and must be verified, traced, baselined, and correlated to generated or hand-written code.",
+          "properties": {
+            "model_ref": { "type": "string" },
+            "model_verification_ref": { "type": "string" },
+            "model_code_trace_ref": { "type": "string" },
+            "simulation_correlation_ref": { "type": "string" },
+	            "generated_code_ref": { "type": "string" }
+	          }
+	        },
+	        "learning_enabled": {
+	          "type": "object",
+	          "additionalProperties": false,
+	          "description": "Learning-enabled / ML assurance data. Traditional DO-178C, ISO 26262, and IEC 61508 structural coverage evidence does not automatically apply to learned model behavior; this block makes the gap explicit and blocks certification overclaim.",
+	          "properties": {
+	            "present": { "type": "boolean", "description": "True when any safety-relevant component contains learned logic, trained weights, data-driven classifiers, neural nets, reinforcement learning policies, or statistical models." },
+	            "certification_position": {
+	              "type": "string",
+	              "enum": ["not-in-scope", "research-only", "dal-d-ceiling", "safety-case-with-assumptions", "accepted-means-of-compliance"],
+	              "description": "The project's explicit position on ML certification. DAL C+ or equivalent claims require accepted-means-of-compliance plus cited authority evidence."
+	            },
+	            "accepted_means_of_compliance_ref": { "type": "string", "description": "Authority-accepted means of compliance, issue paper, certification basis, or equivalent formal approval for using learned logic in the declared safety role." },
+	            "components": {
+	              "type": "array",
+	              "items": {
+	                "type": "object",
+	                "additionalProperties": false,
+	                "required": ["id", "model_type", "safety_role"],
+	                "properties": {
+	                  "id": { "type": "string" },
+	                  "model_type": { "type": "string", "enum": ["neural-network", "tree-ensemble", "linear-model", "bayesian-model", "reinforcement-learning", "classifier", "regressor", "other"] },
+	                  "safety_role": { "type": "string", "enum": ["none", "training-only", "advisory", "guarded", "direct-control"] },
+	                  "requirements_ref": { "type": "string" },
+	                  "model_ref": { "type": "string" },
+	                  "weights_ref": { "type": "string" }
+	                }
+	              }
+	            },
+	            "ml_lifecycle_ref": { "type": "string", "description": "ML lifecycle plan covering data, training, validation, configuration, deployment, and monitoring." },
+	            "data_requirements_ref": { "type": "string" },
+	            "data_collection_ref": { "type": "string" },
+	            "data_preprocessing_ref": { "type": "string" },
+	            "training_process_ref": { "type": "string" },
+	            "validation_dataset_ref": { "type": "string" },
+	            "test_oracle_ref": { "type": "string", "description": "Oracle strategy for deciding correctness. Pseudo-oracles, consensus labels, or learned oracles must be explicitly justified." },
+	            "operational_design_domain_ref": { "type": "string", "description": "Declared operating domain/envelope for the ML component." },
+	            "ood_detection_ref": { "type": "string", "description": "Out-of-distribution detection or rejection evidence and limits." },
+	            "uncertainty_calibration_ref": { "type": "string" },
+	            "robustness_ref": { "type": "string", "description": "Adversarial, perturbation, environmental, and distribution-shift robustness evidence." },
+	            "runtime_monitor_ref": { "type": "string", "description": "Runtime monitor, guard, checker, or safety cage evidence." },
+	            "fallback_safe_state_ref": { "type": "string", "description": "Safe fallback/degradation behavior when the ML component is uncertain, OOD, unavailable, or contradicted." },
+	            "post_deployment_monitoring_ref": { "type": "string" },
+	            "formal_analysis_ref": { "type": "string", "description": "Formal analysis of bounded properties, including scope limits. Not a blanket proof of model correctness." },
+	            "neural_coverage_ref": { "type": "string", "description": "Neural coverage or DNN structural metric evidence. This is not MC/DC and cannot satisfy source structural coverage by itself." },
+	            "assumptions_ref": { "type": "string", "description": "Explicit assumptions used to bridge ML evidence into the safety argument." }
+	          }
+	        }
+	      }
+	    },
+    "soak": {
+      "type": "array",
+      "description": "Soak-tier bindings (docs/04 §4.3, issue #643): one per load dimension. Each binds a NATIVE harness that runs the escalate→bracket→revert→soak loop and emits a capacity-profile/v0 artifact on stdout. The dimension name must match an envelope.target key. Run by src/run-soak.mjs, never the commit gate (soak is its own tier).",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["dimension", "evidence"],
+        "properties": {
+          "dimension": { "type": "string", "description": "load dimension (must match an envelope.target key)" },
+          "evidence": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["tool", "argv"],
+            "properties": {
+              "tool": { "type": "string" },
+              "argv": { "type": "array", "items": { "type": "string" } },
+              "cwd": { "type": "string" },
+              "env": { "type": "object", "additionalProperties": { "type": "string" } },
+              "needs": { "type": "array", "items": { "type": "string" }, "description": "binaries that must be present, else the dimension is 'unknown' (BLOCKS), never a pass" },
+              "ok_when": { "type": "string", "enum": ["exit==0"] },
+              "timeout_ms": { "type": "number", "minimum": 0 }
+            }
+          }
+        }
+      }
+    },
+    "simulate": {
+      "type": "array",
+      "description": "Input-envelope simulation scenarios (docs/09, docs/04 §4.1 'envelope faults'): drive the system-under-test's SENSOR surface through its envelope (nominal→boundary→off-nominal) against an oracle. Keel enumerates the finite input crossing and crosses the oracle (∧) over every vector, reporting the breaking vector. Run by src/run-simulate.mjs.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "atom", "sensors", "harness"],
+        "properties": {
+          "name": { "type": "string" },
+          "atom": { "type": "string", "description": "the atom this scenario instantiates (e.g. specification_fidelity, boundary_completeness, precondition_correctness, security_by_construction). Must exist in schema/atoms.json." },
+          "max_vectors": { "type": "number", "minimum": 1, "description": "cap on the enumerated input crossing; exceeding it BLOCKS (no silent sampling)." },
+          "reference": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "A6 (validated_aircraft_correlation): the REFERENCE-DATA oracle. When present, the harness EMITS the system's output on stdout and Keel compares it to the matching reference datum within tolerance — the verdict's truth traces to reference data, NOT the harness author's intuition. This is what binds specification_fidelity (⟦P⟧(x)=S(x)) honestly. A vector with no reference datum is 'unknown' (un-validatable, blocks). PROVENANCE (A6): supply `from` (a content-hashed reference FILE, the trusted golden artifact) OR inline `data` WITH a `source_ref` — an untraceable inline table is refused by validation.",
+            "properties": {
+              "tolerance": { "type": "number", "minimum": 0, "description": "numeric |output-expect| ≤ tolerance; non-numeric outputs compare by strict equality" },
+              "source_ref": { "type": "string", "description": "provenance of the reference data (golden trace, real-system capture, approved spec) — A6: model truth is data, not intuition. REQUIRED for inline data." },
+              "from": { "type": "string", "description": "path (relative to target.root) to a reference-data file ([{when,expect}] or {tolerance,source_ref,data}); content-hashed into the verdict node id so an edited reference requalifies (A8)" },
+              "signature_file": { "type": "string", "description": "A6 authenticity: path to a base64 ed25519 detached signature over the reference file's bytes; verified against profile.trust_anchor. A valid signature => the reference is authenticated by an external key-holder (independence from the author). Requires trust_anchor; an invalid/unverifiable signature BLOCKS." },
+              "data": {
+                "type": "array",
+                "description": "the reference table: each row maps an input vector to its expected output",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["when", "expect"],
+                  "properties": {
+                    "when": { "type": "object", "description": "the sensor vector this datum applies to ({sensor: value, …})" },
+                    "expect": { "description": "the reference output for that vector" }
+                  }
+                }
+              }
+            }
+          },
+          "sensors": {
+            "type": "array",
+            "description": "the input surface to drive. Each sensor contributes a set of points; the scenario crosses their Cartesian product.",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["name"],
+              "properties": {
+                "name": { "type": "string" },
+                "values": { "type": "array", "description": "explicit equivalence-class / boundary representatives" },
+                "range": { "type": "array", "items": { "type": "number" }, "description": "[lo, hi]: Keel adds lo, hi, and (unless probe_outside:false) lo-step / hi+step as off-nominal — boundary-value analysis" },
+                "step": { "type": "number", "description": "off-nominal probe distance outside a numeric range (default 1)" },
+                "probe_outside": { "type": "boolean", "description": "default true: include just-outside-range points as off-nominal inputs the system must handle" },
+                "offNominal": { "type": "array", "description": "explicit invalid/off-nominal inputs the system must reject or handle (not crash)" }
+              }
+            }
+          },
+          "harness": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["tool", "argv"],
+            "description": "the system-under-test driver. Invoked once per input vector; Keel injects each sensor as env KEEL_SENSOR_<NAME> and the whole vector as KEEL_VECTOR (JSON). Oracle: exit 0 = invariant held · nonzero = violated · 77 = could not evaluate (unknown).",
+            "properties": {
+              "tool": { "type": "string" },
+              "argv": { "type": "array", "items": { "type": "string" } },
+              "cwd": { "type": "string" },
+              "env": { "type": "object", "additionalProperties": { "type": "string" } },
+              "needs": { "type": "array", "items": { "type": "string" } },
+              "timeout_ms": { "type": "number", "minimum": 0 }
+            }
+          }
+        }
+      }
+    },
+    "latency": {
+      "type": "array",
+      "description": "Latency/jitter scenarios (aircraft axiom A5: latency and jitter are first-order verdict variables). The harness runs the operation under test `samples` times and emits its measured latency (ms) on stdout each time; Keel aggregates (max/p99/jitter) and crosses against the declared budget. The measurement is an empirical sensor; the budget decision is deterministic. Run by src/run-latency.mjs. No budget ⇒ unknown (cannot gate).",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "atom", "harness", "budget"],
+        "properties": {
+          "name": { "type": "string" },
+          "atom": { "type": "string", "description": "the atom this binds (e.g. algorithmic_efficiency). Must exist in schema/atoms.json." },
+          "samples": { "type": "number", "minimum": 1, "description": "repeat count for jitter measurement (default 5)" },
+          "budget": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "the auditor's CITED latency budget — at least one bound. An uncited threshold is not law (docs/10 §10.3).",
+            "properties": {
+              "max_ms": { "type": "number", "minimum": 0 },
+              "p99_ms": { "type": "number", "minimum": 0 },
+              "jitter_ms": { "type": "number", "minimum": 0 },
+              "source_ref": { "type": "string", "description": "provenance of the budget (SLO doc, contract, capacity plan)" }
+            }
+          },
+          "harness": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["tool", "argv"],
+            "description": "emits the operation's measured latency (ms) on stdout per invocation",
+            "properties": {
+              "tool": { "type": "string" },
+              "argv": { "type": "array", "items": { "type": "string" } },
+              "cwd": { "type": "string" },
+              "env": { "type": "object", "additionalProperties": { "type": "string" } },
+              "needs": { "type": "array", "items": { "type": "string" } },
+              "timeout_ms": { "type": "number", "minimum": 0 }
+            }
+          }
+        }
+      }
+    },
+    "sim": {
+      "type": "array",
+      "description": "Multi-actor simulation scenarios (docs/04 §4.5; axioms A1/A7; issue #644): concurrent actors with step sequences. Keel enumerates the order-preserving interleavings (the finite schedule space) and crosses the consistency oracle over every one, reporting the breaking interleaving (the race). Run by src/run-sim.mjs. The interaction surface where concurrency_correctness / idempotence live.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "atom", "actors", "harness"],
+        "properties": {
+          "name": { "type": "string" },
+          "atom": { "type": "string", "description": "the atom this binds (e.g. concurrency_correctness, idempotence). Must exist in schema/atoms.json." },
+          "max_interleavings": { "type": "number", "minimum": 1, "description": "cap on the enumerated schedule space; exceeding it BLOCKS (no silent sampling)." },
+          "actors": {
+            "type": "array",
+            "description": "the concurrent actors; each issues an ordered list of operations against the system",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["id", "steps"],
+              "properties": {
+                "id": { "type": "string" },
+                "steps": { "type": "array", "items": { "type": "string" }, "description": "this actor's operation sequence (internal order preserved across all interleavings)" }
+              }
+            }
+          },
+          "harness": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["tool", "argv"],
+            "description": "applies one interleaving to the system and exits 0 if the resulting history is consistent, nonzero if a race/inconsistency is observed, 77 if it cannot evaluate. Keel injects the schedule as env KEEL_SCHEDULE (JSON [{actor,op},…]).",
+            "properties": {
+              "tool": { "type": "string" },
+              "argv": { "type": "array", "items": { "type": "string" } },
+              "cwd": { "type": "string" },
+              "env": { "type": "object", "additionalProperties": { "type": "string" } },
+              "needs": { "type": "array", "items": { "type": "string" } },
+              "timeout_ms": { "type": "number", "minimum": 0 }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/keel/src/adapters/lean.mjs
+++ b/keel/src/adapters/lean.mjs
@@ -1,0 +1,95 @@
+// adapters/lean.mjs — the `tool: lean` seam: machine-check a Lean proof and graft it onto the
+// anchor DAG as a content-addressed proof-term node (issue ledger item 6 / #646; docs/05 §5.2).
+//
+// Lean is REFERENCE, NEVER FORKED (Braid covenant). Keel runs `lake build` on the pinned
+// package and reads ONE three-valued result (docs/02 §2.6) — it does not parse, embed, or
+// reimplement Lean's kernel:
+//   true    — `lake build` exited 0: the Lean kernel certified every proof term in the package.
+//   false   — `lake build` exited nonzero: a proof failed to typecheck (drift / regression).
+//   unknown — the toolchain is absent (no `lake` on PATH): we did not learn the answer. NEVER a
+//             pass (the no-silent-under-check discipline, docs/02 §2.6).
+//
+// PURCHASABLE / DEFERRED (docs/05 §5.2 sequencing principle): a missing toolchain degrades to
+// `unknown` and NEVER blocks the content-addressed floor. Lean depth is grafted ONTO the floor,
+// not a prerequisite for it. The structural concept↔Lean conformance check (src/conformance.mjs)
+// runs with zero dependencies and continues to gate even when this machine-check is skipped.
+//
+// The proof-term node's id folds in the CONTENT of the .lean sources + the toolchain pin + the
+// grafted theorem names, so the proof TERM itself addresses the node: change the proof, change
+// the id (the staleness spine, docs/01 §1.3). This is materially stronger than binding a generic
+// atom node (atoms.mjs) to the lean directory as a `unit`, whose fingerprint would hash only the
+// dir's path/size — not the proof text. That is why a Lean proof gets a dedicated node kind.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { H } from '../anchor.mjs';
+
+export const LEAN_TOOL = 'lake';
+const MAXBUF = 64 * 1024 * 1024;
+const DEFAULT_TIMEOUT_MS = 600_000;
+
+/** Is the Lean build tool (`lake`) on PATH? Absence ⇒ the proof check is `unknown`, never pass. */
+export function leanToolPresent(env = process.env) {
+  return spawnSync('bash', ['-c', `command -v ${LEAN_TOOL}`], { env }).status === 0;
+}
+
+/**
+ * Content fingerprint of the proof inputs: each module's source bytes + the toolchain pin.
+ * A missing source hashes to '∅' (referential-truth-friendly; a vanished proof is never a
+ * silent skip). Returned alongside the verdict so a reader can trace WHAT was checked.
+ */
+export function proofFingerprint(packageDir, modules) {
+  const sources = modules.map((rel) => {
+    try { return { module: rel, hash: H(readFileSync(join(packageDir, rel))) }; }
+    catch { return { module: rel, hash: '∅' }; }
+  });
+  let toolchain = '';
+  try { toolchain = readFileSync(join(packageDir, 'lean-toolchain'), 'utf8').trim(); } catch { /* unpinned */ }
+  return { sources, toolchain };
+}
+
+/**
+ * Run `lake build` on a Lean package; return a three-valued result.
+ * { value:'true'|'false'|'unknown', present, exit?, reason?, log? }.
+ * present=false ⇒ toolchain absent ⇒ value 'unknown' (purchasable; never blocks the floor).
+ */
+export function leanBuild(packageDir, { env = process.env, timeout = DEFAULT_TIMEOUT_MS } = {}) {
+  if (!leanToolPresent(env))
+    return { value: 'unknown', present: false, reason: `toolchain absent: ${LEAN_TOOL} (Lean depth is purchasable, docs/05 §5.2; the structural conformance check still gates)` };
+  const r = spawnSync(LEAN_TOOL, ['build'], { cwd: packageDir, env, encoding: 'utf8', timeout, maxBuffer: MAXBUF });
+  if (r.error) return { value: 'unknown', present: true, reason: `${LEAN_TOOL} failed to launch: ${r.error.message}` };
+  const ok = r.status === 0;
+  return {
+    value: ok ? 'true' : 'false', present: true, exit: r.status,
+    reason: ok ? undefined : `${LEAN_TOOL} build exited ${r.status} — a proof term failed to typecheck`,
+    log: ok ? undefined : (r.stderr || r.stdout || '').slice(-2000),
+  };
+}
+
+/**
+ * The proof-term node: a content-addressed anchor node grafting a Lean proof onto the verdict
+ * DAG (docs/05 §5.2). Pass it to `anchor.evaluate(node)` like any other node — its verdict is
+ * cached keyed by the proof-source content, so an unchanged proof is never re-built.
+ *
+ * opts: { packageDir, modules:[relPath...], theorems?:[name...], env? }
+ *   - modules  : the .lean files whose content addresses the node (the proof sources).
+ *   - theorems : the grafted theorem names (provenance; e.g. ['excellent_not_hallucinated']).
+ *                Part of the id so re-pointing the same sources at a different claim is a new node.
+ */
+export function leanProofNode({ packageDir, modules, theorems = [], env = process.env }) {
+  const fp = proofFingerprint(packageDir, modules);
+  const thms = [...theorems].sort();
+  // IDENTITY = proof content, never location. params + inputs both feed anchor.nodeId, so the
+  // volatile packageDir path MUST NOT appear here — only the module relpaths (folded into the
+  // source fingerprint) and the grafted theorems. Same proof bytes anywhere ⇒ same node id.
+  return {
+    kind: 'lean:proof',
+    params: { theorems: thms, modules: [...modules].sort() },
+    inputs: [H('lean/proof/v1', { sources: fp.sources, toolchain: fp.toolchain, theorems: thms })],
+    compute() {
+      const r = leanBuild(packageDir, { env });
+      return { value: r.value, present: r.present, reason: r.reason, theorems: thms, proof: fp };
+    },
+  };
+}

--- a/keel/src/adapters/registry.mjs
+++ b/keel/src/adapters/registry.mjs
@@ -1,0 +1,83 @@
+// adapters/registry.mjs — ingest a host CI registry as a Keel tailoring profile.
+//
+// Keel is the generic authority; a deployment tailors it by FILLING SCHEMA (docs/03).
+// logic-os-kernel already ships an ontology of verifiers — `lwks.verify.registry/v0`
+// (scripts/ci/registry.json): each verifier runs a real Tier-1 tool and cites a DO-178C
+// clause. That registry IS a profile dialect. Rather than generate a second artifact that
+// can drift (the staleness Keel exists to kill), this adapter consumes the registry LIVE
+// and maps it onto Keel's atom/concept algebra:
+//
+//   verifier            → an evidence BINDING that instantiates an atom (never asserts it)
+//   verifier.atom       → which of the 20 Excellent-Code atoms this evidence speaks to
+//   verifier.run        → the tool the atom is instantiated by (exit==0 ⇒ true, else false)
+//   absent tool / no atom → 'unknown' (skip, NEVER pass — the honesty upgrade over H0)
+//
+// The registry stays the host's single source of truth; Keel is the engine that composes
+// its verdict. No network. The adapter is PURE (no fs/process): the front-end supplies the
+// pre-fingerprinted unit and docker presence.
+
+/**
+ * Translate one registry verifier's `run` (or docker-gated `run_no_docker`) spec into a
+ * Keel evidence descriptor consumable by atoms.mjs (tool + argv + needs + cwd).
+ */
+export function verifierEvidence(v, dockerPresent) {
+  let spec = v.run, dockerGated = false;
+  if (v.run_no_docker && !dockerPresent) { spec = v.run_no_docker; dockerGated = true; }
+  // A verifier may declare a crossing matrix (docs/07 §7.2): the same obligation held across
+  // N declared points (configs/feature-flags/platforms). Carried straight to atoms.mjs, which
+  // crosses every point and holds the atom true only if all hold (Kleene ∧). Absent → 1 point.
+  const cross = Array.isArray(v.cross) && v.cross.length ? v.cross : undefined;
+  // scope (#647): the file globs this verifier's evidence depends on — narrows the bound atom's
+  // staleness fingerprint to those files (atoms.unitFingerprint). Absent ⇒ whole-unit (coarse).
+  const scope = Array.isArray(v.scope) && v.scope.length ? v.scope : undefined;
+  const base = { needs: v.needs || [], cwd: v.cwd, dockerGated: dockerGated || undefined, cross, scope };
+  return spec.type === 'shell'
+    ? { tool: 'bash', argv: ['-c', spec.cmd], ...base }
+    : { tool: spec.cmd[0], argv: spec.cmd.slice(1), ...base };
+}
+
+/**
+ * Build Keel activations from a registry document against a single pre-fingerprinted unit
+ * (the workspace). Each verifier becomes one (atom, unit, binding) activation; distinct
+ * verifiers mapping to the same atom remain distinct nodes (their command differs, so the
+ * anchor's bind-version differs) and aggregate via three-valued ∧ in the engine.
+ *
+ * Returns:
+ *   activations — for engine.composeReport
+ *   unmapped    — verifier ids carrying no (valid) `atom` annotation: the mapping DEBT. These
+ *                 contribute no evidence; reported so coverage is never silently overstated.
+ *
+ * opts: { atomsDoc, unit, dockerPresent }
+ */
+export function registryActivations(reg, { atomsDoc, unit, dockerPresent = true }) {
+  const atomDef = (id) => atomsDoc.atoms.find(a => a.id === id);
+  const activations = [];
+  const unmapped = [];
+  for (const v of reg.verifiers || []) {
+    const advisory = (v.severity || 'block') === 'advisory';
+    // ADVISORY verifiers (the propose→dispose dup ladder rungs 2–4, the embedding proposer)
+    // carry no atom BY DESIGN — they must not inflate hard coverage (docs/05 §5.5). They are
+    // still RUN and SURFACED, but excluded from the gate. So an advisory verifier with no atom
+    // is NOT mapping debt; it is a proposer signal bound to a synthetic, non-gating def.
+    if (advisory) {
+      const def = (v.atom && atomDef(v.atom)) || { id: v.id, name: v.id, evidence: 'advisory signal' };
+      activations.push({
+        atomId: def.id, atomDef: def, advisory: true, role: v.role,
+        binding: { atom: def.id, evidence: verifierEvidence(v, dockerPresent) },
+        unit, source: v.id,
+      });
+      continue;
+    }
+    if (!v.atom) { unmapped.push({ id: v.id, why: 'no atom annotation (CM/standards-axis or mapping debt)' }); continue; }
+    const def = atomDef(v.atom);
+    if (!def) { unmapped.push({ id: v.id, why: `atom '${v.atom}' absent from ontology` }); continue; }
+    activations.push({
+      atomId: v.atom,
+      atomDef: def,
+      binding: { atom: v.atom, evidence: verifierEvidence(v, dockerPresent) },
+      unit,
+      source: v.id,
+    });
+  }
+  return { activations, unmapped };
+}

--- a/keel/src/anchor.mjs
+++ b/keel/src/anchor.mjs
@@ -1,0 +1,193 @@
+// anchor.mjs — the content-addressed verdict graph (the ANCHOR).
+//
+// One source of truth: a Merkle DAG of verification nodes. A node's id is the hash
+// of its kind, params, and its inputs' hashes; its verdict is a pure function of
+// those inputs. This file implements (docs/01-architecture.md):
+//   - content hashing (H)                                                 §1.1
+//   - the stale-proof cache: a cached verdict is valid iff its node id     §1.3
+//     still matches the recomputed id (changed input => new id => miss)
+//   - the append-only run manifest (the verification tape)                 §1.5
+//
+// Determinism: no wall-clock, no randomness. Identity is content. Standalone:
+// only Node builtins. The principle is borrowed from content-addressed fact
+// stores; the runtime is NOT imported (docs/01 §1.8).
+
+import { createHash } from 'node:crypto';
+import { readFileSync, mkdirSync, writeFileSync, existsSync, statSync, appendFileSync, globSync } from 'node:fs';
+import { join } from 'node:path';
+import { singleFlight } from './concurrency.mjs';
+import { signSeal, releaseSigningKey } from './sign.mjs';
+
+// Staleness-fingerprint policy (the file set a content fingerprint covers). Lives here, the lowest
+// layer, because BOTH whole-unit fingerprinting (engine.contentFingerprint) and binding-scope
+// fingerprinting (atoms.unitFingerprint with a declared `scope`) must hash file sets the SAME way —
+// derive-or-define-once, never a slight-difference copy (docs/01 §1.3 design rule).
+export const SRC_GLOBS = ['**/*.mjs', '**/*.js', '**/*.ts', '**/*.rs', '**/*.py', '**/*.toml'];
+export const EXCLUDE = ['/.git/', '/.keel/', '/node_modules/', '/target/', '/.worktrees/'];
+
+/** H — the hash primitive. Stable JSON (sorted keys) so equal content => equal id. */
+export function H(...parts) {
+  const h = createHash('sha256');
+  for (const p of parts) h.update(typeof p === 'string' ? p : stableStringify(p));
+  return h.digest('hex').slice(0, 40);
+}
+
+/** Deterministic JSON matching JSON.stringify semantics: sorted keys, undefined
+ *  object-keys omitted, undefined/array-holes => null. Round-trips through JSON.parse. */
+export function stableStringify(v) {
+  if (v === null) return 'null';
+  if (typeof v !== 'object') { const s = JSON.stringify(v); return s === undefined ? 'null' : s; }
+  if (Array.isArray(v)) return '[' + v.map(stableStringify).join(',') + ']';
+  const keys = Object.keys(v).filter(k => v[k] !== undefined).sort();
+  return '{' + keys.map(k => JSON.stringify(k) + ':' + stableStringify(v[k])).join(',') + '}';
+}
+
+/** Content hash of a file on disk; '∅' if absent (referential-truth-friendly). */
+export function hashFile(path) {
+  try { return H(readFileSync(path)); } catch { return '∅'; }
+}
+
+/** Content hash of a directory's tracked shape — cheap structural fingerprint. */
+export function hashPathMeta(path) {
+  try { const s = statSync(path); return H(path, String(s.size), s.isDirectory() ? 'd' : 'f'); }
+  catch { return '∅'; }
+}
+
+/**
+ * Content fingerprint of a FILE SET under `dir`: the hash of sorted [relpath, contentHash] over
+ * every file matching `globs` (minus `exclude`). The single source for staleness granularity —
+ * the wider the glob set, the coarser the recompute. A whole-unit fingerprint passes SRC_GLOBS;
+ * a binding `scope` passes only the globs that binding's evidence actually depends on, so an edit
+ * outside the scope does NOT change the fingerprint and the bound atom node is NOT recomputed
+ * (symbol-granular staleness grows from here toward .braid — issue ledger item 2 / #647).
+ */
+export function globFingerprint(dir, globs, exclude = EXCLUDE) {
+  const files = [];
+  for (const pat of globs) {
+    for (const f of globSync(pat, { cwd: dir })) {
+      if (exclude.some(x => ('/' + f + '/').includes(x))) continue;
+      files.push([f, hashFile(join(dir, f))]);
+    }
+  }
+  files.sort((a, b) => (a[0] < b[0] ? -1 : 1));
+  return H(files);
+}
+
+/**
+ * The Anchor: a content-addressed store of node verdicts under <dir>.
+ * - nodeId(kind, params, inputHashes) computes the deterministic id.
+ * - evaluate(node) returns the cached verdict if the id matches (stale-proof),
+ *   else computes via node.compute(), stores, and returns it.
+ */
+export class Anchor {
+  constructor(dir, { signingKeyPem = releaseSigningKey() } = {}) {
+    this.dir = dir;
+    this.store = join(dir, 'nodes');
+    mkdirSync(this.store, { recursive: true });
+    this.touched = [];        // node ids visited this run (for the manifest)
+    this.recomputed = 0;
+    this.reused = 0;
+    this._flight = singleFlight();  // collapse identical nodes computed concurrently
+    // R#5: an optional release private key (PEM). When present, each seal carries a detached
+    // ed25519 signature over its manifest hash — authenticity + transparency, not just integrity.
+    this._signingKeyPem = signingKeyPem;
+  }
+
+  nodeId(kind, params, inputHashes) {
+    return H(kind, params || {}, [...inputHashes].sort().join('|'));
+  }
+
+  /**
+   * node = { kind, params, inputs:[hash...], compute: () => verdict }
+   * verdict is any JSON-serializable value; it is stored keyed by the node id.
+   * A changed input changes the id => the old verdict is a different file =>
+   * structural staleness: we never read a verdict that does not belong to the
+   * current inputs.
+   */
+  evaluate(node) {
+    const id = this.nodeId(node.kind, node.params, node.inputs);
+    const path = join(this.store, id + '.json');
+    if (existsSync(path)) {
+      this.reused++;
+      this.touched.push(id);
+      return { id, ...JSON.parse(readFileSync(path, 'utf8')), cached: true };
+    }
+    const verdict = node.compute();
+    const record = { kind: node.kind, params: node.params, inputs: node.inputs, verdict };
+    writeFileSync(path, stableStringify(record) + '\n');
+    this.recomputed++;
+    this.touched.push(id);
+    return { id, ...record, cached: false };
+  }
+
+  /**
+   * Async sibling of evaluate(): identical content-addressed semantics, but awaits a
+   * node whose compute() returns a Promise (the spawn-based evaluator, atoms.mjs). Wrapped
+   * in single-flight on the node id so two crossings that resolve to the SAME node compute
+   * once — the second awaits the first rather than racing a duplicate subprocess + write.
+   * Determinism is unchanged: identity is content, and side-effects run exactly once per id.
+   */
+  async evaluateAsync(node) {
+    const id = this.nodeId(node.kind, node.params, node.inputs);
+    const path = join(this.store, id + '.json');
+    if (existsSync(path)) {
+      this.reused++;
+      this.touched.push(id);
+      return { id, ...JSON.parse(readFileSync(path, 'utf8')), cached: true };
+    }
+    return this._flight(id, async () => {
+      // re-check inside the flight: a sibling caller may have just written it
+      if (existsSync(path)) {
+        this.reused++;
+        this.touched.push(id);
+        return { id, ...JSON.parse(readFileSync(path, 'utf8')), cached: true };
+      }
+      const verdict = await node.compute();
+      const record = { kind: node.kind, params: node.params, inputs: node.inputs, verdict };
+      writeFileSync(path, stableStringify(record) + '\n');
+      this.recomputed++;
+      this.touched.push(id);
+      return { id, ...record, cached: false };
+    });
+  }
+
+  /**
+   * Seal the run: write an append-only manifest referencing the touched nodes.
+   * runId is content-derived (caller passes the codebase fingerprint), never a clock.
+   */
+  seal(runId, summary) {
+    // tape-binding (docs/01 §1.5): each seal is a hash-chained fact. prev = the manifest
+    // hash of the previous seal on this anchor's chain. A verdict you cannot place on the
+    // chain is a verdict you cannot trust — the chain is the append-only verification tape.
+    const prev = this._chainTip();
+    const manifest = {
+      schema: 'keel.manifest/v0',
+      run: runId,
+      nodes: this.touched,
+      recomputed: this.recomputed,
+      reused: this.reused,
+      prev,                       // null for the genesis seal
+      ...summary,
+    };
+    const path = join(this.dir, `manifest-${runId}.json`);
+    const body = stableStringify(manifest) + '\n';
+    writeFileSync(path, body);
+    const manifest_hash = H(body);
+    // R#5: sign the manifest hash with the release key when configured. The signature attests the
+    // factory produced this seal; combined with the prev-link it makes the chain a transparency
+    // record (a rewritten/forged/replayed seal fails verify-seal.mjs). Unsigned ⇒ sig:null, honest.
+    const sig = this._signingKeyPem ? signSeal(manifest_hash, this._signingKeyPem) : null;
+    appendFileSync(join(this.dir, '_chain.jsonl'),
+      stableStringify({ run: runId, manifest_hash, prev, sig }) + '\n');
+    return { path, manifest, manifest_hash, prev, sig };
+  }
+
+  /** The manifest hash of the latest seal on this anchor's chain, or null at genesis. */
+  _chainTip() {
+    const chain = join(this.dir, '_chain.jsonl');
+    if (!existsSync(chain)) return null;
+    const lines = readFileSync(chain, 'utf8').split('\n').filter(Boolean);
+    if (!lines.length) return null;
+    try { return JSON.parse(lines[lines.length - 1]).manifest_hash; } catch { return null; }
+  }
+}

--- a/keel/src/atoms.mjs
+++ b/keel/src/atoms.mjs
@@ -1,0 +1,234 @@
+// atoms.mjs — instantiate evidence atoms from real Tier-1 tools.
+//
+// An atom is NEVER asserted true by Keel. It is instantiated by running the tool
+// bound to it (docs/02 §2.2, docs/03 §3.4) and reading a three-valued result
+// (docs/02 §2.6):
+//   true    — tool ran and ok_when held
+//   false   — tool ran and ok_when did not hold
+//   unknown — no binding, a needed binary is absent, or the tool self-skipped (exit 77)
+//
+// Evidence gathering is wrapped as content-addressed nodes so re-running on an
+// unchanged unit reuses the verdict (anchor.mjs). The tool process is the heavy
+// work; the orchestrator only collects its result (docs/04 §4.2).
+//
+// CROSSING (docs/07 §7.2). A binding's evidence may declare a `cross` matrix: a list of
+// points (platform, config, …) that the SAME obligation must hold across. The atom is
+// `true` only if every crossed point is `true` (Kleene ∧). One point that goes red, or is
+// unknown, dominates — exactly the "cross 100%, find where the bridge fails" model. With no
+// matrix the cross is a single point (back-compatible). Heavy enumerations (mutants, fuzz
+// inputs) are crossed INSIDE the bound tool, which reports one exit; Keel's matrix is the
+// declarable config/platform axis layered on top.
+
+import { spawn, spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { H, hashFile, hashPathMeta, globFingerprint } from './anchor.mjs';
+
+const PATH_WITH_CARGO = `${process.env.PATH || ''}:${join(process.env.CARGO_HOME || join(process.env.HOME || '', '.cargo'), 'bin')}`;
+const RUN_ENV = { ...process.env, PATH: PATH_WITH_CARGO };
+
+/**
+ * R#3 hermetic env (docs/15 §15.4): when a profile declares an execution_policy, an evidence run
+ * inherits ONLY the explicitly passed-through ambient vars (plus a minimal PATH/LANG base) — host
+ * secrets, tokens, and credentials that were not allow-listed are absent inside the harness. With
+ * no policy the full RUN_ENV is used (back-compatible). The binding's own `env` always layers on top.
+ */
+export function policyEnv(policy) {
+  if (!policy) return RUN_ENV;
+  const base = { PATH: PATH_WITH_CARGO, LANG: process.env.LANG || 'C' };
+  for (const k of policy.env_passthrough || []) if (process.env[k] !== undefined) base[k] = process.env[k];
+  return base;
+}
+
+// Exit code a tool uses to self-report "namespace real, evidence harness not wired here"
+// (the automake skip convention). Distinct from a needed-binary being absent: the tool RAN
+// and declined. Maps to 'unknown' (skip, NEVER pass) with the tool's own reason.
+const SKIP_EXIT = 77;
+const MAXBUF = 64 * 1024 * 1024;
+// Per-point wall-clock bound so a tool that hangs (reads stdin, deadlocks) can never stall the
+// gate forever (H1). Generous by default — real suites take minutes; override with ev.timeout_ms.
+// A timeout is 'unknown' (we did not learn the answer), never a pass.
+const DEFAULT_TIMEOUT_MS = 600_000;
+
+function has(bin) {
+  return spawnSync('bash', ['-c', `command -v ${bin}`], { env: RUN_ENV }).status === 0;
+}
+
+/** Non-blocking spawn → Promise<{status, stdout, stderr, error, timedOut}>. The async sibling of
+ *  spawnSync so the pool (concurrency.mjs) can keep K tools running at once. stdin is closed
+ *  (`ignore`) so an interactive tool reads EOF instead of hanging; a hard timeout (H1) kills a
+ *  tool that hangs anyway and is reported as a timeout (→ unknown, never pass). */
+function spawnAsync(tool, argv, opts) {
+  const timeout = opts.timeout || DEFAULT_TIMEOUT_MS;
+  return new Promise((resolve) => {
+    let stdout = '', stderr = '', launchError = null;
+    const child = spawn(tool, argv, { ...opts, stdio: ['ignore', 'pipe', 'pipe'], timeout });
+    // bound RETAINED output ~MAXBUF (parent heap); destroy the stream once capped so a chatty
+    // child cannot keep us busy forever (M3). The verdict reads only exit status, not full output.
+    const cap = (s, add, stream) => { if (s.length >= MAXBUF) { stream?.destroy?.(); return s; } return s + add; };
+    child.stdout?.on('data', (d) => { stdout = cap(stdout, d.toString(), child.stdout); });
+    child.stderr?.on('data', (d) => { stderr = cap(stderr, d.toString(), child.stderr); });
+    child.on('error', (e) => { launchError = e; resolve({ status: null, stdout, stderr, error: e }); });
+    // on timeout Node kills the child → close fires with code=null, signal='SIGTERM'.
+    child.on('close', (code, signal) => {
+      if (launchError) return;
+      resolve({ status: code, stdout, stderr, error: null, timedOut: code === null && signal != null });
+    });
+  });
+}
+
+/**
+ * Hash the content a node's verdict depends on, so its id changes when (and only when) that
+ * content changes (staleness spine, docs/01 §1.3).
+ *
+ * `scope` (issue ledger item 2 / #647) NARROWS that dependency: when a binding declares the
+ * file globs its evidence actually reads, the fingerprint covers ONLY those files (relative to
+ * the unit root) — an edit elsewhere in the unit does not change the id, so the bound atom is
+ * NOT recomputed. This is the first step from unit-granular toward symbol-granular incremental
+ * (the seam; per-symbol sub-units extend it later, growing toward .braid). Verdict-invariant:
+ * a scope only changes WHICH inputs are watched, never how the tool runs. Absent scope ⇒ the
+ * coarse whole-unit fingerprint (back-compatible), preferring the front-end's precomputed one.
+ */
+export function unitFingerprint(unit, scope) {
+  if (Array.isArray(scope) && scope.length) return globFingerprint(unit.root || unit.path || unit.id || '.', scope);
+  if (unit.fingerprint) return unit.fingerprint;
+  return unit.manifest ? hashFile(unit.manifest) : hashPathMeta(unit.path || unit.id);
+}
+
+/** The crossing matrix for a binding: explicit points, or a single default point. */
+function crossPoints(ev) {
+  return Array.isArray(ev.cross) && ev.cross.length ? ev.cross : [{ label: 'base' }];
+}
+
+/** Three-valued ∧ over crossed-point values: false dominates, then unknown. */
+function crossAnd(vs) {
+  return vs.includes('false') ? 'false' : vs.includes('unknown') ? 'unknown' : 'true';
+}
+
+/** Extract a numeric score from a tool's stdout per an evidence `score` spec (graded atoms,
+ *  docs/02 §2.5). Returns a number (optionally normalised by `max` into [0,1]) or null when no
+ *  number is present — null => the atom is 'unknown' (no measurement), never a silent pass. */
+function extractScore(stdout, spec) {
+  const nums = (stdout || '').match(/-?\d+(?:\.\d+)?/g);
+  if (!nums || !nums.length) return null;
+  const s = parseFloat(spec.from === 'stdout-first-number' ? nums[0] : nums[nums.length - 1]);
+  if (!Number.isFinite(s)) return null;
+  return (typeof spec.max === 'number' && spec.max > 0) ? s / spec.max : s;
+}
+
+/**
+ * Build the DAG node that instantiates one (atom, unit) pair. The verdict is
+ * { value, reason, points:[…] }. compute() is ASYNC (await-able) so the engine pool can
+ * run many atom nodes concurrently; the node id folds in the FULL evidence spec (tool, argv
+ * structurally, cwd, env, every crossed point) so any change that affects compute() changes
+ * the id (staleness spine, docs/01 §1.3).
+ *
+ * The unit-fingerprint input is NARROWED by `evidence.scope` when declared (#647): the node
+ * then depends only on the scoped files, so an edit outside the scope does not recompute it.
+ *
+ * `meta` carries { advisory, source }: the node id is NAMESPACED by them so an advisory /
+ * proposer node can never share a content-addressed verdict with a gated atom node, and two
+ * distinct verifiers mapping to the same atom stay distinct nodes even if their commands
+ * happen to coincide (C1/C3 defence-in-depth).
+ */
+export function atomNode(atomDef, binding, unit, meta = {}) {
+  const ev = binding?.evidence;
+  const points = ev ? crossPoints(ev) : [{ label: 'base' }];
+  // C3: the channel an advisory verdict lives in is part of its identity — a gated reuse of an
+  // advisory node (or vice-versa) is impossible by construction, independent of command text.
+  const channel = meta.advisory ? `advisory:${meta.source || ''}` : (meta.source ? `gated:${meta.source}` : 'gated');
+  const inputs = [
+    unitFingerprint(unit, ev?.scope),
+    binding ? evidenceFingerprint(ev, points) : 'nobind',
+    channel,
+  ];
+  return {
+    kind: `atom:${atomDef.id}`,
+    params: { unit: unit.id, atom: atomDef.id, channel },
+    inputs,
+    async compute() {
+      if (!binding) return { value: 'unknown', reason: `no binding for ${atomDef.id} (evidence source unbound)` };
+      // H2: ok_when is only meaningful as exit==0; an author who declares anything else is
+      // silently misled today. Surface it as unknown (blocks, never passes) rather than ignore.
+      if (ev.ok_when && ev.ok_when !== 'exit==0')
+        return { value: 'unknown', reason: `unsupported ok_when '${ev.ok_when}' (only exit==0 is interpreted) — reword the evidence` };
+      for (const bin of ev.needs || []) {
+        if (!has(bin)) return { value: 'unknown', reason: `toolchain absent: ${bin}` };
+      }
+      // cross every declared point; the atom holds only if all hold (Kleene ∧)
+      const results = [];
+      for (const pt of points) {
+        const argv = pt.argv || ev.argv;
+        if (!Array.isArray(argv)) { results.push({ label: pt.label || 'base', value: 'unknown', reason: 'no argv (malformed binding/point — refusing to spawn a bare tool)' }); continue; }
+        const cwd = (pt.cwd ?? ev.cwd) ? join(unit.root || '.', pt.cwd ?? ev.cwd) : (unit.root || '.');
+        const baseEnv = policyEnv(meta.policy);
+        const env = (pt.env || ev.env) ? { ...baseEnv, ...ev.env, ...pt.env } : baseEnv;
+        const r = await spawnAsync(ev.tool, argv, { cwd, env, encoding: 'utf8', timeout: pt.timeout_ms || ev.timeout_ms });
+        results.push(readPoint(pt, ev, r));
+      }
+      // GRADED atom (docs/02 §2.5): each point yields a numeric score; the worst point dominates
+      // (the bridge fails where it is weakest). The raw score is returned and cached here; crossing
+      // to boolean against the profile threshold happens in the runner post-process (engine.mjs),
+      // so changing the bar never re-runs the tool. A point that couldn't measure => atom unknown.
+      if (ev.score) {
+        const bad = results.filter(p => p.value === 'unknown');
+        if (bad.length) return { value: 'unknown', points: results, reason: bad.map(p => `[${p.label}] ${p.reason}`).join(' · ') };
+        return { value: 'graded', score: Math.min(...results.map(p => p.score)), points: results };
+      }
+      const value = crossAnd(results.map(p => p.value));
+      const failed = results.filter(p => p.value !== 'true');
+      return {
+        value,
+        points: results,
+        reason: value === 'true' ? undefined
+          : failed.map(p => `[${p.label}] ${p.reason}`).join(' · '),
+        log: value === 'true' ? undefined : failed.map(p => p.log).filter(Boolean).join('\n---\n').slice(-2000),
+      };
+    },
+  };
+}
+
+/** Read one crossed point's three-valued result from a finished process. */
+function readPoint(pt, ev, r) {
+  const label = pt.label || 'base';
+  if (r.error) return { label, value: 'unknown', reason: `tool failed to launch: ${r.error.message}` };
+  if (r.timedOut) return { label, value: 'unknown', reason: `timed out (${(pt.timeout_ms || ev.timeout_ms || DEFAULT_TIMEOUT_MS) / 1000}s) — treated as unknown, never pass` };
+  if (r.status === SKIP_EXIT) {
+    const last = (r.stdout || '').trim().split('\n').filter(Boolean).pop() || 'self-reported skip';
+    return { label, value: 'unknown', exit: 77, reason: last.replace(/^SKIP:\s*/, '') };
+  }
+  // GRADED measurement (docs/02 §2.5): the tool must exit 0 (it ran) and emit a number; the
+  // boolean crossing is deferred to the engine against profile.thresholds. exit!=0 or no number
+  // => 'unknown' (no measurement), never a silent pass.
+  if (ev.score) {
+    if (r.status !== 0) return { label, value: 'unknown', exit: r.status, reason: `${ev.tool} exited ${r.status} — no score measured`, log: (r.stderr || r.stdout || '').slice(-2000) };
+    const score = extractScore(r.stdout, ev.score);
+    if (score == null) return { label, value: 'unknown', exit: r.status, reason: `no number on stdout to score (from: ${ev.score.from})` };
+    return { label, value: 'graded', score, exit: r.status };
+  }
+  const ok = r.status === 0; // ok_when is enforced to exit==0 in compute() (H2)
+  return {
+    label, value: ok ? 'true' : 'false', exit: r.status,
+    reason: ok ? undefined : `${ev.tool} ${(pt.argv || ev.argv).join(' ')} exited ${r.status}`,
+    log: ok ? undefined : (r.stderr || r.stdout || '').slice(-2000),
+  };
+}
+
+/**
+ * C1/C2: content fingerprint of the FULL evidence spec, hashed STRUCTURALLY (not space-joined).
+ * Argv element boundaries, cwd, env, and every crossed point are preserved, so two materially
+ * different commands (`["-c","true"]` vs `["-c true"]`, or same command in a different cwd/env)
+ * can never collide on a node id and inherit one another's cached verdict.
+ */
+function evidenceFingerprint(ev, points) {
+  return H('evidence/v1', {
+    tool: ev.tool,
+    argv: ev.argv || [],
+    cwd: ev.cwd || '',
+    env: ev.env || {},
+    ok_when: ev.ok_when || 'exit==0',
+    points: points.map(p => ({
+      label: p.label || '', argv: p.argv || ev.argv || [],
+      cwd: p.cwd ?? ev.cwd ?? '', env: { ...(ev.env || {}), ...(p.env || {}) },
+    })),
+  });
+}

--- a/keel/src/concepts.mjs
+++ b/keel/src/concepts.mjs
@@ -1,0 +1,53 @@
+// concepts.mjs — the concept algebra (docs/02 §2.3).
+//
+// A concept is a formula over atom ids:  atomId | {all:[…]} | {any:[…]} | {not:f}
+// Evaluated in three-valued (Kleene) logic over atom values 'true'|'false'|'unknown'
+// (docs/02 §2.6). 'unknown' is never silently 'true': a gated concept that evaluates
+// to 'unknown' is a BLOCK upstream (run.mjs), not a pass.
+//
+// The algebra is deterministic and associative — the calculator test. It runs in the
+// engine; only the result (verdict + failing atoms) crosses to a projection.
+
+const T = 'true', F = 'false', U = 'unknown';
+
+/** Collect the atom ids a formula references (so the runner knows what to gather). */
+export function atomsOf(formula, acc = new Set()) {
+  if (typeof formula === 'string') acc.add(formula);
+  else if (formula.all) formula.all.forEach(f => atomsOf(f, acc));
+  else if (formula.any) formula.any.forEach(f => atomsOf(f, acc));
+  else if (formula.not) atomsOf(formula.not, acc);
+  return acc;
+}
+
+/** Evaluate a formula given values: { atomId -> 'true'|'false'|'unknown' }. */
+export function evalFormula(formula, values) {
+  if (typeof formula === 'string') return values[formula] ?? U;
+  if (formula.all) return kleeneAll(formula.all.map(f => evalFormula(f, values)));
+  if (formula.any) return kleeneAny(formula.any.map(f => evalFormula(f, values)));
+  if (formula.not) return kleeneNot(evalFormula(formula.not, values));
+  throw new Error('malformed concept formula: ' + JSON.stringify(formula));
+}
+
+function kleeneAll(vs) { // ∧: false dominates, then unknown, else true
+  if (vs.includes(F)) return F;
+  if (vs.includes(U)) return U;
+  return T;
+}
+function kleeneAny(vs) { // ∨: true dominates, then unknown, else false
+  if (vs.includes(T)) return T;
+  if (vs.includes(U)) return U;
+  return F;
+}
+function kleeneNot(v) { return v === T ? F : v === F ? T : U; }
+
+/**
+ * Evaluate a concept against atom values and report the atoms responsible for a
+ * non-true verdict — the surprise-weighted payload a projection actually needs.
+ */
+export function evalConcept(concept, values) {
+  const verdict = evalFormula(concept.formula, values);
+  const referenced = [...atomsOf(concept.formula)];
+  const offenders = referenced.filter(a => (values[a] ?? U) !== T)
+    .map(a => ({ atom: a, value: values[a] ?? U }));
+  return { concept: concept.id, verdict, offenders };
+}

--- a/keel/src/concurrency.mjs
+++ b/keel/src/concurrency.mjs
@@ -1,0 +1,68 @@
+// concurrency.mjs — the bounded execution pool (docs/07 §7.4).
+//
+// Keel's verdict is a pure function of CONTENT (anchor.mjs): a node's id is the hash
+// of its inputs, and its verdict is computed once and cached by that id. Nothing about
+// the VERDICT depends on the order in which nodes are evaluated. That is exactly the
+// property that licenses concurrency: the finite structural-outcome space (docs/07 §7.1)
+// can be crossed in any order, in parallel, and the composed verdict is identical.
+//
+// So this file owns ONE seam — "evaluate N independent nodes with at most K running at
+// once" — and nothing else. No randomness, no wall-clock; only ordering of side-effects,
+// which the content-addressed store is immune to. Standalone: zero dependencies.
+
+import { cpus } from 'node:os';
+
+/**
+ * Default crossing width. Concurrency changes throughput, NEVER the verdict, so the
+ * default is a performance choice, not a correctness one. Bounded below by 1 and kept
+ * a little under core count so a verification run never starves the host it runs on.
+ * Override with --concurrency N or KEEL_CONCURRENCY for reproducible logs/timing.
+ */
+export function defaultConcurrency() {
+  const env = Number(process.env.KEEL_CONCURRENCY);
+  if (Number.isInteger(env) && env > 0) return env;
+  let n = 4;
+  try { n = cpus().length; } catch { /* sandboxed: fall back */ }
+  return Math.max(1, n - 2);
+}
+
+/**
+ * mapPool — run `fn` over `items` with at most `limit` in flight; resolve to results in
+ * INPUT ORDER (so the caller's aggregation is deterministic regardless of finish order).
+ *
+ * A worker that throws does NOT reject the pool: the slot's result is `{ __poolError: e }`
+ * so one failed crossing point cannot abort the whole crossing (the engine decides how a
+ * fault maps to a verdict — a thrown evaluator is 'unknown', never a silent pass).
+ */
+export async function mapPool(items, limit, fn) {
+  const list = [...items];
+  const results = new Array(list.length);
+  const width = Math.max(1, Math.min(limit | 0 || 1, list.length || 1));
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const i = next++;
+      if (i >= list.length) return;
+      try { results[i] = await fn(list[i], i); }
+      catch (e) { results[i] = { __poolError: e }; }
+    }
+  }
+  await Promise.all(Array.from({ length: width }, () => worker()));
+  return results;
+}
+
+/**
+ * dedupe — guarantee a key is computed at most once even if requested concurrently.
+ * Two parallel crossings that resolve to the SAME content-addressed node id must not
+ * both run the (possibly expensive, possibly file-writing) compute; the second awaits
+ * the first. Returns a function with the same signature as `compute`.
+ */
+export function singleFlight() {
+  const inflight = new Map();
+  return async function once(key, compute) {
+    if (inflight.has(key)) return inflight.get(key);
+    const p = (async () => compute())().finally(() => inflight.delete(key));
+    inflight.set(key, p);
+    return p;
+  };
+}

--- a/keel/src/conformance.mjs
+++ b/keel/src/conformance.mjs
@@ -1,0 +1,146 @@
+// conformance.mjs — concept↔Lean conformance (issue ledger #645 item 7; docs/02 §2.4).
+//
+// The framework's three canonical concepts (CoreGroundedCorrect / Hallucinated / Excellent)
+// have TWO declarations that must never disagree:
+//   • the formal skeleton in `lean/ExcellentCode/Framework.lean` (the authority), and
+//   • the machine-readable formulas in `schema/concepts.json` (what the engine evaluates).
+// A "slight difference" between them is precisely the bug Keel exists to catch, turned on
+// Keel itself. This module RE-DERIVES the three concepts from the Lean skeleton and asserts
+// the JSON formulas are structurally identical — same atom leaf-set, same boolean shape.
+//
+// SCOPE: this module verifies STRUCTURAL agreement between the two declared artifacts — it does
+// NOT run Lean. "Conformance passes" means "the JSON did not drift from the declared Lean
+// skeleton". The COMPLEMENTARY check that the skeleton itself TYPECHECKS is now `lake build` via
+// the `tool: lean` seam (src/adapters/lean.mjs), run as the `lean-skeleton-machinecheck` row in
+// qualify.mjs (#646, ledger item 6 — the #645 residual is closed). Together: this proves the JSON
+// matches the Lean; that proves the Lean is sound. This zero-dep check is the always-on gate;
+// the machine-check degrades to SKIP when the toolchain is absent (Lean depth is purchasable).
+// The check fails LOUDLY on any drift or on a Lean construct it cannot interpret (no silent
+// under-check — the assertSchemaSupported discipline).
+
+import { stableStringify } from './anchor.mjs';
+
+const FRAMEWORK_CONCEPTS = ['CoreGroundedCorrect', 'Hallucinated', 'Excellent'];
+
+/** Strip Lean comments so identifiers inside prose ("`holds a`") are never parsed as code. */
+function stripComments(src) {
+  // block comments /- ... -/ (covers /-- docstrings -/; this skeleton does not nest them)
+  let s = src.replace(/\/-[\s\S]*?-\//g, ' ');
+  // line comments -- ... (after block strip; no '--' appears inside code here)
+  s = s.replace(/--[^\n]*/g, ' ');
+  return s;
+}
+
+/** Constructor ids of `inductive Atom where | a | b ... deriving ...` — the atom universe. */
+function parseAtomUniverse(stripped) {
+  const m = stripped.match(/inductive\s+Atom\s+where([\s\S]*?)deriving\b/);
+  if (!m) throw new Error('conformance: could not locate `inductive Atom where ... deriving`');
+  return [...m[1].matchAll(/\|\s*([a-z_][a-zA-Z0-9_]*)/g)].map((x) => x[1]);
+}
+
+/** Capture a `def <Name> ... := <body>` body, up to the next top-level keyword or EOF. */
+function defBody(stripped, name) {
+  const re = new RegExp(`def\\s+${name}\\b[\\s\\S]*?:=([\\s\\S]*?)(?=\\n\\s*(?:def|theorem|end)\\b|$)`);
+  const m = stripped.match(re);
+  if (!m) throw new Error(`conformance: def ${name} not found in Framework.lean`);
+  return m[1];
+}
+
+/**
+ * Parse one def body into a raw shape:
+ *   { op: 'not', ref: 'OtherDef' }  — a negation of another framework def
+ *   { op: 'all'|'any', atoms: [...] } — a conjunction/disjunction over `holds <atom>`
+ * Throws on a construct it cannot interpret (mixed ∧/∨, empty, unrecognized).
+ */
+function parseDef(body, name) {
+  const neg = body.match(/¬\s*([A-Z][A-Za-z0-9_]*)/);
+  if (neg) {
+    // a pure negation of another def: there must be no bare `holds <atom>` conjuncts
+    if (/holds\s+[a-z_]/.test(body))
+      throw new Error(`conformance: def ${name} mixes ¬<Def> with holds-atoms — not interpretable`);
+    return { op: 'not', ref: neg[1] };
+  }
+  const atoms = [...body.matchAll(/holds\s+([a-z_][a-zA-Z0-9_]*)/g)].map((m) => m[1]);
+  if (!atoms.length) throw new Error(`conformance: def ${name} references no atoms and no negation`);
+  const hasAnd = body.includes('∧'), hasOr = body.includes('∨');
+  if (hasAnd && hasOr) throw new Error(`conformance: def ${name} mixes ∧ and ∨ — unsupported shape`);
+  if (atoms.length > 1 && !hasAnd && !hasOr)
+    throw new Error(`conformance: def ${name} lists multiple atoms with no ∧/∨ connective`);
+  return { op: hasOr ? 'any' : 'all', atoms };
+}
+
+/** Parse the three framework defs + the atom universe from Framework.lean source text. */
+export function parseLeanFramework(src) {
+  const stripped = stripComments(src);
+  const universe = parseAtomUniverse(stripped);
+  const defs = {};
+  for (const name of FRAMEWORK_CONCEPTS) defs[name] = parseDef(defBody(stripped, name), name);
+  return { universe, defs };
+}
+
+/** Canonicalize a Lean raw shape to {op, atoms:sorted} | {op:'not', child}, resolving refs. */
+function leanShape(name, defs, seen = new Set()) {
+  if (seen.has(name)) throw new Error(`conformance: cyclic Lean def reference at ${name}`);
+  seen.add(name);
+  const d = defs[name];
+  if (!d) throw new Error(`conformance: Lean def ${name} referenced but not parsed`);
+  if (d.op === 'not') return { op: 'not', child: leanShape(d.ref, defs, seen) };
+  return { op: d.op, atoms: [...d.atoms].sort() };
+}
+
+/** Canonicalize a concepts.json formula to the same shape grammar. */
+function jsonShape(f, ctx) {
+  if (typeof f === 'string') return { op: 'all', atoms: [f] }; // a bare atom = singleton conjunction
+  if (f && f.not !== undefined) return { op: 'not', child: jsonShape(f.not, ctx) };
+  for (const op of ['all', 'any']) {
+    if (Array.isArray(f && f[op])) {
+      const atoms = [];
+      for (const child of f[op]) {
+        if (typeof child === 'string') atoms.push(child);
+        else throw new Error(`conformance: ${ctx} JSON formula nests a non-atom under ${op} — framework concepts must be flat`);
+      }
+      return { op, atoms: atoms.sort() };
+    }
+  }
+  throw new Error(`conformance: ${ctx} JSON formula is not an interpretable shape: ${stableStringify(f)}`);
+}
+
+/**
+ * Check concepts.json against the Lean skeleton.
+ * @returns { ok: boolean, discrepancies: string[], checked: string[] }
+ */
+export function checkConformance({ conceptsDoc, leanText, atomsDoc }) {
+  const discrepancies = [];
+  const checked = [];
+  const { universe, defs } = parseLeanFramework(leanText);
+
+  const atomIds = new Set((atomsDoc.atoms || []).map((a) => a.id));
+
+  // (1) the Lean atom universe must be exactly the schema's 20 atoms (no phantom, none missing).
+  const uniSet = new Set(universe);
+  for (const id of universe) if (!atomIds.has(id)) discrepancies.push(`Lean Atom universe declares '${id}', not in schema/atoms.json`);
+  for (const id of atomIds) if (!uniSet.has(id)) discrepancies.push(`schema/atoms.json atom '${id}' is missing from the Lean Atom universe`);
+  if (universe.length !== uniSet.size) discrepancies.push(`Lean Atom universe has duplicate constructors`);
+
+  // (2) every framework concept in the schema must equal its Lean shape, and vice-versa.
+  const byId = Object.fromEntries((conceptsDoc.concepts || []).map((c) => [c.id, c]));
+  const frameworkInJson = (conceptsDoc.concepts || []).filter((c) => c.origin === 'framework').map((c) => c.id);
+  for (const name of FRAMEWORK_CONCEPTS) {
+    if (!byId[name]) { discrepancies.push(`framework concept '${name}' present in Lean but absent from concepts.json`); continue; }
+    if (byId[name].origin !== 'framework') discrepancies.push(`concept '${name}' must be origin:'framework' (it is the Lean-bound set)`);
+    let lean, json;
+    try { lean = leanShape(name, defs); } catch (e) { discrepancies.push(String(e.message)); continue; }
+    try { json = jsonShape(byId[name].formula, name); } catch (e) { discrepancies.push(String(e.message)); continue; }
+    // every atom referenced must be a real atom
+    const leaves = (s) => (s.op === 'not' ? leaves(s.child) : s.atoms);
+    for (const a of leaves(json)) if (!atomIds.has(a)) discrepancies.push(`concept '${name}' references unknown atom '${a}'`);
+    if (stableStringify(lean) !== stableStringify(json))
+      discrepancies.push(`concept '${name}' DRIFT — Lean ${stableStringify(lean)} ≠ JSON ${stableStringify(json)}`);
+    checked.push(name);
+  }
+  // a framework concept in JSON that Lean does not define is also drift
+  for (const id of frameworkInJson)
+    if (!FRAMEWORK_CONCEPTS.includes(id)) discrepancies.push(`concept '${id}' is origin:'framework' in concepts.json but has no Lean definition`);
+
+  return { ok: discrepancies.length === 0, discrepancies, checked };
+}

--- a/keel/src/engine.mjs
+++ b/keel/src/engine.mjs
@@ -1,0 +1,174 @@
+// engine.mjs — the shared verdict core (the basement; docs/01 §1, docs/02 §2.6).
+//
+// One place computes a verdict, for EVERY front-end (profile, kernel-registry, …). A
+// front-end's only job is to produce ACTIVATIONS — flat (atom, unit, binding) triples —
+// and a gate concept; the engine evaluates each as a content-addressed node, aggregates
+// per-atom with three-valued ∧, and composes the gate. Determinism: identity is content,
+// no wall-clock, no randomness. Standalone: only Node builtins + Keel's own modules.
+
+import { globFingerprint, SRC_GLOBS, EXCLUDE } from './anchor.mjs';
+import { atomNode } from './atoms.mjs';
+import { evalConcept, evalFormula } from './concepts.mjs';
+import { mapPool, defaultConcurrency } from './concurrency.mjs';
+
+// Re-exported for back-compat (front-ends import these from engine). The single definition lives
+// in anchor.mjs so binding-scope fingerprinting (atoms.mjs) shares it — never a divergent copy.
+export { SRC_GLOBS, EXCLUDE } from './anchor.mjs';
+
+/** Content fingerprint of a whole unit dir: every source file (the coarsest, default scope).
+ *  A binding may narrow this to its own `scope` (atoms.unitFingerprint) for finer staleness. */
+export function contentFingerprint(dir, { globs = SRC_GLOBS, exclude = EXCLUDE } = {}) {
+  return globFingerprint(dir, globs, exclude);
+}
+
+/** Three-valued ∧ aggregating one atom across its units: false dominates, then unknown. */
+export function kleeneAll(vs) {
+  return vs.includes('false') ? 'false' : vs.includes('unknown') ? 'unknown' : 'true';
+}
+
+/** Cross a graded atom's score to a three-valued floor verdict against a profile threshold
+ *  (docs/02 §2.5, #648 item 8). No measurement OR no declared threshold => 'unknown' (the bar is
+ *  the auditor's parameter; absence of a bar blocks, it never silently passes). */
+export function crossGraded(score, threshold) {
+  if (typeof score !== 'number' || Number.isNaN(score)) return 'unknown';
+  if (typeof threshold !== 'number') return 'unknown';
+  return score >= threshold ? 'true' : 'false';
+}
+
+/**
+ * Claim-coherence (the punishing gate; docs/09): you may CLAIM only what you DEMONSTRATED.
+ * Given the formula of the concept a profile asserts it meets (`assurance_claim`) and the measured
+ * atom values, find every atom the claim rests on that has NO definite evidence (unknown/unrun/
+ * unbound). If any exist the claim OUTRUNS the evidence — the run must BLOCK, regardless of how
+ * narrow the enforced `gate_concept` was. This is "deeply punishing of overclaim, without being
+ * overhot": it fires ONLY when you explicitly assert a claim, and only on the gap between assertion
+ * and demonstration — an honest `unknown` on something you never claimed does not block.
+ *
+ * A claim is DEMONSTRATED only when its concept formula actually HOLDS under the measured values —
+ * not merely when every atom was measured. Two honest failure modes are kept distinct:
+ *   - `undemonstrated` (claim formula 'unknown' — a claimed atom is unrun/unbound): the claim
+ *     OUTRAN its evidence ⇒ BLOCK.
+ *   - `refuted` (claim formula 'false' under measured atoms): the evidence DISPROVES the claim
+ *     ⇒ NO-GO.
+ * Prior bug (Open Risk #4, 2026-06-21 handoff): only `unknown` atoms counted as undemonstrated, so
+ * a claimed atom measured FALSE was reported "coherent / demonstrated" — overclaim dressed as proof.
+ * Now a false claimed atom that breaks the formula refutes the claim.
+ * Returns { coherent, claimValue, claimedAtoms, undemonstrated, refuted, refutingAtoms }.
+ */
+export function claimCoherence(claimFormula, atomValues) {
+  const claimedAtoms = [...collectAtoms(claimFormula)];
+  const undemonstrated = claimedAtoms.filter((id) => atomValues[id] !== 'true' && atomValues[id] !== 'false');
+  const claimValue = evalFormula(claimFormula, atomValues);
+  return {
+    coherent: claimValue === 'true',
+    claimValue,
+    claimedAtoms,
+    undemonstrated,
+    refuted: claimValue === 'false',
+    refutingAtoms: claimValue === 'false' ? claimedAtoms.filter((id) => atomValues[id] === 'false') : [],
+  };
+}
+
+/** Collect the atom ids a concept formula references. */
+export function collectAtoms(f, acc = new Set()) {
+  if (typeof f === 'string') acc.add(f);
+  else if (f.all) f.all.forEach(x => collectAtoms(x, acc));
+  else if (f.any) f.any.forEach(x => collectAtoms(x, acc));
+  else if (f.not) collectAtoms(f.not, acc);
+  return acc;
+}
+
+/**
+ * The engine core. Given a flat list of ACTIVATIONS, evaluate every one as a
+ * content-addressed node through the anchor — CONCURRENTLY, with at most `concurrency`
+ * tools running at once (concurrency.mjs) — aggregate per-atom across its units with
+ * three-valued ∧, fill any gate-referenced atom that was never activated with 'unknown'
+ * (unknown ≠ pass; docs/02 §2.6), and compose the gate concept. The single calculator-test
+ * core — the only place a verdict is computed.
+ *
+ * Concurrency is sound here because identity is CONTENT: a node's verdict and id do not
+ * depend on evaluation order, so crossing the activation set in parallel yields the
+ * identical composed verdict as crossing it serially (docs/07 §7.4).
+ *
+ * ADVISORY activations (act.advisory === true) are evaluated and surfaced but are EXCLUDED
+ * from the gate's atom values — the seam (docs/05 §5.5) that lets a non-deterministic or
+ * proposer signal share the ontology without ever flipping GO→NO-GO.
+ *
+ * activation = { atomId, atomDef, binding|null, unit, source?, advisory?, role? }
+ * returns    = { gate, atomValues, atoms, advisories, crossing, recomputed, reused }
+ */
+export async function composeReport({ activations, gate, anchor, concurrency = defaultConcurrency(), thresholds = {}, policy = null }) {
+  const evaluated = await mapPool(activations, concurrency, async (act) => {
+    // pass the channel meta so the node id is namespaced by advisory/source (engine never lets
+    // an advisory node's verdict be reused by a gated atom — C3 defence-in-depth in atoms.mjs).
+    // `policy` (execution_policy) confines the evidence run's env (R#3); it does not affect the
+    // node id (the binding's declared env still does), only which ambient vars the tool can read.
+    const node = atomNode(act.atomDef, act.binding, act.unit, { advisory: act.advisory, source: act.source, policy });
+    const res = await anchor.evaluateAsync(node);
+    return { act, verdict: res.verdict, cached: res.cached };
+  });
+
+  const perAtom = {};
+  const atoms = [];
+  const advisories = [];
+  let crossedPoints = 0, crossedFalse = 0, crossedUnknown = 0;
+  for (let i = 0; i < evaluated.length; i++) {
+    const e = evaluated[i];
+    const act = activations[i];
+    // a thrown evaluator is unknown, never a silent pass (docs/02 §2.6)
+    const verdict = e.__poolError ? { value: 'unknown', reason: `evaluator fault: ${e.__poolError.message}` } : e.verdict;
+    const points = verdict.points || [];
+    crossedPoints += points.length || 1;
+    crossedFalse += points.filter(p => p.value === 'false').length;
+    crossedUnknown += points.filter(p => p.value === 'unknown').length;
+    // GRADED threshold crossing (#648 item 8): the cached score crosses to boolean HERE, in
+    // post-process, against the profile threshold — keeping the bar out of the cached node so
+    // re-bar never re-runs the tool. No bar => unknown (blocks, never silently passes).
+    let value = verdict.value, graded;
+    if (act.atomDef?.kind === 'graded' && verdict.value === 'graded') {
+      const threshold = thresholds[act.atomId];
+      value = crossGraded(verdict.score, threshold);
+      graded = { score: verdict.score, threshold };
+    }
+    const row = {
+      atom: act.atomId, unit: act.unit.id, value,
+      reason: (value === 'unknown' && graded && graded.threshold === undefined)
+        ? `graded score ${graded.score} but no profile threshold — set thresholds['${act.atomId}'] (docs/02 §2.5)`
+        : verdict.reason,
+      score: graded?.score, threshold: graded?.threshold,
+      cached: e.cached, source: act.source,
+      points: points.length > 1 ? points.map(p => ({ label: p.label, value: p.value, score: p.score })) : undefined,
+    };
+    if (act.advisory) { advisories.push({ ...row, role: act.role }); continue; }
+    atoms.push(row);
+    (perAtom[act.atomId] ||= []).push(value);
+  }
+
+  const atomValues = {};
+  for (const id of Object.keys(perAtom)) atomValues[id] = kleeneAll(perAtom[id]);
+  for (const id of collectAtoms(gate.formula)) if (!(id in atomValues)) atomValues[id] = 'unknown';
+  return {
+    gate: evalConcept(gate, atomValues), atomValues, atoms, advisories,
+    crossing: { points: crossedPoints, failed: crossedFalse, unknown: crossedUnknown },
+    recomputed: anchor.recomputed, reused: anchor.reused,
+  };
+}
+
+/**
+ * Coverage instrument (the H1 measurement): of the full atom ontology, how many carry a
+ * DEFINITE verdict (true|false — i.e. evidence actually ran) vs are 'unknown' (unbound or
+ * tool-absent). This is the honest denominator — unknown is NEVER counted as covered.
+ */
+export function coverage(atomsDoc, atomValues) {
+  const all = atomsDoc.atoms.map(a => a.id);
+  const definite = all.filter(id => atomValues[id] === 'true' || atomValues[id] === 'false');
+  const unknown = all.filter(id => !(atomValues[id] === 'true' || atomValues[id] === 'false'));
+  return {
+    total: all.length,
+    covered: definite.length,
+    uncovered: unknown.length,
+    ratio: definite.length / all.length,
+    covered_atoms: definite,
+    uncovered_atoms: unknown,
+  };
+}

--- a/keel/src/latency.mjs
+++ b/keel/src/latency.mjs
@@ -1,0 +1,34 @@
+// latency.mjs — latency/jitter as a first-order verdict variable (aircraft axiom A5; issue: kernel #657).
+//
+// A5 (latency_bounded_execution): "transport_delay ≤ qualified_budget; latency and jitter are
+// first-order fidelity variables." The honest reconciliation with Keel's determinism: the latency
+// MEASUREMENT is an empirical, non-deterministic SENSOR (wall-clock varies); the DECISION RULE
+// (aggregate → compare to a cited budget) is deterministic. Determinism lives in the control law,
+// not the sensor (cf. the math-vs-embedding-sensor split). The measurement is treated as a property
+// of the source version: measured per source fingerprint and reused until the source changes (A8).
+//
+// A budget is the auditor's CITED parameter — no budget ⇒ 'unknown' (cannot gate; an uncited
+// threshold is not law). No samples ⇒ 'unknown' (BLOCKS, never a silent pass).
+
+/** Aggregate latency samples (ms) into the verdict-relevant statistics. jitter = max − min
+ *  (the spread the scheduler must keep bounded; A5). p99 by nearest-rank. */
+export function aggregateLatency(samples) {
+  const s = (samples || []).filter((x) => typeof x === 'number' && Number.isFinite(x)).sort((a, b) => a - b);
+  if (!s.length) return { n: 0 };
+  const max = s[s.length - 1], min = s[0];
+  const p99 = s[Math.min(s.length - 1, Math.ceil(0.99 * s.length) - 1)];
+  return { n: s.length, min, max, p99, jitter: max - min, mean: s.reduce((a, b) => a + b, 0) / s.length };
+}
+
+/** Accept the aggregate against a declared budget. Any breached bound ⇒ 'false' with the reason(s).
+ *  No samples or no budget ⇒ 'unknown' (blocks). */
+export function acceptLatency(agg, budget) {
+  if (!agg || !agg.n) return { value: 'unknown', reasons: ['no latency samples measured (harness unbound or produced no number)'] };
+  if (!budget || (budget.max_ms == null && budget.p99_ms == null && budget.jitter_ms == null))
+    return { value: 'unknown', reasons: ['no latency budget declared — cannot gate (cite max_ms / p99_ms / jitter_ms; an uncited threshold is not law, docs/10 §10.3)'] };
+  const reasons = [];
+  if (budget.max_ms != null && agg.max > budget.max_ms) reasons.push(`max ${agg.max}ms > budget ${budget.max_ms}ms`);
+  if (budget.p99_ms != null && agg.p99 > budget.p99_ms) reasons.push(`p99 ${agg.p99}ms > budget ${budget.p99_ms}ms`);
+  if (budget.jitter_ms != null && agg.jitter > budget.jitter_ms) reasons.push(`jitter ${agg.jitter}ms > budget ${budget.jitter_ms}ms`);
+  return { value: reasons.length ? 'false' : 'true', reasons };
+}

--- a/keel/src/project.mjs
+++ b/keel/src/project.mjs
@@ -1,0 +1,67 @@
+// project.mjs — the three projections of the one anchor (docs/01 §1.5).
+//
+// AI and humans never share a representation; each reads a projection of the same
+// content-addressed truth, derived live, so they cannot drift. Emit by SURPRISE,
+// not by volume: a passing atom costs ~nothing; detail is spent on the anomalous.
+
+/** Symbolic projection — the exact record, for audit/proofs/the tape. Loss-less. */
+export function symbolic(report) {
+  return {
+    schema: 'keel.projection.symbolic/v0',
+    run: report.run,
+    gate_concept: report.gate.concept,
+    verdict: report.gate.verdict,
+    atoms: report.atoms,        // every (atom,unit) value + evidence pointer
+    concepts: report.concepts,  // every concept verdict
+    cache: { recomputed: report.recomputed, reused: report.reused },
+  };
+}
+
+/**
+ * AI projection — the decision digest. Conventional structure, meaningful names,
+ * surprise-weighted: only non-true atoms are detailed, with a targeted fix. This is
+ * what an orchestrating AI reads to act, and the input to a downstream cost model.
+ */
+export function ai(report, atomDefs) {
+  const offenders = report.gate.offenders.map(o => ({
+    atom: o.atom,
+    value: o.value,
+    units: report.atoms.filter(a => a.atom === o.atom && a.value !== 'true').map(a => a.unit),
+    fix: fixFor(o.atom, o.value, atomDefs),
+  }));
+  return {
+    schema: 'keel.projection.ai/v0',
+    run: report.run,
+    verdict: report.gate.verdict,        // true | false | unknown
+    gate: report.gate.concept,
+    // emit-by-surprise: nothing about the passing atoms
+    offenders: report.gate.verdict === 'true' ? [] : offenders,
+    note: report.gate.verdict === 'unknown'
+      ? 'blocked: a gated atom is unknown (no evidence) — bind a tool or run the tier'
+      : undefined,
+  };
+}
+
+function fixFor(atom, value, atomDefs) {
+  const def = (atomDefs || []).find(d => d.id === atom);
+  if (value === 'unknown') return `bind/run the evidence source for ${atom} (${def?.evidence || 'tool'}); unknown ≠ pass`;
+  return `${atom} is false — ${def?.formal || 'predicate unmet'}; address via ${def?.evidence || 'the bound tool'}`;
+}
+
+/** Human projection — DEFERRED. Interface only (docs/01 §1.5); see issue ledger. */
+export function human() {
+  return { schema: 'keel.projection.human/v0', deferred: true,
+    note: 'narrative + headroom/cost rendering not implemented in first pass' };
+}
+
+/** Terse one-line render of the AI projection for a terminal. */
+export function renderAI(p) {
+  const mark = p.verdict === 'true' ? 'GO' : p.verdict === 'unknown' ? 'BLOCKED' : 'NO-GO';
+  const lines = [`${mark} — gate '${p.gate}' = ${p.verdict}  (run ${p.run})`];
+  for (const o of p.offenders) {
+    lines.push(`  ✗ ${o.atom} = ${o.value}${o.units.length ? `  [${o.units.join(', ')}]` : ''}`);
+    lines.push(`     fix: ${o.fix}`);
+  }
+  if (p.note) lines.push(`  note: ${p.note}`);
+  return lines.join('\n');
+}

--- a/keel/src/qualify.mjs
+++ b/keel/src/qualify.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+// qualify.mjs — DO-330-INSPIRED self-qualification for KEEL ITSELF ("who audits the auditor").
+//
+// NOT a DO-330 TQL credential (that needs a Tool Qualification Plan, tool operational requirements,
+// independence, and a certification authority — docs/10 §10.3). This adopts the DISCIPLINE: a tool
+// that gates must PROVE it catches what it claims. The kernel proves its detectors against a
+// known-bad corpus (scripts/ci/selftest-qualification.mjs); this is the same discipline turned
+// on Keel's OWN core guarantees — the properties an independent reviewer most needs to trust:
+//
+//   unknown ≠ pass     — a gate over an UNBOUND atom must BLOCK (exit 1), never GO.
+//   false blocks       — a binding whose tool exits nonzero must make the gate NO-GO (exit 1).
+//   clean control      — a satisfied binding must GO (exit 0): no false positive.
+//   crossing ∧         — a `cross` matrix with one failing point must go NO-GO (find where it fails).
+//   advisory ≠ verdict — an advisory signal going red must NOT flip a GO (the Phase-2 seam).
+//
+// Each fixture is a self-contained profile/registry + an expected verdict. The harness runs
+// Keel against it in a throwaway dir (hermetic; no shared .keel/) and asserts the verdict.
+// Determinism: no wall-clock, no RNG. Exit 0 = Keel qualified · 1 = a MISS (Keel gave the
+// wrong verdict on a planted case — it must not gate) · 2 = harness fault.
+//
+// Usage:  node src/qualify.mjs [--self-test]
+//   --self-test : meta-qualify THIS harness (prove it reports a MISS when Keel passes a case
+//                 that was supposed to fail — the auditor-of-the-auditor).
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync, existsSync, mkdtempSync, cpSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { checkConformance } from './conformance.mjs';
+import { leanBuild } from './adapters/lean.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));      // src/
+const ROOT = resolve(HERE, '..');
+const CORPUS = join(ROOT, 'fixtures', 'known-bad');
+const SCHEMA = join(ROOT, 'schema');
+const LEAN_PKG = join(ROOT, 'lean');
+const LEAN = join(LEAN_PKG, 'ExcellentCode', 'Framework.lean');
+const NODE = process.execPath;
+const MAXBUF = 32 * 1024 * 1024;
+const FRONT_ENDS = { profile: 'run.mjs', registry: 'run-registry.mjs', soak: 'run-soak.mjs', simulate: 'run-simulate.mjs', latency: 'run-latency.mjs', sim: 'run-sim.mjs' };
+
+// M2: a fixture is a trusted-but-verify boundary (a poisoned fixture's bindings run as code).
+// Scrub the env to a hermetic minimum so a fixture cannot read host secrets or touch the host
+// git/HOME, and confine the entry path to the sandbox so `../` cannot escape it.
+function hermeticEnv(sb) {
+  return {
+    PATH: process.env.PATH || '/usr/bin:/bin', HOME: sb,
+    GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null', GIT_TERMINAL_PROMPT: '0',
+    LANG: process.env.LANG || 'C', TMPDIR: sb,
+  };
+}
+function safeJoin(sb, rel) {
+  const p = resolve(sb, rel);
+  if (p !== sb && !p.startsWith(sb + '/')) throw new Error(`entry '${rel}' escapes the sandbox`);
+  return p;
+}
+
+/** Run Keel against one fixture in a hermetic temp dir; return { verdict, exit }. */
+function runFixture(dir, c) {
+  const sb = mkdtempSync(join(tmpdir(), 'keel-qual-'));
+  try {
+    cpSync(dir, sb, { recursive: true, filter: (s) => !s.endsWith('case.json') });
+    const script = join(HERE, FRONT_ENDS[c.front_end] || 'run.mjs');
+    const entryFlag = c.front_end === 'registry' ? '--registry' : '--profile';
+    const entry = safeJoin(sb, c.entry || '');
+    if ((c.args || []).some((a) => typeof a === 'string' && a.includes('..')))
+      throw new Error(`case args contain '..' (refused): ${JSON.stringify(c.args)}`);
+    const args = [script, entryFlag, entry, ...(c.args || [])];
+    const r = spawnSync(NODE, args, { cwd: sb, env: hermeticEnv(sb), encoding: 'utf8', maxBuffer: MAXBUF });
+    const out = `${r.stdout || ''}\n${r.stderr || ''}`;
+    return { exit: r.status, verdict: parseVerdict(out, r.status), out };
+  } finally {
+    rmSync(sb, { recursive: true, force: true });
+  }
+}
+
+/** Read the verdict mark off Keel's render (GO / NO-GO / BLOCKED), falling back to exit code. */
+function parseVerdict(out, exit) {
+  if (/\bNO-GO\b/.test(out)) return 'NO-GO';
+  if (/\bBLOCKED\b/.test(out)) return 'BLOCKED';
+  if (/\bGO\b/.test(out)) return 'GO';
+  return exit === 0 ? 'GO' : exit === 2 ? 'FAULT' : 'NO-GO';
+}
+
+/** The qualification verdict for one fixture given Keel's result. */
+function judge(c, r) {
+  if (r.exit === 2) return { qualified: false, why: `Keel runner FAULTED (exit 2) — ${tail(r.out)}` };
+  // M1: the EXIT CODE is the contract run.mjs/run-registry.mjs guarantee (0 GO · 1 NO-GO/BLOCKED ·
+  // 2 fault). Require every case to assert it so the fragile verdict-string parse is never the sole
+  // signal. expect_verdict (GO/NO-GO/BLOCKED) is an additional, optional discriminator.
+  if (c.expect_exit === undefined)
+    return { qualified: false, why: `case must declare expect_exit (the authoritative contract); verdict text alone is not trusted` };
+  if (r.exit !== c.expect_exit)
+    return { qualified: false, why: `expected exit ${c.expect_exit}, got ${r.exit}` };
+  if (c.expect_verdict && r.verdict !== c.expect_verdict)
+    return { qualified: false, why: `expected verdict ${c.expect_verdict}, got ${r.verdict}` };
+  return { qualified: true, why: `Keel returned ${r.verdict} (exit ${r.exit}) as planted` };
+}
+
+const tail = (s) => (s || '').trim().split('\n').filter(Boolean).slice(-1)[0] || '';
+
+function discover() {
+  if (!existsSync(CORPUS)) return [];
+  return readdirSync(CORPUS, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => join(CORPUS, d.name))
+    .filter((p) => existsSync(join(p, 'case.json')))
+    .sort();
+}
+
+function metaSelfTest() {
+  // Take the clean control (Keel correctly returns GO) but JUDGE it as if NO-GO were expected.
+  // The harness MUST report a MISS — otherwise it is blind and must not certify Keel.
+  console.log('================================================');
+  console.log('META SELF-TEST — qualification harness (audits the auditor)');
+  console.log('================================================');
+  const control = discover().find((d) => {
+    try { return JSON.parse(readFileSync(join(d, 'case.json'), 'utf8')).expect_verdict === 'GO'; } catch { return false; }
+  });
+  if (!control) { console.error('✗ harness fault: no GO control fixture to meta-test against.'); process.exit(2); }
+  const c = JSON.parse(readFileSync(join(control, 'case.json'), 'utf8'));
+  const r = runFixture(control, c);
+  const asGo = judge({ ...c, expect_verdict: 'GO', expect_exit: 0 }, r);
+  const asNoGo = judge({ ...c, expect_verdict: 'NO-GO', expect_exit: 1 }, r);
+  console.log(`  control '${control.split('/').pop()}' · Keel returned ${r.verdict} (exit ${r.exit})`);
+  console.log(`  judged under expect:GO    → qualified=${asGo.qualified} (MUST be true)`);
+  console.log(`  judged under expect:NO-GO → qualified=${asNoGo.qualified} (MUST be false)`);
+  if (asGo.qualified === true && asNoGo.qualified === false) {
+    console.log('✓ harness correctly distinguishes a real GO from a missed NO-GO.');
+    process.exit(0);
+  }
+  console.error('✗ HARNESS-QUALIFICATION FAILURE: the auditor cannot tell a pass from a miss. Fix judge().');
+  process.exit(1);
+}
+
+// concept↔Lean conformance (issue ledger #645 item 7; docs/02 §2.4): re-derive the three
+// framework concepts from the Lean skeleton and assert concepts.json matches it structurally.
+// This is the ALWAYS-ON, zero-dependency gate (no toolchain needed). It proves the JSON did not
+// drift from the declared skeleton; leanMachineCheckRow() below proves the skeleton TYPECHECKS.
+function conformanceRow() {
+  const J = (f) => JSON.parse(readFileSync(join(SCHEMA, f), 'utf8'));
+  const leanText = readFileSync(LEAN, 'utf8');
+  const r = checkConformance({ conceptsDoc: J('concepts.json'), leanText, atomsDoc: J('atoms.json') });
+  return {
+    name: 'concept-lean-conformance',
+    expect: 'CONFORM', got: r.ok ? 'CONFORM' : 'DRIFT',
+    qualified: r.ok,
+    why: r.ok ? `${r.checked.length} framework concepts match Framework.lean (structural)` : r.discrepancies.join('; '),
+  };
+}
+
+// Lean machine-check (issue ledger item 6 / #646; docs/05 §5.2): `lake build` the skeleton so the
+// conformance reference is COMPILED, not merely transcribed. This closes the #645 item-7 residual.
+// Three-valued, honest: toolchain present + builds ⇒ qualified COMPILED; present + fails ⇒ a real
+// MISS (the skeleton stopped typechecking — drift the structural check cannot see); ABSENT ⇒ SKIP,
+// qualified-but-skipped (Lean depth is purchasable, docs/05 §5.2 — it never blocks the floor, and
+// conformanceRow() still gates). `unknown` is never silently upgraded to a pass.
+function leanMachineCheckRow() {
+  const r = leanBuild(LEAN_PKG);
+  if (!r.present)
+    return { name: 'lean-skeleton-machinecheck', expect: 'COMPILED', got: 'SKIP', qualified: true, skipped: true, why: r.reason };
+  const ok = r.value === 'true';
+  return {
+    name: 'lean-skeleton-machinecheck',
+    expect: 'COMPILED', got: ok ? 'COMPILED' : 'FAILED',
+    qualified: ok,
+    why: ok
+      ? 'lake build certified lean/ExcellentCode/Framework.lean (kernel-checked, not transcribed)'
+      : `lake build FAILED — the skeleton no longer typechecks: ${r.reason}`,
+  };
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) return metaSelfTest();
+  const fixtures = discover();
+  console.log('================================================');
+  console.log('KEEL SELF-QUALIFICATION — known-bad corpus (DO-330-inspired; not a TQL credential)');
+  console.log('================================================');
+  if (!fixtures.length) {
+    console.error(`✗ no fixtures under ${CORPUS} — a self-qualifying gate with an empty corpus is theater.`);
+    process.exit(1);
+  }
+  const rows = [];
+  // ORG.selftest obligation: the framework concepts must equal their Lean definitions (structural),
+  // AND the Lean definitions must typecheck (machine-check, when the toolchain is present).
+  try { rows.push(conformanceRow()); }
+  catch (e) { rows.push({ name: 'concept-lean-conformance', expect: 'CONFORM', got: 'FAULT', qualified: false, why: `conformance harness fault — ${String(e.message)}` }); }
+  try { rows.push(leanMachineCheckRow()); }
+  catch (e) { rows.push({ name: 'lean-skeleton-machinecheck', expect: 'COMPILED', got: 'FAULT', qualified: false, why: `lean machine-check harness fault — ${String(e.message)}` }); }
+  for (const dir of fixtures) {
+    const name = dir.split('/').pop();
+    let c;
+    try { c = JSON.parse(readFileSync(join(dir, 'case.json'), 'utf8')); }
+    catch (e) { rows.push({ name, qualified: false, why: `bad case.json: ${e.message}` }); continue; }
+    const r = runFixture(dir, c);
+    const j = judge(c, r);
+    rows.push({ name, expect: c.expect_verdict, got: r.verdict, qualified: j.qualified, why: j.why });
+  }
+  console.log(`\n${'FIXTURE'.padEnd(30)}${'EXPECT'.padEnd(10)}${'GOT'.padEnd(10)}RESULT`);
+  for (const r of rows) {
+    const mark = r.skipped ? '○ skipped — ' + r.why : r.qualified ? '✓ qualified' : '✗ MISS — ' + r.why;
+    console.log(`${r.name.padEnd(30)}${String(r.expect || '').padEnd(10)}${String(r.got || '').padEnd(10)}${mark}`);
+  }
+
+  const misses = rows.filter((r) => !r.qualified);
+  const skips = rows.filter((r) => r.skipped);
+  console.log('\n================================================');
+  if (!misses.length) {
+    const passed = rows.length - skips.length;
+    const skipNote = skips.length ? ` (${skips.length} check(s) SKIPPED, not passed: ${skips.map((s) => s.name).join(', ')})` : '';
+    console.log(`✅ QUALIFIED — Keel returned the correct verdict on all ${passed} checked case(s).${skipNote}`);
+    process.exit(0);
+  }
+  console.error(`❌ NOT QUALIFIED — ${misses.length} case(s) where Keel gave the wrong verdict. A floor that`);
+  console.error(`   miscalls a planted case must not gate. Fix the engine (NEVER relax the case). Misses:`);
+  for (const m of misses) console.error(`   ✗ ${m.name} — ${m.why}`);
+  process.exit(1);
+}
+
+try { main(); }
+catch (e) {
+  console.error('\n⚠ HARNESS FAULT (not a qualification verdict): ' + String(e && e.stack ? e.stack : e));
+  process.exit(2);
+}

--- a/keel/src/run-latency.mjs
+++ b/keel/src/run-latency.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// run-latency.mjs — the latency/jitter tier front-end (aircraft axiom A5; docs/10 §10.4).
+//
+// For each `latency` scenario, runs the bound harness `samples` times (the harness emits the
+// operation's measured latency in ms on stdout), aggregates (max / p99 / jitter), and crosses the
+// aggregate against the declared budget (latency.acceptLatency). Scenario atoms compose into the
+// gate concept like the other tiers. The measurement is an empirical sensor; the decision is
+// deterministic. Measured per source version and reused on unchanged source (content-addressed, A8).
+//
+// Usage:  node src/run-latency.mjs --profile <profile.json> [--concept <id>]
+// Exit:   0 GO (every budget held) · 1 NO-GO (budget breached) / BLOCKED (unmeasured / no budget) · 2 fault.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Anchor, H } from './anchor.mjs';
+import { contentFingerprint, kleeneAll, collectAtoms } from './engine.mjs';
+import { evalConcept } from './concepts.mjs';
+import { validateProfile } from './validate.mjs';
+import { aggregateLatency, acceptLatency } from './latency.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCHEMA = join(HERE, '..', 'schema');
+const SKIP_EXIT = 77;
+const DEFAULT_SAMPLES = 5;
+const DEFAULT_TIMEOUT_MS = 600_000;
+
+const argv = process.argv.slice(2);
+const arg = (k) => { const i = argv.indexOf(k); return i >= 0 ? argv[i + 1] : undefined; };
+function has(bin) { return spawnSync('bash', ['-c', `command -v ${bin}`]).status === 0; }
+
+/** Run the harness once; return the latency sample (ms) it printed, or null (unmeasured). */
+function oneSample(harness, root) {
+  const cwd = harness.cwd ? join(root, harness.cwd) : root;
+  const r = spawnSync(harness.tool, harness.argv, { cwd, env: { ...process.env, ...harness.env }, encoding: 'utf8', timeout: harness.timeout_ms || DEFAULT_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
+  if (r.error || r.status === SKIP_EXIT || r.status !== 0) return null;
+  const n = Number((r.stdout || '').trim().split(/\s+/).pop());
+  return Number.isFinite(n) ? n : null;
+}
+
+function latencyNode(scn, root, fingerprint) {
+  const samples = scn.samples || DEFAULT_SAMPLES;
+  return {
+    kind: `lat:${scn.name}`,
+    params: { scenario: scn.name, atom: scn.atom },
+    inputs: [fingerprint, H('lat-scn/v1', { harness: { tool: scn.harness.tool, argv: scn.harness.argv, cwd: scn.harness.cwd || '', env: scn.harness.env || {} }, budget: scn.budget || null, samples })],
+    async compute() {
+      for (const bin of scn.harness.needs || []) if (!has(bin)) return { value: 'unknown', reason: `harness toolchain absent: ${bin}` };
+      const ms = [];
+      for (let i = 0; i < samples; i++) { const s = oneSample(scn.harness, root); if (s != null) ms.push(s); }
+      const agg = aggregateLatency(ms);
+      const acc = acceptLatency(agg, scn.budget);
+      return { value: acc.value, agg, reason: acc.reasons.length ? acc.reasons.join(' · ') : undefined };
+    },
+  };
+}
+
+async function main() {
+  const profilePath = arg('--profile');
+  if (!profilePath) { console.error('usage: run-latency.mjs --profile <profile.json> [--concept <id>]'); process.exit(2); }
+
+  const atomsDoc = JSON.parse(readFileSync(join(SCHEMA, 'atoms.json'), 'utf8'));
+  const conceptsDoc = JSON.parse(readFileSync(join(SCHEMA, 'concepts.json'), 'utf8'));
+  const profileSchema = JSON.parse(readFileSync(join(SCHEMA, 'profile.schema.json'), 'utf8'));
+  const profile = JSON.parse(readFileSync(profilePath, 'utf8'));
+
+  const profileErrs = validateProfile(profile, { schema: profileSchema, atomsDoc, conceptsDoc });
+  if (profileErrs.length) {
+    console.error(`⚠ PROFILE INVALID (${profileErrs.length}) — refusing to run (RESTRICTIVE; docs/03 §3.1):`);
+    for (const e of profileErrs) console.error('   · ' + e);
+    process.exit(2);
+  }
+
+  const scenarios = profile.latency || [];
+  if (!scenarios.length) { console.error('⚠ no latency scenarios declared — nothing to measure (A5). Add a profile.latency block.'); process.exit(2); }
+  for (const s of scenarios) if (!atomsDoc.atoms.find(a => a.id === s.atom)) { console.error(`latency scenario '${s.name}' binds unknown atom '${s.atom}'`); process.exit(2); }
+
+  const gateId = arg('--concept') || profile.gate_concept || 'latency_bounded';
+  const gate = conceptsDoc.concepts.find(c => c.id === gateId);
+  if (!gate) { console.error(`unknown concept '${gateId}'`); process.exit(2); }
+
+  const root = profile.target?.root || process.cwd();
+  const fingerprint = contentFingerprint(root);
+  const anchor = new Anchor(join(process.cwd(), '.keel'));
+
+  const perAtom = {};
+  const rows = [];
+  for (const scn of scenarios) {
+    const res = await anchor.evaluateAsync(latencyNode(scn, root, fingerprint));
+    const v = res.verdict || {};
+    (perAtom[scn.atom] ||= []).push(v.value);
+    rows.push({ name: scn.name, atom: scn.atom, value: v.value, agg: v.agg, reason: v.reason });
+  }
+  const atomValues = {};
+  for (const id of Object.keys(perAtom)) atomValues[id] = kleeneAll(perAtom[id]);
+  for (const id of collectAtoms(gate.formula)) if (!(id in atomValues)) atomValues[id] = 'unknown';
+  const gateRes = evalConcept(gate, atomValues);
+
+  const runId = H('latency', fingerprint, gateId, scenarios.map(s => s.name));
+  anchor.seal(runId, { tier: 'latency', gate: gateId, verdict: gateRes.verdict });
+  writeFileSync(join(anchor.dir, `latency-${runId}.json`), JSON.stringify({ schema: 'keel.latency-run/v0', run: runId, gate: gateId, verdict: gateRes.verdict, scenarios: rows }, null, 2) + '\n');
+
+  const mark = gateRes.verdict === 'true' ? 'GO' : gateRes.verdict === 'false' ? 'NO-GO' : 'BLOCKED';
+  console.log('═'.repeat(60));
+  console.log(`KEEL — latency tier (A5)  ·  gate '${gateId}'  ·  scenarios=${scenarios.length}  ·  recomputed=${anchor.recomputed} reused=${anchor.reused}`);
+  console.log('═'.repeat(60));
+  console.log(`${mark} — gate '${gateId}' = ${gateRes.verdict}  (run ${runId})`);
+  for (const r of rows) {
+    const g = r.value === 'true' ? '✓' : r.value === 'false' ? '✗' : '?';
+    const a = r.agg && r.agg.n ? `max=${r.agg.max}ms p99=${r.agg.p99}ms jitter=${r.agg.jitter}ms n=${r.agg.n}` : 'no samples';
+    console.log(`  ${g} ${r.name.padEnd(24)} atom=${r.atom}  ${a}${r.reason ? `  — ${r.reason}` : ''}`);
+  }
+  console.log('═'.repeat(60));
+  console.log(`anchor: .keel/latency-${runId}.json  ·  measurement is empirical (sensor); the budget decision is deterministic (A5)`);
+  process.exit(gateRes.verdict === 'true' ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error('⚠ RUNNER FAULT (not a verdict) — treat as NO-GO:');
+  console.error('   ' + (e && e.stack ? e.stack : e));
+  process.exit(2);
+});

--- a/keel/src/run-registry.mjs
+++ b/keel/src/run-registry.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// run-registry.mjs — run a host CI registry THROUGH the Keel authority (the wiring).
+//
+// This is the second front-end onto the shared engine (engine.mjs). It ingests a
+// `lwks.verify.registry/v0` document (e.g. logic-os-kernel's scripts/ci/registry.json),
+// maps every verifier onto a Keel atom via adapters/registry.mjs, evaluates each as a
+// content-addressed node (re-runs that touch nothing REUSE — the 171s test does not
+// re-execute on byte-identical source), composes the gate concept in three-valued logic,
+// and reports atom-COVERAGE — the honest H1 measurement of how much of the 20-atom
+// Excellent-Code space the host's CI actually exercises with evidence (unknown ≠ pass).
+//
+// Standalone: a git repo gets a fast/sound git fingerprint; anything else falls back to a
+// pure content fingerprint. No network. Identity is content, not clock.
+//
+// Usage:  node src/run-registry.mjs --registry <file> [--root <dir>] [--concept <id>] [--tier commit|nightly|release]
+// Exit:   0 GO (gate true) · 1 NO-GO/BLOCKED (gate false/unknown) · 2 runner fault.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Anchor, H, hashFile } from './anchor.mjs';
+import { composeReport, coverage, contentFingerprint, collectAtoms } from './engine.mjs';
+import { registryActivations } from './adapters/registry.mjs';
+import { symbolic, ai, renderAI } from './project.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCHEMA = join(HERE, '..', 'schema');
+const argv = process.argv.slice(2);
+const arg = (k, d) => { const i = argv.indexOf(k); return i >= 0 ? argv[i + 1] : d; };
+
+/** Sound, fast staleness fingerprint of a git working tree; null if not a git repo. */
+function gitFingerprint(root) {
+  const tree = spawnSync('git', ['-C', root, 'rev-parse', 'HEAD^{tree}'], { encoding: 'utf8' });
+  if (tree.status !== 0) return null;
+  const st = spawnSync('git', ['-C', root, 'status', '--porcelain', '--untracked-files=all'],
+    { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 });
+  // Exclude Keel's OWN output (.keel/) and build noise from the dirty set: writing the anchor
+  // would otherwise dirty the tree and change the next run's fingerprint, defeating reuse
+  // (Keel invalidating itself). These paths never constitute the code under verification.
+  const IGNORE = ['.keel/', '.git/', 'node_modules/', 'target/', '.ci-runs/'];
+  const lines = (st.stdout || '').split('\n')
+    .filter(Boolean)
+    .filter(l => !IGNORE.some(x => l.slice(3).trim().replace(/^"|"$/g, '').startsWith(x)));
+  if (!lines.length) return H('git-tree', tree.stdout.trim());
+  // working tree is dirty: fold in the porcelain status AND the content of every changed
+  // path, so any uncommitted edit changes the fingerprint (no stale reuse of a pre-edit pass).
+  const parts = ['git-tree', tree.stdout.trim(), 'dirty', lines.join('\n')];
+  for (const line of lines) {
+    let p = line.slice(3).trim();
+    if (p.includes(' -> ')) p = p.split(' -> ').pop();           // rename: hash the new path
+    p = p.replace(/^"|"$/g, '');
+    if (p) parts.push(p, hashFile(join(root, p)));
+  }
+  return H(...parts);
+}
+
+function fingerprintRoot(root) {
+  return gitFingerprint(root) || contentFingerprint(root);
+}
+
+async function main() {
+  const registryPath = arg('--registry');
+  if (!registryPath) {
+    console.error('usage: run-registry.mjs --registry <file> [--root <dir>] [--concept <id>] [--tier commit]');
+    process.exit(2);
+  }
+  const root = arg('--root', process.cwd());
+  const tier = arg('--tier', 'commit');
+  const concurrency = Number(arg('--concurrency')) || undefined; // undefined → engine default
+
+  const atomsDoc = JSON.parse(readFileSync(join(SCHEMA, 'atoms.json'), 'utf8'));
+  const conceptsDoc = JSON.parse(readFileSync(join(SCHEMA, 'concepts.json'), 'utf8'));
+  const reg = JSON.parse(readFileSync(registryPath, 'utf8'));
+
+  const gateId = arg('--concept', reg.gate_concept || 'sound');
+  const gate = conceptsDoc.concepts.find(c => c.id === gateId);
+  if (!gate) { console.error(`unknown concept '${gateId}'`); process.exit(2); }
+
+  // tier-scoped verifiers (the host's registry tiers map straight through)
+  const verifiers = (reg.verifiers || []).filter(v => (v.tier || 'commit') === tier);
+  const dockerPresent = spawnSync('bash', ['-c', '[ -S /var/run/docker.sock ]']).status === 0;
+
+  // one workspace unit, fingerprinted once: sound staleness (reuse only on identical source)
+  const fingerprint = fingerprintRoot(root);
+  const unit = { id: 'workspace', unit: 'workspace', path: root, root, fingerprint };
+
+  const { activations, unmapped } =
+    registryActivations({ ...reg, verifiers }, { atomsDoc, unit, dockerPresent });
+
+  const anchor = new Anchor(join(root, '.keel'));
+  const composed = await composeReport({ activations, gate, anchor, concurrency });
+  const cov = coverage(atomsDoc, composed.atomValues);
+  const runId = H('registry', reg.schema || 'reg', fingerprint, gateId, tier);
+
+  const report = {
+    run: runId, gate: composed.gate, atoms: composed.atoms,
+    concepts: [composed.gate], recomputed: composed.recomputed, reused: composed.reused,
+  };
+  const sym = symbolic(report);
+  const aip = ai(report, atomsDoc.atoms);
+
+  anchor.seal(runId, { gate: gateId, verdict: composed.gate.verdict, tier, coverage: cov });
+  writeFileSync(join(anchor.dir, `projection-symbolic-${runId}.json`), JSON.stringify(sym, null, 2) + '\n');
+  writeFileSync(join(anchor.dir, `projection-ai-${runId}.json`), JSON.stringify(aip, null, 2) + '\n');
+  // stable-named latest result for the host CI wrapper to consume
+  writeFileSync(join(anchor.dir, 'latest-registry.json'), JSON.stringify({
+    schema: 'keel.registry-run/v0', run: runId, root, tier, gate: gateId,
+    verdict: composed.gate.verdict, coverage: cov, crossing: composed.crossing,
+    advisories: composed.advisories.map(a => ({ source: a.source, atom: a.atom, value: a.value, role: a.role })),
+    unmapped: unmapped.map(u => u.id), ai: aip,
+  }, null, 2) + '\n');
+
+  // ── render ──
+  const bar = '═'.repeat(64);
+  console.log(bar);
+  console.log(`KEEL ⇐ registry '${reg.schema}'  ·  tier=${tier}  ·  gate='${gateId}'`);
+  console.log(`verifiers=${activations.length} mapped${unmapped.length ? ` (+${unmapped.length} UNMAPPED)` : ''}  ·  recomputed=${composed.recomputed} reused=${composed.reused}  ·  docker=${dockerPresent ? 'present' : 'absent'}`);
+  console.log(`crossing: ${composed.crossing.points} structural point(s) crossed concurrently (${composed.crossing.failed} failed, ${composed.crossing.unknown} unknown)`);
+  console.log(bar);
+  console.log(renderAI(aip));
+  if (composed.advisories.length) {
+    console.log(bar);
+    console.log(`⚠ ADVISORY (surfaced, never blocks the verdict) — ${composed.advisories.length} signal(s):`);
+    for (const a of composed.advisories)
+      console.log(`     · ${a.source || a.atom} = ${a.value}${a.role ? ` [${a.role}]` : ''}${a.reason ? ` — ${a.reason}` : ''}`);
+  }
+  console.log(bar);
+  // coverage — the H1 instrument. Covered = an atom with a DEFINITE (true|false) verdict.
+  console.log(`ATOM COVERAGE — ${cov.covered}/${cov.total} atoms exercised with evidence (${(cov.ratio * 100).toFixed(0)}%); ${cov.uncovered} unknown (unbound/tool-absent — NOT counted)`);
+  console.log(`  covered:   ${cov.covered_atoms.join(', ') || '(none)'}`);
+  console.log(`  uncovered: ${cov.uncovered_atoms.join(', ') || '(none)'}`);
+  if (unmapped.length) {
+    console.log(`  ⚠ unmapped verifiers (evidence not yet wired to an atom — mapping debt):`);
+    for (const u of unmapped) console.log(`     · ${u.id} — ${u.why}`);
+  }
+  // which gated atoms (if any) are blocking the verdict
+  const gatedUnknown = [...collectAtoms(gate.formula)].filter(a => composed.atomValues[a] === 'unknown');
+  if (composed.gate.verdict !== 'true' && gatedUnknown.length) {
+    console.log(`  gate '${gateId}' blocked-by-unknown: ${gatedUnknown.join(', ')}  (bind evidence; unknown ≠ pass)`);
+  }
+  console.log(bar);
+  console.log(`anchor: ${join(root, '.keel')}/manifest-${runId}.json  ·  latest: .keel/latest-registry.json`);
+
+  process.exit(composed.gate.verdict === 'true' ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error('⚠ RUNNER FAULT (not a verdict) — tool-qualification failure (DO-330); treat as NO-GO:');
+  console.error('   ' + (e && e.stack ? e.stack : e));
+  process.exit(2);
+});

--- a/keel/src/run-sim.mjs
+++ b/keel/src/run-sim.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// run-sim.mjs — the multi-actor simulation tier (docs/04 §4.5; axioms A1 closed-loop / A7 repeatable;
+// issue #644). The interaction surface is where atom 17 (concurrency_correctness) and atom 16
+// (idempotence) actually live, and where single-unit testing is blind.
+//
+// For each `sim` scenario, Keel ENUMERATES the order-preserving interleavings of the declared actors'
+// step sequences (the finite schedule space — the interaction analogue of the input crossing), drives
+// each interleaving through the system-under-test harness (injected as env KEEL_SCHEDULE), and crosses
+// the consistency oracle (Kleene ∧) over every interleaving. Concurrency-correct iff EVERY schedule is
+// consistent; the breaking interleaving is the race, reported by label. Harness deferred behind the
+// tool seam; unmeasured ⇒ BLOCKS (unknown ≠ pass). A fuller in-Keel linearizability oracle is a named
+// deferral — today the per-target harness embeds the consistency check (exit 0 ok / nonzero violated).
+//
+// Usage:  node src/run-sim.mjs --profile <profile.json> [--concept <id>] [--concurrency N]
+// Exit:   0 GO (every interleaving consistent) · 1 NO-GO/BLOCKED · 2 runner fault.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Anchor, H } from './anchor.mjs';
+import { contentFingerprint, kleeneAll, collectAtoms } from './engine.mjs';
+import { evalConcept } from './concepts.mjs';
+import { mapPool, defaultConcurrency } from './concurrency.mjs';
+import { validateProfile } from './validate.mjs';
+import { enumerateInterleavings, crossOracle } from './simulate.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCHEMA = join(HERE, '..', 'schema');
+const SKIP_EXIT = 77;
+const DEFAULT_TIMEOUT_MS = 600_000;
+
+const argv = process.argv.slice(2);
+const arg = (k) => { const i = argv.indexOf(k); return i >= 0 ? argv[i + 1] : undefined; };
+function has(bin) { return spawnSync('bash', ['-c', `command -v ${bin}`]).status === 0; }
+
+/** Drive ONE interleaving through the harness; oracle = exit 0 consistent · nonzero violated · 77 unknown. */
+function driveSchedule(harness, schedule, root) {
+  const env = { ...process.env, ...harness.env, KEEL_SCHEDULE: JSON.stringify(schedule.steps) };
+  const cwd = harness.cwd ? join(root, harness.cwd) : root;
+  const r = spawnSync(harness.tool, harness.argv, { cwd, env, encoding: 'utf8', timeout: harness.timeout_ms || DEFAULT_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
+  const base = { label: schedule.label, off: false };
+  if (r.error) return { ...base, value: 'unknown', reason: `harness failed to launch: ${r.error.message}` };
+  if (r.status === SKIP_EXIT) return { ...base, value: 'unknown', reason: (r.stdout || '').trim().split('\n').pop()?.replace(/^SKIP:\s*/, '') || 'harness self-skipped' };
+  return { ...base, value: r.status === 0 ? 'true' : 'false',
+    reason: r.status === 0 ? undefined : `inconsistent under this interleaving (exit ${r.status})${(r.stderr || r.stdout) ? ': ' + (r.stderr || r.stdout).trim().split('\n').pop() : ''}` };
+}
+
+function simNode(scn, root, fingerprint, concurrency) {
+  return {
+    kind: `sim-actors:${scn.name}`,
+    params: { scenario: scn.name, atom: scn.atom },
+    inputs: [fingerprint, H('sim-actors/v1', { actors: scn.actors, harness: { tool: scn.harness.tool, argv: scn.harness.argv, cwd: scn.harness.cwd || '', env: scn.harness.env || {} }, max: scn.max_interleavings || null })],
+    async compute() {
+      for (const bin of scn.harness.needs || []) if (!has(bin)) return { value: 'unknown', reason: `harness toolchain absent: ${bin}` };
+      const en = enumerateInterleavings(scn.actors, { cap: scn.max_interleavings });
+      if (en.error) return { value: 'unknown', reason: en.error };
+      const points = await mapPool(en.schedules, concurrency, async (sch) => driveSchedule(scn.harness, sch, root));
+      const safe = points.map((p, i) => p && p.__poolError ? { label: en.schedules[i].label, off: false, value: 'unknown', reason: `driver fault: ${p.__poolError.message}` } : p);
+      const oracle = crossOracle(safe);
+      return { value: oracle.value, explored: oracle.driven,
+        reason: oracle.breaking ? `race at interleaving [${oracle.breaking.label}]${oracle.breaking.reason ? ' — ' + oracle.breaking.reason : ''}` : undefined };
+    },
+  };
+}
+
+async function main() {
+  const profilePath = arg('--profile');
+  if (!profilePath) { console.error('usage: run-sim.mjs --profile <profile.json> [--concept <id>]'); process.exit(2); }
+  const concurrency = Number(arg('--concurrency')) || defaultConcurrency();
+
+  const atomsDoc = JSON.parse(readFileSync(join(SCHEMA, 'atoms.json'), 'utf8'));
+  const conceptsDoc = JSON.parse(readFileSync(join(SCHEMA, 'concepts.json'), 'utf8'));
+  const profileSchema = JSON.parse(readFileSync(join(SCHEMA, 'profile.schema.json'), 'utf8'));
+  const profile = JSON.parse(readFileSync(profilePath, 'utf8'));
+
+  const profileErrs = validateProfile(profile, { schema: profileSchema, atomsDoc, conceptsDoc });
+  if (profileErrs.length) {
+    console.error(`⚠ PROFILE INVALID (${profileErrs.length}) — refusing to run (RESTRICTIVE; docs/03 §3.1):`);
+    for (const e of profileErrs) console.error('   · ' + e);
+    process.exit(2);
+  }
+
+  const scenarios = profile.sim || [];
+  if (!scenarios.length) { console.error('⚠ no sim scenarios declared — nothing to interleave (docs/04 §4.5). Add a profile.sim block.'); process.exit(2); }
+  for (const s of scenarios) if (!atomsDoc.atoms.find(a => a.id === s.atom)) { console.error(`sim scenario '${s.name}' binds unknown atom '${s.atom}'`); process.exit(2); }
+
+  const gateId = arg('--concept') || profile.gate_concept || 'concurrent_safe';
+  const gate = conceptsDoc.concepts.find(c => c.id === gateId);
+  if (!gate) { console.error(`unknown concept '${gateId}'`); process.exit(2); }
+
+  const root = profile.target?.root || process.cwd();
+  const fingerprint = contentFingerprint(root);
+  const anchor = new Anchor(join(process.cwd(), '.keel'));
+
+  const perAtom = {};
+  const rows = [];
+  for (const scn of scenarios) {
+    const res = await anchor.evaluateAsync(simNode(scn, root, fingerprint, concurrency));
+    const v = res.verdict || {};
+    (perAtom[scn.atom] ||= []).push(v.value);
+    rows.push({ name: scn.name, atom: scn.atom, value: v.value, explored: v.explored, reason: v.reason });
+  }
+  const atomValues = {};
+  for (const id of Object.keys(perAtom)) atomValues[id] = kleeneAll(perAtom[id]);
+  for (const id of collectAtoms(gate.formula)) if (!(id in atomValues)) atomValues[id] = 'unknown';
+  const gateRes = evalConcept(gate, atomValues);
+
+  const runId = H('sim', fingerprint, gateId, scenarios.map(s => s.name));
+  anchor.seal(runId, { tier: 'sim', gate: gateId, verdict: gateRes.verdict });
+  writeFileSync(join(anchor.dir, `sim-${runId}.json`), JSON.stringify({ schema: 'keel.sim-run/v0', run: runId, gate: gateId, verdict: gateRes.verdict, scenarios: rows }, null, 2) + '\n');
+
+  const mark = gateRes.verdict === 'true' ? 'GO' : gateRes.verdict === 'false' ? 'NO-GO' : 'BLOCKED';
+  console.log('═'.repeat(60));
+  console.log(`KEEL — multi-actor sim tier  ·  gate '${gateId}'  ·  scenarios=${scenarios.length}  ·  recomputed=${anchor.recomputed} reused=${anchor.reused}`);
+  console.log('═'.repeat(60));
+  console.log(`${mark} — gate '${gateId}' = ${gateRes.verdict}  (run ${runId})`);
+  for (const r of rows) {
+    const g = r.value === 'true' ? '✓' : r.value === 'false' ? '✗' : '?';
+    console.log(`  ${g} ${r.name.padEnd(24)} atom=${r.atom}  interleavings=${r.explored ?? '—'}${r.reason ? `  — ${r.reason}` : ''}`);
+  }
+  console.log('═'.repeat(60));
+  console.log(`anchor: .keel/sim-${runId}.json  ·  Keel enumerates+crosses interleavings; the harness embeds the consistency oracle (full linearizability check = deferred)`);
+  process.exit(gateRes.verdict === 'true' ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error('⚠ RUNNER FAULT (not a verdict) — treat as NO-GO:');
+  console.error('   ' + (e && e.stack ? e.stack : e));
+  process.exit(2);
+});

--- a/keel/src/run-simulate.mjs
+++ b/keel/src/run-simulate.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// run-simulate.mjs — the input-envelope simulator front-end (docs/09; docs/04 §4.1; issue #644-adjacent).
+//
+// Treats the codebase as the airplane and plays with its sensor values. For each `simulate` scenario
+// in the profile, Keel ENUMERATES the finite input crossing (nominal→boundary→off-nominal) from the
+// declared sensor model, drives each vector through the system-under-test harness as a
+// content-addressed node (concurrent, reused on unchanged source+vector), and crosses the oracle (∧)
+// over every vector. The scenario's atom is `true` iff the oracle held on EVERY input vector; one
+// violated vector ⇒ `false` and the breaking vector is reported; an unmeasured vector ⇒ `unknown`.
+// Scenario atoms compose into the gate concept (engine.evalConcept) exactly like the static gate.
+//
+// The harness (the running system) is deferred behind the tool seam; enumeration + oracle-crossing
+// is Keel's deterministic job. Unmeasured ⇒ BLOCKS (unknown ≠ pass; docs/02 §2.6).
+//
+// Usage:  node src/run-simulate.mjs --profile <profile.json> [--concept <id>] [--concurrency N]
+// Exit:   0 GO (oracle held across every driven envelope) · 1 NO-GO/BLOCKED · 2 runner fault.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Anchor, H } from './anchor.mjs';
+import { contentFingerprint, kleeneAll, collectAtoms } from './engine.mjs';
+import { evalConcept } from './concepts.mjs';
+import { mapPool, defaultConcurrency } from './concurrency.mjs';
+import { validateProfile } from './validate.mjs';
+import { enumerateEnvelope, crossOracle, referenceFor, compareToReference, verifyReferenceSignature } from './simulate.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCHEMA = join(HERE, '..', 'schema');
+const SKIP_EXIT = 77;
+const DEFAULT_TIMEOUT_MS = 600_000;
+
+const argv = process.argv.slice(2);
+const arg = (k) => { const i = argv.indexOf(k); return i >= 0 ? argv[i + 1] : undefined; };
+function has(bin) { return spawnSync('bash', ['-c', `command -v ${bin}`]).status === 0; }
+
+/** Drive ONE input vector through the harness and apply the oracle.
+ *  Two oracle modes:
+ *   - EXIT (default): exit 0 held · nonzero violated · 77 unknown. The harness author decides
+ *     pass/fail — convenient, but intuition-based (A6 warns against trusting this for truth).
+ *   - REFERENCE (scenario has `reference`): the harness EMITS the system's output on stdout; Keel
+ *     compares it to the declared reference datum within tolerance (A6). Truth traces to the
+ *     reference data, not the harness's own judgement. No reference entry for a vector ⇒ unknown
+ *     (un-validatable, blocks) — you cannot pass an input you have no reference for. */
+function driveVector(harness, vector, root, reference) {
+  const env = { ...process.env, ...harness.env, KEEL_VECTOR: JSON.stringify(vector.values) };
+  for (const [k, v] of Object.entries(vector.values)) env[`KEEL_SENSOR_${k.toUpperCase()}`] = String(v);
+  const cwd = harness.cwd ? join(root, harness.cwd) : root;
+  const r = spawnSync(harness.tool, harness.argv, { cwd, env, encoding: 'utf8', timeout: harness.timeout_ms || DEFAULT_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
+  const base = { label: vector.label, off: vector.off };
+  if (r.error) return { ...base, value: 'unknown', reason: `harness failed to launch: ${r.error.message}` };
+  if (r.status === SKIP_EXIT) return { ...base, value: 'unknown', reason: (r.stdout || '').trim().split('\n').pop()?.replace(/^SKIP:\s*/, '') || 'harness self-skipped' };
+
+  if (reference) {
+    if (r.status !== 0) return { ...base, value: 'unknown', reason: `harness exited ${r.status} — produced no output to validate against reference` };
+    const entry = referenceFor(reference, vector.values);
+    if (!entry) return { ...base, value: 'unknown', reason: `no reference datum for this vector — cannot validate (A6: truth must trace to reference data, not intuition)` };
+    let out = (r.stdout || '').trim();
+    const asNum = Number(out);
+    if (out !== '' && !Number.isNaN(asNum)) out = asNum;
+    const v = compareToReference(out, entry.expect, reference.tolerance || 0);
+    return { ...base, value: v, reason: v === 'true' ? undefined : `output ${JSON.stringify(out)} ≠ reference ${JSON.stringify(entry.expect)} (±${reference.tolerance || 0})` };
+  }
+  return { ...base, value: r.status === 0 ? 'true' : 'false',
+    reason: r.status === 0 ? undefined : `oracle violated (exit ${r.status})${(r.stderr || r.stdout) ? ': ' + (r.stderr || r.stdout).trim().split('\n').pop() : ''}` };
+}
+
+/** A6 provenance: resolve a scenario's reference to its actual data + a content hash that TRACES to
+ *  a source (trace_to_source_data, immutable_record). `from` loads + hashes an external reference
+ *  FILE (the trusted golden artifact); inline `data` hashes the table and must carry a `source_ref`
+ *  (enforced by validate.mjs). Returns { ref, hash } or { error }. */
+function resolveReference(reference, root, trustAnchorPem) {
+  if (!reference) return { ref: null, hash: 'none', authenticated: 'n/a' };
+  if (reference.from) {
+    let rawBuf;
+    try { rawBuf = readFileSync(join(root, reference.from)); }
+    catch (e) { return { error: `reference file '${reference.from}' unreadable: ${e.message}` }; }
+    const raw = rawBuf.toString('utf8');
+    let loaded;
+    try { loaded = JSON.parse(raw); } catch { return { error: `reference file '${reference.from}' is not valid JSON` }; }
+    const data = Array.isArray(loaded) ? loaded : loaded.data;
+    if (!Array.isArray(data)) return { error: `reference file '${reference.from}' has no data array` };
+    const tolerance = reference.tolerance ?? (Array.isArray(loaded) ? 0 : loaded.tolerance) ?? 0;
+    const source_ref = reference.source_ref || (Array.isArray(loaded) ? undefined : loaded.source_ref) || reference.from;
+    // A6 AUTHENTICITY: verify a detached signature against the configured external trust anchor.
+    let authenticated = 'self_asserted';
+    if (reference.signature_file) {
+      if (!trustAnchorPem) return { error: `reference declares signature_file but profile has no trust_anchor to verify it (cannot authenticate)` };
+      let sigBuf;
+      try { sigBuf = Buffer.from(readFileSync(join(root, reference.signature_file), 'utf8').trim(), 'base64'); }
+      catch (e) { return { error: `signature file '${reference.signature_file}' unreadable: ${e.message}` }; }
+      let ok;
+      try { ok = verifyReferenceSignature(rawBuf, sigBuf, trustAnchorPem); }
+      catch (e) { return { error: `signature verification errored (malformed key/sig): ${e.message}` }; }
+      if (!ok) return { error: `reference signature INVALID — '${reference.from}' does not match its signature under the trust anchor (tampered or wrong key)` };
+      authenticated = true;
+    }
+    return { ref: { tolerance, source_ref, data }, hash: H('ref-file/v1', reference.from, raw), authenticated };
+  }
+  return { ref: reference, hash: H('ref-inline/v1', reference.data || [], reference.tolerance || 0), authenticated: 'self_asserted' };
+}
+
+/** Build a content-addressed node for one scenario: enumerate its envelope, drive every vector,
+ *  cross the oracle. The node id folds in source fingerprint + the full scenario spec + the RESOLVED
+ *  reference content hash (so a changed/edited reference invalidates the verdict — A8). */
+function scenarioNode(scn, root, fingerprint, concurrency, trustAnchorPem) {
+  const resolved = resolveReference(scn.reference, root, trustAnchorPem);
+  return {
+    kind: `sim:${scn.name}`,
+    params: { scenario: scn.name, atom: scn.atom },
+    inputs: [fingerprint, H('sim-scn/v4', { sensors: scn.sensors, harness: { tool: scn.harness.tool, argv: scn.harness.argv, cwd: scn.harness.cwd || '', env: scn.harness.env || {} }, ref_hash: resolved.hash, authenticated: resolved.authenticated, max: scn.max_vectors || null })],
+    async compute() {
+      if (resolved.error) return { value: 'unknown', reason: `reference unresolved (A6): ${resolved.error}` };
+      for (const bin of scn.harness.needs || []) if (!has(bin)) return { value: 'unknown', reason: `harness toolchain absent: ${bin}` };
+      const en = enumerateEnvelope(scn.sensors, { cap: scn.max_vectors });
+      if (en.error) return { value: 'unknown', reason: en.error };
+      const points = await mapPool(en.vectors, concurrency, async (vec) => driveVector(scn.harness, vec, root, resolved.ref));
+      const safe = points.map((p, i) => p && p.__poolError ? { label: en.vectors[i].label, off: en.vectors[i].off, value: 'unknown', reason: `driver fault: ${p.__poolError.message}` } : p);
+      const oracle = crossOracle(safe);
+      return { value: oracle.value, driven: oracle.driven, offNominal: oracle.offNominal,
+        reference: resolved.ref ? { source_ref: resolved.ref.source_ref, hash: resolved.hash, authenticated: resolved.authenticated } : undefined,
+        reason: oracle.breaking ? `broke at [${oracle.breaking.label}]${oracle.breaking.off ? ' (off-nominal)' : ''}${oracle.breaking.reason ? ' — ' + oracle.breaking.reason : ''}` : undefined };
+    },
+  };
+}
+
+async function main() {
+  const profilePath = arg('--profile');
+  if (!profilePath) { console.error('usage: run-simulate.mjs --profile <profile.json> [--concept <id>]'); process.exit(2); }
+  const concurrency = Number(arg('--concurrency')) || defaultConcurrency();
+
+  const atomsDoc = JSON.parse(readFileSync(join(SCHEMA, 'atoms.json'), 'utf8'));
+  const conceptsDoc = JSON.parse(readFileSync(join(SCHEMA, 'concepts.json'), 'utf8'));
+  const profileSchema = JSON.parse(readFileSync(join(SCHEMA, 'profile.schema.json'), 'utf8'));
+  const profile = JSON.parse(readFileSync(profilePath, 'utf8'));
+
+  const profileErrs = validateProfile(profile, { schema: profileSchema, atomsDoc, conceptsDoc });
+  if (profileErrs.length) {
+    console.error(`⚠ PROFILE INVALID (${profileErrs.length}) — refusing to run (RESTRICTIVE; docs/03 §3.1):`);
+    for (const e of profileErrs) console.error('   · ' + e);
+    process.exit(2);
+  }
+
+  const scenarios = profile.simulate || [];
+  if (!scenarios.length) { console.error('⚠ no simulate scenarios declared — nothing to drive (docs/09). Add a profile.simulate block.'); process.exit(2); }
+  for (const s of scenarios) if (!atomsDoc.atoms.find(a => a.id === s.atom)) { console.error(`simulate scenario '${s.name}' binds unknown atom '${s.atom}'`); process.exit(2); }
+
+  const gateId = arg('--concept') || profile.gate_concept || 'sound';
+  const gate = conceptsDoc.concepts.find(c => c.id === gateId);
+  if (!gate) { console.error(`unknown concept '${gateId}'`); process.exit(2); }
+
+  const root = profile.target?.root || process.cwd();
+  const fingerprint = contentFingerprint(root);
+  // A6 trust anchor: the external public key against which reference signatures are verified.
+  let trustAnchorPem = null;
+  if (profile.trust_anchor) {
+    try { trustAnchorPem = readFileSync(join(root, profile.trust_anchor), 'utf8'); }
+    catch (e) { console.error(`⚠ trust_anchor '${profile.trust_anchor}' unreadable: ${e.message}`); process.exit(2); }
+  }
+  const anchor = new Anchor(join(process.cwd(), '.keel'));
+
+  const perAtom = {};
+  const rows = [];
+  for (const scn of scenarios) {
+    const res = await anchor.evaluateAsync(scenarioNode(scn, root, fingerprint, concurrency, trustAnchorPem));
+    const v = res.verdict || {};
+    (perAtom[scn.atom] ||= []).push(v.value);
+    rows.push({ name: scn.name, atom: scn.atom, value: v.value, driven: v.driven, offNominal: v.offNominal, authenticated: v.reference?.authenticated, reason: v.reason });
+  }
+  const atomValues = {};
+  for (const id of Object.keys(perAtom)) atomValues[id] = kleeneAll(perAtom[id]);
+  for (const id of collectAtoms(gate.formula)) if (!(id in atomValues)) atomValues[id] = 'unknown';
+  const gateRes = evalConcept(gate, atomValues);
+
+  const runId = H('simulate', fingerprint, gateId, scenarios.map(s => s.name));
+  anchor.seal(runId, { tier: 'simulate', gate: gateId, verdict: gateRes.verdict });
+  writeFileSync(join(anchor.dir, `simulate-${runId}.json`), JSON.stringify({ schema: 'keel.simulate-run/v0', run: runId, gate: gateId, verdict: gateRes.verdict, scenarios: rows, atomValues }, null, 2) + '\n');
+
+  const mark = gateRes.verdict === 'true' ? 'GO' : gateRes.verdict === 'false' ? 'NO-GO' : 'BLOCKED';
+  console.log('═'.repeat(60));
+  console.log(`KEEL — input-envelope simulation  ·  gate '${gateId}'  ·  scenarios=${scenarios.length}  ·  recomputed=${anchor.recomputed} reused=${anchor.reused}`);
+  console.log('═'.repeat(60));
+  console.log(`${mark} — gate '${gateId}' = ${gateRes.verdict}  (run ${runId})`);
+  for (const r of rows) {
+    const glyph = r.value === 'true' ? '✓' : r.value === 'false' ? '✗' : '?';
+    console.log(`  ${glyph} ${r.name.padEnd(26)} atom=${r.atom}  driven=${r.driven ?? '—'} (off-nominal ${r.offNominal ?? 0})${r.reason ? `  — ${r.reason}` : ''}`);
+  }
+  console.log('═'.repeat(60));
+  console.log(`anchor: .keel/simulate-${runId}.json  ·  enumeration+oracle is Keel's; the harness (the running system) is the per-target seam`);
+  process.exit(gateRes.verdict === 'true' ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error('⚠ RUNNER FAULT (not a verdict) — treat as NO-GO:');
+  console.error('   ' + (e && e.stack ? e.stack : e));
+  process.exit(2);
+});

--- a/keel/src/run-soak.mjs
+++ b/keel/src/run-soak.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// run-soak.mjs — the endurance-tier front-end (docs/04 §4.3–4.4; issue #643).
+//
+// Loads a tailoring profile, and for each dimension the profile's `envelope.target` declares,
+// invokes the bound soak harness (a NATIVE tool that runs the escalate→bracket→revert→soak loop
+// and emits a `capacity-profile/v0` artifact on stdout) as a content-addressed node — so an
+// unchanged target reuses the (expensive) characterization. It then decides ENVELOPE-RELATIVE
+// acceptance (soak.acceptEnvelope): GO iff measured V_NO ≥ target × margin on every dimension.
+//
+// The soak loop itself is deferred behind the tool seam (compiled per-target code; docs/04 §4.2):
+// with no binding, an absent binary, or a self-skip (exit 77), the dimension is `unknown` and the
+// run BLOCKS — unknown ≠ pass (docs/02 §2.6). Keel never prices anything (§4.6).
+//
+// Usage:  node src/run-soak.mjs --profile <profile.json>
+// Exit:   0 GO (envelope held) · 1 NO-GO (shortfall) / BLOCKED (unmeasured) · 2 runner fault.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Anchor, H } from './anchor.mjs';
+import { contentFingerprint } from './engine.mjs';
+import { validateProfile } from './validate.mjs';
+import { acceptEnvelope, validateCapacityProfile } from './soak.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCHEMA = join(HERE, '..', 'schema');
+const SKIP_EXIT = 77;
+const DEFAULT_TIMEOUT_MS = 1_800_000; // soak is slow by nature (minutes–hours); generous bound
+
+const argv = process.argv.slice(2);
+const arg = (k) => { const i = argv.indexOf(k); return i >= 0 ? argv[i + 1] : undefined; };
+
+function has(bin) { return spawnSync('bash', ['-c', `command -v ${bin}`]).status === 0; }
+
+/** Build a content-addressed soak node for one dimension: run the harness, parse its
+ *  capacity-profile/v0, return { v_no } or { v_no:null, reason } (unmeasured ⇒ unknown). */
+function soakNode(dim, binding, root, fingerprint) {
+  const ev = binding?.evidence;
+  return {
+    kind: `soak:${dim}`,
+    params: { dimension: dim },
+    inputs: [fingerprint, ev ? H('soak-ev/v1', { tool: ev.tool, argv: ev.argv || [], cwd: ev.cwd || '', env: ev.env || {} }) : 'nobind'],
+    async compute() {
+      if (!ev) return { v_no: null, reason: `no soak binding for dimension '${dim}'` };
+      for (const bin of ev.needs || []) if (!has(bin)) return { v_no: null, reason: `soak harness toolchain absent: ${bin}` };
+      if (!Array.isArray(ev.argv)) return { v_no: null, reason: 'soak binding has no argv (refusing to spawn a bare tool)' };
+      const cwd = ev.cwd ? join(root, ev.cwd) : root;
+      const r = spawnSync(ev.tool, ev.argv, { cwd, env: { ...process.env, ...ev.env }, encoding: 'utf8', timeout: ev.timeout_ms || DEFAULT_TIMEOUT_MS, maxBuffer: 64 * 1024 * 1024 });
+      if (r.status === SKIP_EXIT) return { v_no: null, reason: (r.stdout || '').trim().split('\n').pop()?.replace(/^SKIP:\s*/, '') || 'soak harness self-skipped' };
+      if (r.status !== 0) return { v_no: null, reason: `soak harness '${ev.tool}' exited ${r.status} — no characterization`, log: (r.stderr || r.stdout || '').slice(-2000) };
+      let prof;
+      try { prof = JSON.parse(r.stdout); } catch { return { v_no: null, reason: 'soak harness stdout is not valid capacity-profile/v0 JSON' }; }
+      const perrs = validateCapacityProfile(prof);
+      if (perrs.length) return { v_no: null, reason: `invalid capacity-profile: ${perrs.join('; ')}` };
+      return { v_no: prof.v_no, v_ne: prof.v_ne, profile: prof };
+    },
+  };
+}
+
+async function main() {
+  const profilePath = arg('--profile');
+  if (!profilePath) { console.error('usage: run-soak.mjs --profile <profile.json>'); process.exit(2); }
+
+  const atomsDoc = JSON.parse(readFileSync(join(SCHEMA, 'atoms.json'), 'utf8'));
+  const conceptsDoc = JSON.parse(readFileSync(join(SCHEMA, 'concepts.json'), 'utf8'));
+  const profileSchema = JSON.parse(readFileSync(join(SCHEMA, 'profile.schema.json'), 'utf8'));
+  const profile = JSON.parse(readFileSync(profilePath, 'utf8'));
+
+  const profileErrs = validateProfile(profile, { schema: profileSchema, atomsDoc, conceptsDoc });
+  if (profileErrs.length) {
+    console.error(`⚠ PROFILE INVALID (${profileErrs.length}) — refusing to run (RESTRICTIVE; docs/03 §3.1):`);
+    for (const e of profileErrs) console.error('   · ' + e);
+    process.exit(2);
+  }
+
+  const envelope = profile.envelope;
+  if (!envelope || !envelope.target || !Object.keys(envelope.target).length) {
+    console.error('⚠ no envelope.target declared — the soak tier has nothing to accept against (docs/04 §4.4). Declare envelope.target in the profile.');
+    process.exit(2);
+  }
+
+  const root = profile.target?.root || process.cwd();
+  const fingerprint = contentFingerprint(root);
+  const soakBindings = profile.soak || [];
+  const bindingFor = (dim) => soakBindings.find((s) => s.dimension === dim);
+
+  const anchor = new Anchor(join(process.cwd(), '.keel'));
+  const profiles = {};
+  for (const dim of Object.keys(envelope.target)) {
+    const res = await anchor.evaluateAsync(soakNode(dim, bindingFor(dim), root, fingerprint));
+    const v = res.verdict || {};   // compute()'s return is stored under .verdict
+    profiles[dim] = v.v_no == null ? null : { v_no: v.v_no, v_ne: v.v_ne };
+  }
+
+  const decision = acceptEnvelope(profiles, envelope);
+  const runId = H('soak', fingerprint, envelope, soakBindings);
+  anchor.seal(runId, { tier: 'soak', verdict: decision.verdict, limiting: decision.limiting });
+  writeFileSync(join(anchor.dir, `soak-${runId}.json`), JSON.stringify({ schema: 'keel.soak-run/v0', run: runId, envelope, decision, profiles }, null, 2) + '\n');
+
+  const mark = decision.verdict === 'true' ? 'GO' : decision.verdict === 'false' ? 'NO-GO' : 'BLOCKED';
+  console.log('═'.repeat(60));
+  console.log(`KEEL — soak tier  ·  dimensions=${decision.dimensions.length}  ·  margin×=${envelope.margin ?? 1}  ·  recomputed=${anchor.recomputed} reused=${anchor.reused}`);
+  console.log('═'.repeat(60));
+  console.log(`${mark} — envelope ${decision.verdict === 'true' ? 'held with margin' : decision.verdict === 'false' ? 'NOT met' : 'NOT fully measured'}  (run ${runId})`);
+  for (const d of decision.dimensions) {
+    const m = d.margin == null ? '   —  ' : `${d.margin.toFixed(2)}×`;
+    const glyph = d.value === 'true' ? '✓' : d.value === 'false' ? '✗' : '?';
+    console.log(`  ${glyph} ${d.dimension.padEnd(22)} V_NO=${d.v_no ?? '—'}  required=${d.required}  margin=${m}${d.reason ? `  — ${d.reason}` : ''}`);
+  }
+  if (decision.limiting) console.log(`  limiting dimension: ${decision.limiting} (the spar that gives first)`);
+  console.log('═'.repeat(60));
+  console.log(`anchor: .keel/soak-${runId}.json  ·  Keel emits the physical characterization; cost is a downstream projection (§4.6)`);
+  process.exit(decision.verdict === 'true' ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error('⚠ RUNNER FAULT (not a verdict) — treat as NO-GO:');
+  console.error('   ' + (e && e.stack ? e.stack : e));
+  process.exit(2);
+});

--- a/keel/src/run.mjs
+++ b/keel/src/run.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+// run.mjs — the runner (the thin, swappable operational surface; docs/06 §6.4).
+//
+// Loads the restrictive ontology (schema/atoms.json, schema/concepts.json) and a
+// tailoring profile, enumerates the target's units, AUTO-ACTIVATES each atom the gate
+// concept references against each matching unit (docs/01 §1.2), composes the verdict
+// with the three-valued concept algebra, projects it for symbolic + AI consumers, and
+// seals a content-addressed manifest. No network. Identity is content, not clock.
+//
+// Usage:  node src/run.mjs --profile <profile.json> [--concept <id>]
+// Exit:   0 GO (gate true) · 1 NO-GO/BLOCKED (false/unknown) · 2 runner fault.
+
+import { readFileSync, writeFileSync, globSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Anchor, H, hashFile } from './anchor.mjs';
+import { symbolic, ai, renderAI } from './project.mjs';
+import { composeReport, contentFingerprint, collectAtoms, claimCoherence } from './engine.mjs';
+import { validateProfile } from './validate.mjs';
+import { qualifyTools } from './toolqual.mjs';
+import { verifySafetyRefs } from './safetyrefs.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCHEMA = join(HERE, '..', 'schema');
+
+const argv = process.argv.slice(2);
+const arg = (k) => { const i = argv.indexOf(k); return i >= 0 ? argv[i + 1] : undefined; };
+
+/** Enumerate units per the profile's discovery rules. */
+function discoverUnits(profile, root) {
+  const units = [];
+  for (const rule of profile.units) {
+    const d = rule.discover;
+    if (d.type === 'literal') {
+      for (const v of d.values || []) {
+        const path = v === '.' ? root : join(root, v);
+        units.push({ id: v, unit: rule.unit, path, root: path });
+      }
+    } else if (d.type === 'manifest' || d.type === 'glob') {
+      for (const m of globSync(d.pattern, { cwd: root })) {
+        const isManifest = d.type === 'manifest';
+        const unitDir = isManifest ? dirname(m) : m;
+        units.push({
+          id: unitDir, unit: rule.unit,
+          path: join(root, unitDir), root: join(root, unitDir),
+          manifest: isManifest ? join(root, m) : undefined,
+        });
+      }
+    }
+  }
+  return units;
+}
+
+async function main() {
+  const profilePath = arg('--profile');
+  if (!profilePath) { console.error('usage: run.mjs --profile <profile.json> [--concept <id>] [--concurrency N]'); process.exit(2); }
+  const concurrency = Number(arg('--concurrency')) || undefined;
+
+  const atomsDoc = JSON.parse(readFileSync(join(SCHEMA, 'atoms.json'), 'utf8'));
+  const conceptsDoc = JSON.parse(readFileSync(join(SCHEMA, 'concepts.json'), 'utf8'));
+  const profileSchema = JSON.parse(readFileSync(join(SCHEMA, 'profile.schema.json'), 'utf8'));
+  const profile = JSON.parse(readFileSync(profilePath, 'utf8'));
+
+  // RESTRICTIVE load gate (#648 item 1): validate the fill before any run. A malformed
+  // profile is refused as a runner fault (exit 2), never silently half-honoured (docs/03).
+  const profileErrs = validateProfile(profile, { schema: profileSchema, atomsDoc, conceptsDoc });
+  if (profileErrs.length) {
+    console.error(`⚠ PROFILE INVALID (${profileErrs.length}) — refusing to run (RESTRICTIVE; docs/03 §3.1):`);
+    for (const e of profileErrs) console.error('   · ' + e);
+    process.exit(2);
+  }
+
+  const root = profile.target?.root || process.cwd();
+
+  // EXECUTABLE tool qualification (Open Risk #2, docs/15 §15.4): a safety_case's evidence tools
+  // claim trustworthiness; here Keel RUNS each declared fixture (planted defect it must flag +
+  // clean input it must pass). A tool that fails its own fixture cannot be trusted to catch what
+  // it claims — NO-GO. Skipped tools (no fixture / toolchain absent) are surfaced, never a pass;
+  // whether a fixture was REQUIRED is enforced at validation (self-qualified under high intent).
+  if (profile.safety_case) {
+    const tqRows = qualifyTools(profile.safety_case, { cwd: root });
+    const failed = tqRows.filter((r) => r.ok === false);
+    if (failed.length) {
+      console.error('═'.repeat(60));
+      console.error(`⛔ NO-GO — TOOL QUALIFICATION FAILED: ${failed.length} evidence tool(s) did not pass their own fixture:`);
+      for (const r of failed) console.error(`     · ${r.tool} — ${r.why}`);
+      console.error(`   A tool that cannot demonstrate it catches defects must not produce gating evidence. (tool unqualified ⇒ NO-GO)`);
+      console.error('═'.repeat(60));
+      process.exit(1);
+    }
+    for (const r of tqRows.filter((x) => x.skipped)) console.log(`○ tool-qualification SKIPPED (not a pass): ${r.tool} — ${r.why}`);
+
+    // REFERENCE VERIFICATION (Open Risk #1, docs/15 §15.4): a safety-case reference must RESOLVE —
+    // exist (under high intent), match its declared content hash, and (if signed) verify against the
+    // trust anchor. A string ref pointing at nothing/altered/forged content is NO-GO.
+    const intent = profile.safety_case.certification_intent || 'none';
+    const highIntent = intent === 'internal-assurance' || intent === 'certification-support';
+    const refRows = verifySafetyRefs(profile.safety_case, { root, highIntent });
+    const refFailed = refRows.filter((r) => r.ok === false);
+    if (refFailed.length) {
+      console.error('═'.repeat(60));
+      console.error(`⛔ NO-GO — SAFETY-CASE REFERENCE(S) UNVERIFIED: ${refFailed.length} reference(s) did not resolve:`);
+      for (const r of refFailed) console.error(`     · ${r.key} — ${r.why}`);
+      console.error(`   A safety-case reference must point at real, unaltered, attested evidence. (unresolved reference ⇒ NO-GO)`);
+      console.error('═'.repeat(60));
+      process.exit(1);
+    }
+  }
+
+  const gateId = arg('--concept') || profile.gate_concept || 'sound';
+  const gate = conceptsDoc.concepts.find(c => c.id === gateId);
+  if (!gate) { console.error(`unknown concept '${gateId}'`); process.exit(2); }
+
+  const units = discoverUnits(profile, root);
+  // pre-compute each unit's content fingerprint once (drives staleness; docs/01 §1.3)
+  for (const u of units) u.fingerprint = u.manifest ? hashFile(u.manifest) : contentFingerprint(u.path);
+
+  // assurance_claim (docs/09): the concept the profile ASSERTS it meets. Its atoms are activated
+  // and evaluated alongside the enforced gate, so an honest claim can be demonstrated — and a claim
+  // that outruns its evidence is BLOCKED below (claim-coherence). Defaults to the gate concept.
+  const claimId = profile.assurance_claim || null;
+  const claim = claimId ? conceptsDoc.concepts.find(c => c.id === claimId) : null;
+  if (claimId && !claim) { console.error(`unknown assurance_claim concept '${claimId}'`); process.exit(2); }
+  const atomIds = new Set([...collectAtoms(gate.formula), ...(claim ? collectAtoms(claim.formula) : [])]);
+
+  const anchor = new Anchor(join(process.cwd(), '.keel'));
+  const activations = profileActivations(profile, units, atomsDoc, atomIds);
+  const composed = await composeReport({ activations, gate, anchor, concurrency, thresholds: profile.thresholds || {}, policy: profile.execution_policy || null });
+  const gateRes = composed.gate;
+
+  // CLAIM-COHERENCE GATE: you may claim only what you demonstrated (docs/09). Fires only when a
+  // claim is asserted; blocks on the gap between assertion and evidence, never on un-claimed unknowns.
+  let claimVerdict = null;
+  if (claim) {
+    claimVerdict = claimCoherence(claim.formula, composed.atomValues);
+    // REFUTED: the claimed concept's evidence is FALSE. The claim is disproven, not merely
+    // unproven — measured ≠ demonstrated (Open Risk #4). A refuted claim is NO-GO even when the
+    // narrow enforced gate would pass.
+    if (claimVerdict.refuted) {
+      console.error('═'.repeat(60));
+      console.error(`⛔ NO-GO — CLAIM REFUTED: profile asserts '${claimId}', but the evidence DISPROVES it:`);
+      for (const a of claimVerdict.refutingAtoms) console.error(`     · ${a} = false (measured and failed)`);
+      console.error(`   A claimed concept whose evidence is FALSE is refuted — "measured" is not "demonstrated". (claim refuted ⇒ NO-GO)`);
+      console.error('═'.repeat(60));
+      process.exit(1);
+    }
+    // UNDEMONSTRATED: the claim outran its evidence (a claimed atom is unrun/unbound ⇒ unknown).
+    if (!claimVerdict.coherent) {
+      console.error('═'.repeat(60));
+      console.error(`⛔ CLAIM NOT DEMONSTRATED — profile asserts '${claimId}' but ${claimVerdict.undemonstrated.length} atom(s) have NO evidence (unrun/unbound):`);
+      for (const a of claimVerdict.undemonstrated) console.error(`     · ${a} = ${composed.atomValues[a] || 'unknown'}`);
+      console.error(`   A claim that outruns its evidence is overclaim. Demonstrate these atoms or drop the claim to one you can prove. (claim ≠ evidence ⇒ NO-GO)`);
+      console.error('═'.repeat(60));
+      process.exit(1);
+    }
+  }
+  const runId = H(units.map(u => [u.id, u.fingerprint]), gateId, claimId || '');
+  const report = {
+    run: runId, gate: gateRes, atoms: composed.atoms,
+    concepts: [gateRes], recomputed: composed.recomputed, reused: composed.reused,
+  };
+
+  const sym = symbolic(report);
+  const aip = ai(report, atomsDoc.atoms);
+  const { manifest } = anchor.seal(runId, { gate: gateId, verdict: gateRes.verdict });
+  writeFileSync(join(anchor.dir, `projection-symbolic-${runId}.json`), JSON.stringify(sym, null, 2) + '\n');
+  writeFileSync(join(anchor.dir, `projection-ai-${runId}.json`), JSON.stringify(aip, null, 2) + '\n');
+  void manifest;
+
+  console.log('═'.repeat(60));
+  console.log(`KEEL — gate '${gateId}'  ·  units=${units.length}  ·  recomputed=${anchor.recomputed} reused=${anchor.reused}`);
+  console.log(`crossing: ${composed.crossing.points} structural point(s) crossed concurrently (${composed.crossing.failed} failed, ${composed.crossing.unknown} unknown)`);
+  console.log('═'.repeat(60));
+  console.log(renderAI(aip));
+  if (composed.advisories.length) {
+    console.log('═'.repeat(60));
+    console.log(`⚠ ADVISORY (surfaced, never blocks) — ${composed.advisories.length} signal(s)`);
+    for (const a of composed.advisories)
+      console.log(`     · ${a.source || a.atom} = ${a.value}${a.reason ? ` — ${a.reason}` : ''}`);
+  }
+  if (claim) {
+    console.log('═'.repeat(60));
+    console.log(`✓ claim '${claimId}' DEMONSTRATED — its formula HOLDS on the evidence (all ${claimVerdict.claimedAtoms.length} claimed atom(s) measured true; claim = evidence).`);
+  }
+  console.log('═'.repeat(60));
+  console.log(`anchor: .keel/manifest-${runId}.json  ·  projections: .keel/projection-{symbolic,ai}-${runId}.json  (all ${report.atoms.length} atom evals in symbolic)`);
+  process.exit(gateRes.verdict === 'true' ? 0 : 1);
+}
+
+/** Profile front-end: enumerate (atom,unit) activations for the given atom-id set (the union of the
+ *  gate concept's atoms and any assurance_claim's atoms). */
+export function profileActivations(profile, units, atomsDoc, atomIds) {
+  const atomDef = (id) => atomsDoc.atoms.find(a => a.id === id);
+  const bindingFor = (id, unit) =>
+    (profile.bindings || []).find(b => b.atom === id && (!b.unit || b.unit === unit.unit));
+  const acts = [];
+  for (const id of atomIds) {
+    const def = atomDef(id);
+    if (!def) continue; // unbound in the ontology => composeReport fills it unknown
+    const matching = units.filter(u => u.unit === (bindingFor(id, u)?.unit || def.unit));
+    for (const u of matching) acts.push({ atomId: id, atomDef: def, binding: bindingFor(id, u), unit: u });
+  }
+  return acts;
+}
+
+main().catch((e) => {
+  console.error('⚠ RUNNER FAULT (not a verdict) — tool-qualification failure (DO-330); treat as NO-GO:');
+  console.error('   ' + (e && e.stack ? e.stack : e));
+  process.exit(2);
+});

--- a/keel/src/safetyrefs.mjs
+++ b/keel/src/safetyrefs.mjs
@@ -1,0 +1,72 @@
+// safetyrefs.mjs — safety-case reference verification (Open Risk #1, docs/15 §15.4).
+//
+// safety_case references were bare strings: 'docs/safety/plan.md' could point at NOTHING, or at a
+// file silently altered after review, and the gate never noticed. A gating reference must resolve.
+// Here a reference is checked three ways, reusing the A6 machinery (file bytes + ed25519, builtins
+// only):
+//   EXISTENCE — under high intent the file must exist (a required artifact that is absent is a hole).
+//   HASH      — when reference_integrity[key].hash is declared, sha256(file) must match (no drift).
+//   SIGNATURE — when reference_integrity[key].signature_file is declared, a detached ed25519
+//               signature over the file bytes must verify against trust_anchor.public_key_file
+//               (attested OUTSIDE the AI authoring loop; a signature with no anchor cannot be trusted).
+// A failure is NO-GO (run.mjs). Absence of an integrity spec under low intent ⇒ skipped, never a pass.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { verifyReferenceSignature } from './simulate.mjs';
+
+// The gating reference fields and how to read each from the safety_case (flat + nested).
+const REF_PATHS = {
+  safety_plan_ref: (sc) => sc.safety_plan_ref,
+  hazard_analysis_ref: (sc) => sc.hazard_analysis_ref,
+  requirements_traceability_ref: (sc) => sc.requirements_traceability_ref,
+  verification_plan_ref: (sc) => sc.verification_plan_ref,
+  configuration_index_ref: (sc) => sc.configuration_index_ref,
+  independence_evidence_ref: (sc) => sc.independence?.evidence_ref,
+  structural_coverage_source_ref: (sc) => sc.structural_coverage?.source_ref,
+};
+
+export const REFERENCE_KEYS = Object.keys(REF_PATHS);
+
+function safeRead(p, enc) { try { return readFileSync(p, enc); } catch { return null; } }
+
+/**
+ * Verify a safety_case's references against the target tree.
+ * Returns one row per declared reference: { key, ok, skipped, why }.
+ *   ok === false → NO-GO (missing/mismatched/forged); ok === true → resolved + verified;
+ *   skipped === true → not checked (low intent, no integrity spec) — surfaced, never a pass.
+ */
+export function verifySafetyRefs(sc, { root = '.', highIntent = false } = {}) {
+  if (!sc) return [];
+  const integ = sc.reference_integrity || {};
+  const anchorPem = sc.trust_anchor?.public_key_file
+    ? safeRead(join(root, sc.trust_anchor.public_key_file), 'utf8') : null;
+  const rows = [];
+  for (const [key, get] of Object.entries(REF_PATHS)) {
+    const rel = get(sc);
+    if (rel == null) continue;                 // reference not declared
+    const spec = integ[key];
+    const abs = join(root, rel);
+    if (!existsSync(abs)) {
+      if (highIntent || spec) rows.push({ key, ok: false, why: `referenced file does not exist: ${rel}` });
+      else rows.push({ key, ok: null, skipped: true, why: `ref not checked (low intent, no integrity spec): ${rel}` });
+      continue;
+    }
+    const buf = readFileSync(abs);
+    if (spec?.hash) {
+      const got = createHash('sha256').update(buf).digest('hex');
+      if (got !== spec.hash) { rows.push({ key, ok: false, why: `content hash mismatch for ${rel}: declared ${spec.hash.slice(0, 16)}…, actual ${got.slice(0, 16)}… (reference altered after it was recorded)` }); continue; }
+    }
+    if (spec?.signature_file) {
+      if (!anchorPem) { rows.push({ key, ok: false, why: `signature declared for ${rel} but no trust_anchor.public_key_file to verify it against (an unverifiable signature is not trust)` }); continue; }
+      const sig = safeRead(join(root, spec.signature_file));
+      if (!sig) { rows.push({ key, ok: false, why: `signature file missing: ${spec.signature_file}` }); continue; }
+      let valid = false;
+      try { valid = verifyReferenceSignature(buf, sig, anchorPem); } catch { valid = false; }
+      if (!valid) { rows.push({ key, ok: false, why: `invalid signature for ${rel} — not attested by the trust anchor` }); continue; }
+    }
+    rows.push({ key, ok: true, why: spec ? 'reference exists and integrity verified' : 'reference exists (self-asserted; no integrity spec)' });
+  }
+  return rows;
+}

--- a/keel/src/selftest.mjs
+++ b/keel/src/selftest.mjs
@@ -1,0 +1,445 @@
+#!/usr/bin/env node
+// selftest.mjs — deterministic qualification of the concept algebra (docs/05 §5.3,
+// in miniature). It is BOTH a test (exit 0/1) and the evidence that instantiates
+// `testability_falsifiability` for Keel's self-hosting profile: a falsifiable claim,
+// mechanically checked. A precursor to the full ORG.selftest against known-bad
+// fixtures (issue ledger).
+
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { evalFormula, evalConcept, atomsOf } from './concepts.mjs';
+import { Anchor, H, stableStringify } from './anchor.mjs';
+import { atomNode, unitFingerprint, policyEnv } from './atoms.mjs';
+import { mapPool, singleFlight } from './concurrency.mjs';
+import { validate, validateProfile } from './validate.mjs';
+import { crossGraded, claimCoherence } from './engine.mjs';
+import { qualifyTools } from './toolqual.mjs';
+import { verifySafetyRefs } from './safetyrefs.mjs';
+import { signSeal, verifySealSig } from './sign.mjs';
+import { verifyChain } from './verify-seal.mjs';
+import { acceptEnvelope, validateCapacityProfile } from './soak.mjs';
+import { enumerateEnvelope, crossOracle, referenceFor, compareToReference, enumerateInterleavings, verifyReferenceSignature } from './simulate.mjs';
+import { generateKeyPairSync, sign as cryptoSign, createHash as shaHash } from 'node:crypto';
+import { aggregateLatency, acceptLatency } from './latency.mjs';
+import { checkConformance } from './conformance.mjs';
+import { leanProofNode, proofFingerprint } from './adapters/lean.mjs';
+
+let fails = 0;
+const eq = (got, want, msg) => {
+  const g = stableStringify(got), w = stableStringify(want);
+  if (g !== w) { console.error(`FAIL ${msg}: got ${g}, want ${w}`); fails++; }
+};
+const ne = (a, b, msg) => {
+  if (stableStringify(a) === stableStringify(b)) { console.error(`FAIL ${msg}: expected DIFFERENT, both ${stableStringify(a)}`); fails++; }
+};
+
+// Kleene three-valued truth tables (docs/02 §2.6)
+eq(evalFormula({ all: ['a', 'b'] }, { a: 'true', b: 'true' }), 'true', 'all true');
+eq(evalFormula({ all: ['a', 'b'] }, { a: 'true', b: 'false' }), 'false', 'all: false dominates');
+eq(evalFormula({ all: ['a', 'b'] }, { a: 'true', b: 'unknown' }), 'unknown', 'all: unknown when no false');
+eq(evalFormula({ any: ['a', 'b'] }, { a: 'false', b: 'true' }), 'true', 'any: true dominates');
+eq(evalFormula({ any: ['a', 'b'] }, { a: 'false', b: 'unknown' }), 'unknown', 'any: unknown when no true');
+eq(evalFormula({ any: ['a', 'b'] }, { a: 'false', b: 'false' }), 'false', 'any all false');
+eq(evalFormula({ not: 'a' }, { a: 'true' }), 'false', 'not true');
+eq(evalFormula({ not: 'a' }, { a: 'unknown' }), 'unknown', 'not unknown');
+
+// unknown ≠ pass: a gated concept over a missing atom is unknown, never true
+eq(evalFormula({ all: ['a'] }, {}), 'unknown', 'missing atom => unknown (never silently true)');
+
+// Hallucinated = ¬CoreGroundedCorrect, computed not judged
+const halluc = { id: 'Hallucinated', formula: { not: { all: ['referential_truth', 'type_soundness', 'totality_or_controlled_partiality', 'specification_fidelity'] } } };
+eq(evalConcept(halluc, { referential_truth: 'false', type_soundness: 'true', totality_or_controlled_partiality: 'true', specification_fidelity: 'true' }).verdict,
+   'true', 'unresolved symbol => Hallucinated=true');
+
+// atomsOf collects references
+eq([...atomsOf({ all: ['x', { not: 'y' }] })].sort(), ['x', 'y'], 'atomsOf');
+
+// hashing is deterministic and order-insensitive for object keys
+eq(H({ a: 1, b: 2 }) === H({ b: 2, a: 1 }), true, 'stable hash (key order)');
+
+// ── node-id injectivity (C1/C2/C3 regression guard): materially-different evidence MUST get
+// different node ids, or a broken/advisory verdict can be reused for a passing one. ──
+const A = new Anchor(join(tmpdir(), 'keel-selftest-' + process.pid));
+const nid = (binding, meta) => { const n = atomNode({ id: 'referential_truth' }, binding, { id: 'u', root: '.', fingerprint: 'fp' }, meta); return A.nodeId(n.kind, n.params, n.inputs); };
+const bind = (ev) => ({ atom: 'referential_truth', evidence: ev });
+const base = bind({ tool: 'bash', argv: ['-c', 'true'] });
+ne(nid(base), nid(bind({ tool: 'bash', argv: ['-c true'] })), 'argv element boundaries change the id (C1)');
+ne(nid(base), nid(bind({ tool: 'bash', argv: ['-c', 'true'], cwd: 'x' })), 'cwd changes the id (C2)');
+ne(nid(base), nid(bind({ tool: 'bash', argv: ['-c', 'true'], env: { K: '1' } })), 'env changes the id (C2)');
+ne(nid(base, { source: 'V1' }), nid(base, { source: 'V2' }), 'distinct verifier sources are distinct nodes (C3)');
+ne(nid(base, { source: 'V', advisory: true }), nid(base, { source: 'V', advisory: false }), 'advisory channel is namespaced from gated (C3)');
+eq(nid(base, { source: 'V' }) === nid(base, { source: 'V' }), true, 'identical evidence+source ⇒ identical id (reuse still works)');
+
+// ── profile load gate (#648 item 1): the RESTRICTIVE validator must reject malformed fills ──
+const SCHEMA_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'schema');
+const J = (f) => JSON.parse(readFileSync(join(SCHEMA_DIR, f), 'utf8'));
+const pSchema = J('profile.schema.json'), pAtoms = J('atoms.json'), pConcepts = J('concepts.json');
+const ctx = { schema: pSchema, atomsDoc: pAtoms, conceptsDoc: pConcepts };
+// the validator must accept a known-good fill: the live self-hosting profile (if present) must pass
+const goodProfile = {
+  target: { name: 't', root: '.', ecosystem: 'rust' },
+  units: [{ unit: 'crate', discover: { type: 'literal', values: ['.'] } }],
+  bindings: [{ atom: 'referential_truth', evidence: { tool: 'bash', argv: ['-c', 'true'], ok_when: 'exit==0' } }],
+  gate_concept: 'sound',
+  thresholds: { boundary_completeness: 0.8 },
+};
+eq(validateProfile(goodProfile, ctx), [], 'valid profile passes the load gate');
+// structural rejections
+const hasErr = (p, needle, msg) => eq(validateProfile(p, ctx).some((e) => e.includes(needle)), true, msg);
+hasErr({ ...goodProfile, surprise: 1 }, 'unexpected property', 'extra top-level key rejected (additionalProperties:false)');
+hasErr({ units: goodProfile.units, bindings: [], gate_concept: 'sound' }, "missing required 'target'", 'missing required field rejected');
+hasErr({ ...goodProfile, target: { name: 't', ecosystem: 'cobol' } }, 'not one of', 'bad enum value rejected');
+hasErr({ ...goodProfile, thresholds: { boundary_completeness: 1.5 } }, 'maximum', 'out-of-range threshold rejected');
+// referential rejections (the JSON-Schema cannot express these)
+hasErr({ ...goodProfile, bindings: [{ atom: 'no_such_atom', evidence: { tool: 'x', argv: [], ok_when: 'exit==0' } }] }, 'not a known atom', 'binding to a nonexistent atom rejected');
+hasErr({ ...goodProfile, gate_concept: 'no_such_concept' }, 'not a known concept', 'unknown gate_concept rejected');
+hasErr({ ...goodProfile, thresholds: { referential_truth: 0.5 } }, 'BOOLEAN atom', 'threshold on a boolean atom rejected');
+// generic validator: enum + range basics
+eq(validate('a', { enum: ['a', 'b'] }), [], 'generic validate: enum member passes');
+eq(validate(3, { type: 'number', maximum: 2 }).length, 1, 'generic validate: maximum violated');
+
+// ── graded-atom threshold crossing (#648 item 8, docs/02 §2.5) ──
+eq(crossGraded(0.92, 0.8), 'true', 'graded: score >= threshold => true');
+eq(crossGraded(0.8, 0.8), 'true', 'graded: score == threshold => true (inclusive)');
+eq(crossGraded(0.6, 0.8), 'false', 'graded: score < threshold => false');
+eq(crossGraded(0.92, undefined), 'unknown', 'graded: no threshold => unknown (auditor must set the bar; blocks, never passes)');
+eq(crossGraded(null, 0.8), 'unknown', 'graded: no score => unknown (no measurement)');
+eq(crossGraded(NaN, 0.8), 'unknown', 'graded: NaN score => unknown');
+
+// ── soak: envelope-relative acceptance (#643, docs/04 §4.4) ──
+const env2 = { target: { calls_per_sec: 2000, inferences_per_sec: 50 }, margin: 1.5 };
+// both dimensions hold with margin (3000 >= 2000×1.5; 80 >= 50×1.5=75) => GO
+eq(acceptEnvelope({ calls_per_sec: { v_no: 3000 }, inferences_per_sec: { v_no: 80 } }, env2).verdict, 'true', 'soak: V_NO ≥ target×margin on all dims => GO');
+// inferences short (70 < 75) => NO-GO, limiting = inferences
+const shortfall = acceptEnvelope({ calls_per_sec: { v_no: 3000 }, inferences_per_sec: { v_no: 70 } }, env2);
+eq(shortfall.verdict, 'false', 'soak: one dim below target×margin => NO-GO');
+eq(shortfall.limiting, 'inferences_per_sec', 'soak: limiting dimension = smallest margin (the spar that gives first)');
+// a dimension with no measurement => unknown (BLOCKS, never pass)
+eq(acceptEnvelope({ calls_per_sec: { v_no: 3000 }, inferences_per_sec: null }, env2).verdict, 'unknown', 'soak: unmeasured dim => unknown (unknown ≠ pass)');
+// no target dimensions => unknown (nothing to accept against)
+eq(acceptEnvelope({}, { target: {} }).verdict, 'unknown', 'soak: empty envelope => unknown');
+// capacity-profile/v0 validation
+eq(validateCapacityProfile({ schema: 'capacity-profile/v0', dimension: 'd', v_no: 48, v_ne: 71 }), [], 'capacity-profile: well-formed passes');
+eq(validateCapacityProfile({ schema: 'wrong', dimension: 'd', v_no: 48 }).length >= 1, true, 'capacity-profile: wrong schema rejected');
+eq(validateCapacityProfile({ schema: 'capacity-profile/v0', dimension: 'd', v_no: 50, v_ne: 40 }).length >= 1, true, 'capacity-profile: v_ne < v_no rejected');
+
+// ── claim-coherence: the punishing gate — claim must equal evidence (docs/09) ──
+const claimF = { all: ['referential_truth', 'testability_falsifiability'] };
+eq(claimCoherence(claimF, { referential_truth: 'true', testability_falsifiability: 'true' }).coherent, true, 'claim: all claimed atoms demonstrated (formula holds) => coherent');
+// Open Risk #4: a claimed atom measured FALSE breaks the claim's formula. "Measured" is NOT
+// "demonstrated" — the claim is REFUTED, not coherent. (The old selftest asserted the bug: it
+// called a false-atom claim "coherent" because evidence existed, which let a refuted claim be
+// reported as demonstrated whenever the claim was broader than the enforced gate.)
+const refuted = claimCoherence(claimF, { referential_truth: 'true', testability_falsifiability: 'false' });
+eq(refuted.coherent, false, 'claim: a claimed atom measured FALSE => NOT coherent (claim refuted, not demonstrated)');
+eq(refuted.refuted, true, 'claim: false claimed atom => refuted=true (evidence disproves the claim)');
+eq(refuted.refutingAtoms, ['testability_falsifiability'], 'claim: names the refuting atom');
+const overreach = claimCoherence(claimF, { referential_truth: 'true' }); // testability unknown/unrun
+eq(overreach.coherent, false, 'claim: an unrun claimed atom => INCOHERENT (overclaim blocks)');
+eq(overreach.refuted, false, 'claim: an UNKNOWN claimed atom is undemonstrated, NOT refuted (distinct honest failure)');
+eq(overreach.undemonstrated, ['testability_falsifiability'], 'claim: names the undemonstrated atom');
+
+// ── input-envelope enumeration + oracle crossing (the simulator; docs/09) ──
+const env3 = enumerateEnvelope([{ name: 'n', values: [1, 2] }, { name: 'flag', values: [true] }]);
+eq(env3.vectors.length, 2, 'enumerate: Cartesian product size (2×1)');
+eq(env3.vectors[0].values, { flag: true, n: 1 }, 'enumerate: deterministic vector (sensors sorted by name)');
+// numeric range adds boundaries + off-nominal probes (lo,hi,lo-step,hi+step)
+const rng = enumerateEnvelope([{ name: 'x', range: [0, 10] }]);
+eq(rng.vectors.length, 4, 'enumerate: range yields lo,hi + 2 off-nominal probes');
+eq(rng.vectors.some(v => v.off), true, 'enumerate: off-nominal probes flagged');
+// cap is honest, never silent
+eq(typeof enumerateEnvelope([{ name: 'a', values: [1, 2, 3] }, { name: 'b', values: [1, 2] }], { cap: 4 }).error, 'string', 'enumerate: exceeding the cap BLOCKS (no silent sampling)');
+// oracle crossing: one violated vector dominates and is reported as the breaking point
+eq(crossOracle([{ label: 'a', value: 'true', off: false }, { label: 'b', value: 'true', off: false }]).value, 'true', 'oracle: all hold => true');
+const broke = crossOracle([{ label: 'nominal', value: 'true', off: false }, { label: 'x=11', value: 'false', off: true, reason: 'panic' }]);
+eq(broke.value, 'false', 'oracle: one violated vector => false');
+eq(broke.breaking.label, 'x=11', 'oracle: reports the breaking input vector');
+eq(crossOracle([{ label: 'a', value: 'true', off: false }, { label: 'b', value: 'unknown', off: false }]).value, 'unknown', 'oracle: unmeasured vector => unknown (never silent pass)');
+
+// ── A6: reference-data oracle (truth traces to data, not intuition; docs/10) ──
+const ref = { tolerance: 0.5, data: [{ when: { x: 1 }, expect: 10 }, { when: { x: 2 }, expect: 20 }] };
+eq(referenceFor(ref, { x: 2 }).expect, 20, 'reference: matches the vector to its datum');
+eq(referenceFor(ref, { x: 9 }), null, 'reference: no datum for an unlisted vector (=> unknown, blocks)');
+eq(compareToReference(10.3, 10, 0.5), 'true', 'reference: within tolerance => true');
+eq(compareToReference(11, 10, 0.5), 'false', 'reference: beyond tolerance => false (regression caught by data)');
+eq(compareToReference('ok', 'ok'), 'true', 'reference: non-numeric strict-equal => true');
+eq(compareToReference('bad', 'ok'), 'false', 'reference: non-numeric mismatch => false');
+// A6 provenance: an inline reference with no source_ref is untraceable => refused at validation
+const simProf = { ...goodProfile, simulate: [{ name: 's', atom: 'specification_fidelity', sensors: [{ name: 'x', values: [1] }], harness: { tool: 'bash', argv: ['-c', 'echo 1'] }, reference: { data: [{ when: { x: 1 }, expect: 1 }] } }] };
+eq(validateProfile(simProf, ctx).some(e => e.includes('untraceable')), true, 'A6: inline reference without source_ref is refused (truth must trace to a source)');
+const simOk = { ...simProf, simulate: [{ ...simProf.simulate[0], reference: { source_ref: 'golden f(x)=x', data: [{ when: { x: 1 }, expect: 1 }] } }] };
+eq(validateProfile(simOk, ctx).some(e => e.includes('untraceable')), false, 'A6: inline reference WITH source_ref is accepted');
+
+// ── A5: latency aggregation + budget acceptance (docs/10) ──
+const agg = aggregateLatency([12, 10, 11, 14, 10]);
+eq([agg.max, agg.min, agg.jitter, agg.p99], [14, 10, 4, 14], 'latency: max/min/jitter/p99 aggregation');
+eq(acceptLatency(agg, { max_ms: 20, jitter_ms: 5 }).value, 'true', 'latency: within budget => true');
+eq(acceptLatency(agg, { max_ms: 13 }).value, 'false', 'latency: max over budget => false');
+eq(acceptLatency(agg, { jitter_ms: 3 }).value, 'false', 'latency: jitter over budget => false');
+eq(acceptLatency({ n: 0 }, { max_ms: 20 }).value, 'unknown', 'latency: no samples => unknown (blocks)');
+eq(acceptLatency(agg, {}).value, 'unknown', 'latency: no budget bound => unknown (cannot gate on uncited threshold)');
+// validator: a latency budget must cite a source_ref
+const latNoCite = { ...goodProfile, latency: [{ name: 'l', atom: 'algorithmic_efficiency', harness: { tool: 'bash', argv: ['-c', 'echo 1'] }, budget: { max_ms: 20 } }] };
+eq(validateProfile(latNoCite, ctx).some(e => e.includes('uncited latency budget')), true, 'A5: latency budget without source_ref is refused');
+
+// ── safety_case gate: standards-inspired CI cannot overclaim DAL/ASIL rigor without process evidence ──
+const highCriticalBase = {
+  ...goodProfile,
+  safety_case: {
+    standards: ['DO-178C', 'DO-331', 'ISO-26262'],
+    certification_intent: 'internal-assurance',
+    aviation_level: 'A',
+    automotive_asil: 'D',
+    safety_plan_ref: 'docs/safety/plan.md',
+    hazard_analysis_ref: 'docs/safety/hazards.md',
+    requirements_traceability_ref: 'docs/safety/trace.csv',
+    verification_plan_ref: 'docs/safety/verification.md',
+    configuration_index_ref: 'docs/safety/config-index.json',
+    independence: { verifier: 'safety-reviewer', reviewer: 'qa', evidence_ref: 'docs/safety/independence.md' },
+    structural_coverage: { statement: true, decision: true, mcdc: true, source_ref: 'reports/coverage/mcdc.json' },
+    tool_qualification: [
+      { tool: 'bash', role: 'shell', standard: 'self-qualified', qualification_ref: 'fixtures/known-bad',
+        fixture: { detects: { argv: ['-c', 'exit 1'] }, accepts: { argv: ['-c', 'exit 0'] } } },
+    ],
+    model_based: {
+      model_ref: 'models/control.slx',
+      model_verification_ref: 'reports/model-check.json',
+      model_code_trace_ref: 'reports/model-code-trace.csv',
+      simulation_correlation_ref: 'reports/model-sim-correlation.json',
+    },
+  },
+};
+eq(validateProfile(highCriticalBase, ctx), [], 'safety_case: complete high-criticality fill passes');
+const noHazard = JSON.parse(JSON.stringify(highCriticalBase));
+delete noHazard.safety_case.hazard_analysis_ref;
+eq(validateProfile(noHazard, ctx).some(e => e.includes('hazard_analysis_ref')), true, 'safety_case: high intent requires hazard analysis source');
+const noMcdc = JSON.parse(JSON.stringify(highCriticalBase));
+noMcdc.safety_case.structural_coverage.mcdc = false;
+eq(validateProfile(noMcdc, ctx).some(e => e.includes('Level A')), true, 'safety_case: DO-178 Level A requires MC/DC under Keel floor');
+const noDo178c = JSON.parse(JSON.stringify(highCriticalBase));
+noDo178c.safety_case.standards = ['DO-331'];
+eq(validateProfile(noDo178c, ctx).some(e => e.includes('DO-331 without DO-178C')), true, 'safety_case: DO-331 cannot stand alone');
+	const missingTool = JSON.parse(JSON.stringify(highCriticalBase));
+	missingTool.safety_case.tool_qualification = [];
+	eq(validateProfile(missingTool, ctx).some(e => e.includes("evidence tool 'bash'")), true, 'safety_case: every evidence-producing tool must be qualified/listed');
+	// Open Risk #2: self-qualified under high intent must carry an EXECUTABLE fixture, not a declaration.
+	const selfQualNoFixture = JSON.parse(JSON.stringify(highCriticalBase));
+	delete selfQualNoFixture.safety_case.tool_qualification[0].fixture;
+	eq(validateProfile(selfQualNoFixture, ctx).some(e => e.includes('no executable fixture')), true, 'R#2: self-qualified under high intent without a fixture is refused (declaration ≠ qualification)');
+	// qualifyTools executor: the fixture must actually prove the tool catches a planted defect.
+	const goodFix = { tool_qualification: [{ tool: 'bash', fixture: { detects: { argv: ['-c', 'exit 1'] }, accepts: { argv: ['-c', 'exit 0'] } } }] };
+	eq(qualifyTools(goodFix)[0].ok, true, 'R#2: a tool that flags the planted defect and passes clean input => qualified');
+	const blindFix = { tool_qualification: [{ tool: 'bash', fixture: { detects: { argv: ['-c', 'exit 0'] }, accepts: { argv: ['-c', 'exit 0'] } } }] };
+	eq(qualifyTools(blindFix)[0].ok, false, 'R#2: a tool that does NOT flag the planted defect => NOT qualified (missed the defect)');
+	const trigger = { tool_qualification: [{ tool: 'bash', fixture: { detects: { argv: ['-c', 'exit 1'] }, accepts: { argv: ['-c', 'exit 1'] } } }] };
+	eq(qualifyTools(trigger)[0].ok, false, 'R#2: a tool that rejects the clean input => NOT qualified (flags everything)');
+	eq(qualifyTools({ tool_qualification: [{ tool: 'bash', standard: 'self-qualified' }] })[0].skipped, true, 'R#2: no fixture => skipped (never a silent pass)');
+
+	// ── Open Risk #1: safety-case reference verification (existence / hash / signature) ──
+	const refDir = mkdtempSync(join(tmpdir(), 'keel-refs-'));
+	const refBody = 'safety plan body';
+	writeFileSync(join(refDir, 'plan.md'), refBody, 'utf8');
+	const refHash = shaHash('sha256').update(Buffer.from(refBody)).digest('hex');
+	eq(verifySafetyRefs({ safety_plan_ref: 'nope.md' }, { root: refDir, highIntent: true })[0].ok, false, 'R#1: missing required ref under high intent => NO-GO');
+	eq(verifySafetyRefs({ safety_plan_ref: 'plan.md', reference_integrity: { safety_plan_ref: { hash: refHash } } }, { root: refDir })[0].ok, true, 'R#1: matching content hash => verified');
+	eq(verifySafetyRefs({ safety_plan_ref: 'plan.md', reference_integrity: { safety_plan_ref: { hash: 'deadbeef' } } }, { root: refDir })[0].ok, false, 'R#1: content hash mismatch => NO-GO (reference altered)');
+	const kp = generateKeyPairSync('ed25519');
+	writeFileSync(join(refDir, 'plan.pub'), kp.publicKey.export({ type: 'spki', format: 'pem' }), 'utf8');
+	writeFileSync(join(refDir, 'plan.sig'), cryptoSign(null, Buffer.from(refBody), kp.privateKey));
+	const signedSC = { safety_plan_ref: 'plan.md', trust_anchor: { public_key_file: 'plan.pub' }, reference_integrity: { safety_plan_ref: { signature_file: 'plan.sig' } } };
+	eq(verifySafetyRefs(signedSC, { root: refDir })[0].ok, true, 'R#1: valid ed25519 signature against the trust anchor => attested');
+	eq(verifySafetyRefs({ ...signedSC, trust_anchor: undefined }, { root: refDir })[0].ok, false, 'R#1: signature with no trust_anchor => NO-GO (unverifiable)');
+	writeFileSync(join(refDir, 'plan.md'), refBody + ' TAMPERED', 'utf8');
+	eq(verifySafetyRefs(signedSC, { root: refDir })[0].ok, false, 'R#1: tampered file fails signature verification => NO-GO');
+
+	// ── Open Risk #3: confinement — tool allowlist + hermetic env ──
+	hasErr({ ...goodProfile, execution_policy: { allow: ['cargo'] } }, "does not permit evidence tool 'bash'", 'R#3: a tool not on execution_policy.allow is refused at load');
+	eq(validateProfile({ ...goodProfile, execution_policy: { allow: ['bash'] } }, ctx), [], 'R#3: an allow-listed tool passes the load gate');
+	// hermetic env: only passthrough vars survive; a host secret is scrubbed.
+	process.env.KEEL_TEST_SECRET = 'do-not-leak';
+	process.env.KEEL_TEST_OK = 'fine';
+	const scrubbed = policyEnv({ env_passthrough: ['KEEL_TEST_OK'] });
+	eq(scrubbed.KEEL_TEST_SECRET, undefined, 'R#3: a non-passthrough host var is ABSENT from the evidence env (no secret leak)');
+	eq(scrubbed.KEEL_TEST_OK, 'fine', 'R#3: an explicitly passed-through var IS present');
+	eq(typeof scrubbed.PATH, 'string', 'R#3: PATH base is always provided so tools resolve');
+	eq(Object.keys(policyEnv(null)).length > Object.keys(scrubbed).length, true, 'R#3: with no policy the full (larger) env is used (back-compatible)');
+	delete process.env.KEEL_TEST_SECRET; delete process.env.KEEL_TEST_OK;
+
+	// ── Open Risk #5: signed seals + append-only transparency chain ──
+	const kp5 = generateKeyPairSync('ed25519');
+	const privPem = kp5.privateKey.export({ type: 'pkcs8', format: 'pem' });
+	const pubPem5 = kp5.publicKey.export({ type: 'spki', format: 'pem' });
+	const sig5 = signSeal('h1', privPem);
+	eq(verifySealSig('h1', sig5, pubPem5), true, 'R#5: a seal signature verifies against the release public key');
+	eq(verifySealSig('tampered', sig5, pubPem5), false, 'R#5: signature does not verify over a different manifest hash (tamper-evident)');
+	eq(verifySealSig('h1', sig5, generateKeyPairSync('ed25519').publicKey.export({ type: 'spki', format: 'pem' })), false, 'R#5: signature does not verify against the wrong key (forgery-evident)');
+	const chain5 = [
+		{ run: 'r1', manifest_hash: 'h1', prev: null, sig: signSeal('h1', privPem) },
+		{ run: 'r2', manifest_hash: 'h2', prev: 'h1', sig: signSeal('h2', privPem) },
+	];
+	eq(verifyChain(chain5, pubPem5).ok, true, 'R#5: an intact, signed chain verifies');
+	eq(verifyChain([chain5[0], { ...chain5[1], prev: 'WRONG' }], pubPem5).ok, false, 'R#5: a broken prev-link (rewritten/reordered history) fails');
+	eq(verifyChain([chain5[0], { ...chain5[1], sig: 'deadbeef' }], pubPem5).ok, false, 'R#5: a forged/invalid signature fails');
+	const unsignedChain = [{ run: 'r1', manifest_hash: 'h1', prev: null }];
+	eq(verifyChain(unsignedChain, pubPem5).ok, true, 'R#5: an unsigned chain is intact (self-asserted), not a failure');
+	eq(verifyChain(unsignedChain, pubPem5).unsigned, 1, 'R#5: unsigned seals are counted, never silently passed as signed');
+	// Anchor actually emits a verifiable signature when given a release key.
+	const sealAnchor = new Anchor(mkdtempSync(join(tmpdir(), 'keel-seal-')), { signingKeyPem: privPem });
+	const sealed = sealAnchor.seal('runX', { gate: 'g', verdict: 'true' });
+	eq(verifySealSig(sealed.manifest_hash, sealed.sig, pubPem5), true, 'R#5: Anchor.seal with a key produces a signature that verifies');
+	const iecMissingSil = JSON.parse(JSON.stringify(highCriticalBase));
+	iecMissingSil.safety_case.standards = ['IEC-61508'];
+	delete iecMissingSil.safety_case.aviation_level;
+	delete iecMissingSil.safety_case.automotive_asil;
+	eq(validateProfile(iecMissingSil, ctx).some(e => e.includes('iec_sil')), true, 'safety_case: IEC 61508 requires SIL');
+	const learnedCoverageLie = JSON.parse(JSON.stringify(highCriticalBase));
+	learnedCoverageLie.safety_case.structural_coverage.scope = ['learned_model'];
+	eq(validateProfile(learnedCoverageLie, ctx).some(e => e.includes('neural/model coverage cannot be counted as MC/DC')), true, 'learning-enabled: learned_model scope cannot satisfy source MC/DC');
+	const mlDalCNoBasis = JSON.parse(JSON.stringify(highCriticalBase));
+	mlDalCNoBasis.safety_case.aviation_level = 'C';
+	mlDalCNoBasis.safety_case.learning_enabled = {
+	  present: true,
+	  certification_position: 'safety-case-with-assumptions',
+	  components: [{ id: 'vision-net', model_type: 'neural-network', safety_role: 'guarded' }],
+	  ml_lifecycle_ref: 'docs/ml/lifecycle.md',
+	  data_requirements_ref: 'docs/ml/data-reqs.md',
+	  data_collection_ref: 'docs/ml/data-collection.md',
+	  data_preprocessing_ref: 'docs/ml/preprocess.md',
+	  training_process_ref: 'docs/ml/training.md',
+	  validation_dataset_ref: 'docs/ml/validation-data.md',
+	  test_oracle_ref: 'docs/ml/oracle.md',
+	  operational_design_domain_ref: 'docs/ml/odd.md',
+	  ood_detection_ref: 'docs/ml/ood.md',
+	  uncertainty_calibration_ref: 'docs/ml/calibration.md',
+	  robustness_ref: 'docs/ml/robustness.md',
+	  runtime_monitor_ref: 'docs/ml/monitor.md',
+	  fallback_safe_state_ref: 'docs/ml/fallback.md',
+	  post_deployment_monitoring_ref: 'docs/ml/post-deploy.md',
+	  assumptions_ref: 'docs/ml/assumptions.md',
+	};
+	eq(validateProfile(mlDalCNoBasis, ctx).some(e => e.includes('DAL C+ requires')), true, 'learning-enabled: DO-178 DAL C+ requires accepted means of compliance');
+	const mlAccepted = JSON.parse(JSON.stringify(mlDalCNoBasis));
+	mlAccepted.safety_case.learning_enabled.certification_position = 'accepted-means-of-compliance';
+	mlAccepted.safety_case.learning_enabled.accepted_means_of_compliance_ref = 'docs/ml/authority-issue-paper.md';
+	eq(validateProfile(mlAccepted, ctx).some(e => e.includes('DAL C+ requires')), false, 'learning-enabled: DAL C+ can proceed only with accepted means of compliance cited');
+	const mlNoMonitor = JSON.parse(JSON.stringify(mlAccepted));
+	delete mlNoMonitor.safety_case.learning_enabled.runtime_monitor_ref;
+	eq(validateProfile(mlNoMonitor, ctx).some(e => e.includes('runtime_monitor_ref')), true, 'learning-enabled: guarded/direct-control ML requires a runtime monitor');
+
+// ── #644: multi-actor interleaving enumeration (docs/04 §4.5) ──
+const il = enumerateInterleavings([{ id: 'A', steps: ['init'] }, { id: 'B', steps: ['use'] }]);
+eq(il.schedules.length, 2, 'interleavings: 2 actors × 1 step => 2 schedules (multinomial)');
+eq(il.schedules.map(s => s.label).sort(), ['A:init>B:use', 'B:use>A:init'], 'interleavings: both order-preserving merges enumerated');
+const il2 = enumerateInterleavings([{ id: 'A', steps: ['a1', 'a2'] }, { id: 'B', steps: ['b1'] }]);
+eq(il2.schedules.length, 3, 'interleavings: (2,1) => 3 = 3!/(2!1!)');
+eq(il2.schedules.every(s => s.steps.findIndex(x => x.op === 'a1') < s.steps.findIndex(x => x.op === 'a2')), true, 'interleavings: each actor internal order preserved');
+eq(typeof enumerateInterleavings([{ id: 'A', steps: ['1', '2', '3', '4'] }, { id: 'B', steps: ['1', '2', '3', '4'] }], { cap: 10 }).error, 'string', 'interleavings: exceeding cap BLOCKS (no silent sampling)');
+
+// ── A6 authenticity: ed25519 reference signature verification (external trust root) ──
+{
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const pub = publicKey.export({ type: 'spki', format: 'pem' });
+  const content = Buffer.from('{"data":[{"when":{"x":1},"expect":2}]}');
+  const goodSig = cryptoSign(null, content, privateKey);
+  eq(verifyReferenceSignature(content, goodSig, pub), true, 'A6: valid signature verifies against the trust anchor');
+  eq(verifyReferenceSignature(Buffer.from('tampered'), goodSig, pub), false, 'A6: tampered content fails verification (no false authentication)');
+  const { publicKey: otherPub } = generateKeyPairSync('ed25519');
+  eq(verifyReferenceSignature(content, goodSig, otherPub.export({ type: 'spki', format: 'pem' })), false, 'A6: a different key fails verification (signature is bound to the real key)');
+}
+
+// ── concept↔Lean conformance (#645 item 7, docs/02 §2.4): the three framework concepts in
+//    concepts.json MUST equal lean/ExcellentCode/Framework.lean (structural — Lean not run here) ──
+const leanText = readFileSync(join(SCHEMA_DIR, '..', 'lean', 'ExcellentCode', 'Framework.lean'), 'utf8');
+const conf = checkConformance({ conceptsDoc: pConcepts, leanText, atomsDoc: pAtoms });
+eq(conf.ok, true, 'conformance: concepts.json matches Framework.lean (no drift): ' + conf.discrepancies.join('; '));
+eq(conf.checked.sort(), ['CoreGroundedCorrect', 'Excellent', 'Hallucinated'], 'conformance: all three framework concepts checked');
+// negative meta-test (auditor-of-the-auditor): a drifted JSON formula MUST be caught
+const drift = JSON.parse(JSON.stringify(pConcepts));
+const cg = drift.concepts.find((c) => c.id === 'CoreGroundedCorrect');
+cg.formula.all = cg.formula.all.filter((a) => a !== 'specification_fidelity');
+eq(checkConformance({ conceptsDoc: drift, leanText, atomsDoc: pAtoms }).ok, false, 'conformance: a dropped atom in a framework formula is caught (not a blind pass)');
+// a phantom atom (not in atoms.json) is caught
+const phantom = JSON.parse(JSON.stringify(pConcepts));
+phantom.concepts.find((c) => c.id === 'Excellent').formula.all[0] = 'no_such_atom';
+eq(checkConformance({ conceptsDoc: phantom, leanText, atomsDoc: pAtoms }).ok, false, 'conformance: a phantom atom in a framework formula is caught');
+
+// ── Lean proof-term node (item 6 / #646, docs/05 §5.2): the `tool: lean` seam grafts a proof
+//    onto the anchor DAG, content-addressed by the proof SOURCE. These assert the IDENTITY law
+//    (no toolchain needed; deterministic) — the lake build itself is gated in qualify.mjs. ──
+const leanPkg = (frameworkSrc, toolchain = 'leanprover/lean4:v4.31.0') => {
+  const dir = mkdtempSync(join(tmpdir(), 'keel-leanpkg-'));
+  mkdirSync(join(dir, 'ExcellentCode'), { recursive: true });
+  writeFileSync(join(dir, 'ExcellentCode', 'Framework.lean'), frameworkSrc);
+  writeFileSync(join(dir, 'lean-toolchain'), toolchain + '\n');
+  return dir;
+};
+const leanNid = (dir, theorems = ['excellent_not_hallucinated']) => {
+  const n = leanProofNode({ packageDir: dir, modules: ['ExcellentCode/Framework.lean'], theorems });
+  return A.nodeId(n.kind, n.params, n.inputs);
+};
+const pkgA = leanPkg('theorem t : True := trivial\n');
+const pkgA2 = leanPkg('theorem t : True := trivial\n');           // identical content, different dir
+const pkgB = leanPkg('theorem t : True := by trivial\n');         // a DIFFERENT proof term
+eq(leanNid(pkgA) === leanNid(pkgA2), true, 'lean proof node: identical proof source ⇒ identical id (cache reuse works)');
+ne(leanNid(pkgA), leanNid(pkgB), 'lean proof node: a changed proof term changes the id (staleness spine)');
+ne(leanNid(pkgA), leanNid(leanPkg('theorem t : True := trivial\n', 'leanprover/lean4:v4.30.0')), 'lean proof node: a changed toolchain pin changes the id');
+ne(leanNid(pkgA), leanNid(pkgA, ['some_other_theorem']), 'lean proof node: a changed grafted-theorem set changes the id');
+// a missing proof source hashes to '∅' deterministically (never a silent skip)
+eq(proofFingerprint(mkdtempSync(join(tmpdir(), 'keel-leanempty-')), ['ExcellentCode/Framework.lean']).sources[0].hash, '∅', 'lean proof node: a missing source is ∅, not silently absent');
+
+// ── binding scope → symbol-granular staleness (item 2 / #647, docs/01 §1.3): a binding's `scope`
+//    narrows the fingerprint to the declared globs, so an edit OUTSIDE the scope must NOT change the
+//    node id (no recompute), while an edit INSIDE it must. Verdict-invariant; deterministic. ──
+const scopeDir = mkdtempSync(join(tmpdir(), 'keel-scope-'));
+writeFileSync(join(scopeDir, 'a.rs'), 'fn a() {}\n');
+writeFileSync(join(scopeDir, 'b.rs'), 'fn b() {}\n');
+const unit = { id: 'u', root: scopeDir };
+const fpScopedA = unitFingerprint(unit, ['a.rs']);          // depends on a.rs only
+const fpAll = unitFingerprint(unit, ['**/*.rs']);           // depends on both
+writeFileSync(join(scopeDir, 'b.rs'), 'fn b() { /* edited */ }\n');   // edit OUTSIDE scope ['a.rs']
+eq(unitFingerprint(unit, ['a.rs']), fpScopedA, 'scope: an edit outside the scope does NOT change the fingerprint (no recompute)');
+ne(unitFingerprint(unit, ['**/*.rs']), fpAll, 'scope: the wider whole-unit fingerprint DOES see the same edit (granularity is real, not a no-op)');
+writeFileSync(join(scopeDir, 'a.rs'), 'fn a() { /* edited */ }\n');   // edit INSIDE scope ['a.rs']
+ne(unitFingerprint(unit, ['a.rs']), fpScopedA, 'scope: an edit inside the scope DOES change the fingerprint (recompute fires)');
+
+// the scope wires through to the NODE ID (the seam: atomNode inputs). Same proof at function level,
+// now proven at identity level so the engine actually reuses/recomputes per scope.
+const scopeNid = (scope) => { const n = atomNode({ id: 'type_soundness' }, { atom: 'type_soundness', evidence: { tool: 'true', argv: [], scope } }, unit); return A.nodeId(n.kind, n.params, n.inputs); };
+writeFileSync(join(scopeDir, 'a.rs'), 'fn a() {}\n');        // reset a.rs
+const nidScoped1 = scopeNid(['a.rs']);
+writeFileSync(join(scopeDir, 'b.rs'), 'fn b() { /* edited again */ }\n');   // outside scope
+eq(scopeNid(['a.rs']), nidScoped1, 'scope: atomNode id is stable across an out-of-scope edit (the seam wires through to identity)');
+writeFileSync(join(scopeDir, 'a.rs'), 'fn a() { changed }\n');             // inside scope
+ne(scopeNid(['a.rs']), nidScoped1, 'scope: atomNode id changes on an in-scope edit');
+
+// ── concurrency primitives (docs/07 §7.4): the seam that licenses crossing in parallel ──
+async function concurrencyTests() {
+  // mapPool resolves in INPUT order regardless of finish order (deterministic aggregation)
+  const out = await mapPool([3, 1, 2], 3, async (n) => { await tick(n); return n * 10; });
+  eq(out, [30, 10, 20], 'mapPool preserves input order under out-of-order completion');
+
+  // a thrown worker is isolated as __poolError, never aborts the crossing (engine maps → unknown)
+  const mixed = await mapPool([1, 2], 2, async (n) => { if (n === 1) throw new Error('boom'); return n; });
+  eq(mixed[0] && mixed[0].__poolError instanceof Error, true, 'mapPool isolates a thrown crossing point');
+  eq(mixed[1], 2, 'mapPool: a sibling fault does not poison other points');
+
+  // bound is respected: at most `limit` in flight at once
+  let live = 0, peak = 0;
+  await mapPool([0, 0, 0, 0, 0], 2, async () => { live++; peak = Math.max(peak, live); await tick(1); live--; });
+  eq(peak <= 2, true, 'mapPool never exceeds the concurrency bound');
+
+  // singleFlight collapses identical concurrent keys to one computation
+  let calls = 0;
+  const once = singleFlight();
+  const compute = async () => { calls++; await tick(1); return 'v'; };
+  const [a, b] = await Promise.all([once('k', compute), once('k', compute)]);
+  eq([a, b, calls], ['v', 'v', 1], 'singleFlight computes a concurrent key exactly once');
+}
+const tick = (n) => new Promise((r) => setImmediate(() => (n > 1 ? tick(n - 1).then(r) : r())));
+
+concurrencyTests().then(() => {
+  if (fails) { console.error(`selftest: ${fails} failed`); process.exit(1); }
+  console.log('selftest: ok (algebra + hashing + concurrency qualified)');
+}).catch((e) => { console.error('selftest harness fault:', e); process.exit(2); });

--- a/keel/src/sign.mjs
+++ b/keel/src/sign.mjs
@@ -1,0 +1,33 @@
+// sign.mjs — release-key signing for seals (Open Risk #5, docs/15 §15.4).
+//
+// A seal's manifest hash proves INTEGRITY (the content has not changed). It does not prove
+// AUTHENTICITY (that this factory produced it) nor that history was not rewritten. R#5 adds a
+// detached ed25519 signature over the seal's manifest hash, verified against a release public key
+// held outside the run — so a consumer can tell a genuine release seal from a forged or replayed
+// one. ed25519 is deterministic (no RNG): signing the same hash with the same key is reproducible,
+// so this does not break Keel's content-addressed determinism.
+
+import { sign as edSign, verify as edVerify, createPrivateKey, createPublicKey } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+/** The release signing key (PEM) from KEEL_RELEASE_KEY (a file path), or null when unset/unreadable.
+ *  Absent key ⇒ seals are unsigned (honest, self-asserted) — signing is opt-in for release runs. */
+export function releaseSigningKey() {
+  const p = process.env.KEEL_RELEASE_KEY;
+  if (!p) return null;
+  try { return readFileSync(p, 'utf8'); } catch { return null; }
+}
+
+/** Sign a seal's manifest hash with an ed25519 private key (PEM). Returns hex signature. */
+export function signSeal(manifestHash, privatePem) {
+  return edSign(null, Buffer.from(String(manifestHash)), createPrivateKey(privatePem)).toString('hex');
+}
+
+/** Verify a seal's signature against an ed25519 public key (PEM). Never throws — bad input is false. */
+export function verifySealSig(manifestHash, sigHex, publicPem) {
+  try {
+    return edVerify(null, Buffer.from(String(manifestHash)), createPublicKey(publicPem), Buffer.from(sigHex, 'hex'));
+  } catch {
+    return false;
+  }
+}

--- a/keel/src/simulate.mjs
+++ b/keel/src/simulate.mjs
@@ -1,0 +1,156 @@
+// simulate.mjs — the INPUT-ENVELOPE simulator (docs/04 §4.1 "envelope faults"; docs/09; issue #644-adjacent).
+//
+// The gap this closes (root cause of the weak gate, 2026-06-18): the rest of Keel verifies the
+// code AT REST (resolve/compile/lint/dup/reproduce) and, where it exercises the running system,
+// pushes only the LOAD scalar (soak.mjs). It has no model of the system's INPUT/SENSOR surface and
+// never drives that surface through its envelope. §4.1 names three dynamic axes — time, interaction,
+// envelope — and the "one bad afternoon from collapse" sentence is about THIS one. Treating the
+// codebase as the airplane: this is the flight simulator that plays with the sensor values.
+//
+// Keel's deterministic job: from a declared sensor model, ENUMERATE the finite input crossing
+// (nominal ∪ boundary ∪ off-nominal — boundary-value analysis, the DO-178C robustness substance),
+// drive each vector through the system-under-test harness, and ∧ the oracle over every point (the
+// system holds across its driven envelope iff EVERY input vector holds). On failure, report the
+// exact breaking vector — "the sensor value where the bridge fails" (the finite-outcome crossing
+// thesis, docs/07, applied to INPUTS instead of platforms). The harness is deferred behind the tool
+// seam (per-target compiled code); enumeration + oracle-crossing is Keel's. Unmeasured ⇒ unknown
+// (BLOCKS, never a silent pass; docs/02 §2.6). No RNG: enumeration is deterministic, so a fuzz-like
+// sweep stays content-addressable and reproducible (it is systematic, not random).
+
+import { verify as cryptoVerify, createPublicKey } from 'node:crypto';
+
+const DEFAULT_MAX_VECTORS = 1024;
+
+/** ed25519 detached-signature verification (A6 authenticity). Builtin crypto only. */
+function verifyEd25519(contentBuf, signatureBuf, publicKeyPem) {
+  const key = createPublicKey(publicKeyPem);
+  return cryptoVerify(null, contentBuf, key, signatureBuf);
+}
+
+/** Build one sensor's value list: explicit `values`, plus numeric `range` boundary points
+ *  (lo, hi, and — when probe_outside — lo-step / hi+step as off-nominal), plus explicit
+ *  `offNominal`. Each entry is { v, off } where off marks an off-nominal/boundary-exceeding input. */
+function sensorPoints(s) {
+  const pts = [];
+  for (const v of s.values || []) pts.push({ v, off: false });
+  if (Array.isArray(s.range) && s.range.length === 2) {
+    const [lo, hi] = s.range;
+    const step = typeof s.step === 'number' ? s.step : 1;
+    pts.push({ v: lo, off: false }, { v: hi, off: false });
+    if (s.probe_outside !== false) pts.push({ v: lo - step, off: true }, { v: hi + step, off: true });
+  }
+  for (const v of s.offNominal || []) pts.push({ v, off: true });
+  // de-dup by value while preserving "off" if any occurrence is off-nominal
+  const seen = new Map();
+  for (const p of pts) {
+    const k = JSON.stringify(p.v);
+    if (!seen.has(k)) seen.set(k, p);
+    else if (p.off) seen.get(k).off = true;
+  }
+  return [...seen.values()];
+}
+
+/**
+ * Enumerate the finite input crossing = the Cartesian product of every sensor's points, in
+ * DETERMINISTIC order (sensors sorted by name; each sensor's points in declared order). Returns
+ * { vectors } or { error } when the product exceeds the cap — NEVER a silent truncation (no silent
+ * caps; the cap is honest and blocks). Each vector = { values:{name:v}, off:bool, label }.
+ */
+export function enumerateEnvelope(sensors, { cap = DEFAULT_MAX_VECTORS } = {}) {
+  if (!Array.isArray(sensors) || !sensors.length) return { error: 'scenario declares no sensors — nothing to drive' };
+  const names = sensors.map((s) => s.name).sort();
+  const byName = Object.fromEntries(sensors.map((s) => [s.name, sensorPoints(s)]));
+  for (const n of names) if (!byName[n].length) return { error: `sensor '${n}' enumerates to zero points (declare values / range / offNominal)` };
+
+  const total = names.reduce((acc, n) => acc * byName[n].length, 1);
+  if (total > cap) return { error: `input crossing is ${total} vectors > cap ${cap} — narrow the sensor model or raise max_vectors (refusing to silently sample)` };
+
+  let vectors = [{ values: {}, off: false, parts: [] }];
+  for (const n of names) {
+    const next = [];
+    for (const base of vectors)
+      for (const p of byName[n]) next.push({ values: { ...base.values, [n]: p.v }, off: base.off || p.off, parts: [...base.parts, `${n}=${JSON.stringify(p.v)}${p.off ? '!' : ''}`] });
+    vectors = next;
+  }
+  return { vectors: vectors.map((v) => ({ values: v.values, off: v.off, label: v.parts.join(' ') })) };
+}
+
+/**
+ * Cross the oracle over the driven vectors (Kleene ∧): the scenario atom is `true` only if EVERY
+ * vector held the oracle; one violated vector dominates to `false`; an unmeasured vector (harness
+ * absent / self-skip / fault) is `unknown` (blocks). Reports the FIRST breaking vector — the input
+ * at which the bridge fails — and counts how many of the driven points were off-nominal.
+ *
+ * points = [{ label, value:'true'|'false'|'unknown', off:bool, reason? }]
+ */
+export function crossOracle(points) {
+  if (!points.length) return { value: 'unknown', breaking: null, driven: 0, offNominal: 0, reason: 'no vectors driven' };
+  const violated = points.find((p) => p.value === 'false');
+  const unmeasured = points.find((p) => p.value === 'unknown');
+  const value = violated ? 'false' : unmeasured ? 'unknown' : 'true';
+  const breaking = violated || (value === 'unknown' ? unmeasured : null);
+  return {
+    value,
+    breaking: breaking ? { label: breaking.label, off: breaking.off, reason: breaking.reason } : null,
+    driven: points.length,
+    offNominal: points.filter((p) => p.off).length,
+  };
+}
+
+/** Multi-actor interleaving enumeration (docs/04 §4.5; axioms A1 closed-loop / A7 repeatable):
+ *  the order-preserving merges of N concurrent actors' step sequences — the finite SCHEDULE space
+ *  (the interaction analogue of the input crossing). The system is concurrency-correct iff the
+ *  consistency oracle holds on EVERY interleaving; the breaking one is the race. Deterministic order;
+ *  the count is the multinomial (Σnᵢ)!/∏nᵢ! — bounded by `cap` (no silent sampling). */
+export function enumerateInterleavings(actors, { cap = 1024 } = {}) {
+  if (!Array.isArray(actors) || !actors.length) return { error: 'scenario declares no actors' };
+  const seqs = actors.map((a) => (a.steps || []).map((op) => ({ actor: a.id, op })));
+  if (seqs.some((s) => !s.length)) return { error: 'an actor declares no steps' };
+  const fact = (n) => { let r = 1; for (let i = 2; i <= n; i++) r *= i; return r; };
+  const total = seqs.reduce((a, s) => a + s.length, 0);
+  const count = fact(total) / seqs.reduce((a, s) => a * fact(s.length), 1);
+  if (count > cap) return { error: `${count} interleavings > cap ${cap} — reduce actors/steps or raise max_interleavings (refusing to silently sample)` };
+  const out = [];
+  (function rec(remaining, acc) {
+    if (remaining.every((r) => r.length === 0)) { out.push(acc); return; }
+    for (let i = 0; i < remaining.length; i++) {
+      if (!remaining[i].length) continue;
+      rec(remaining.map((r, j) => (j === i ? r.slice(1) : r)), [...acc, remaining[i][0]]);
+    }
+  })(seqs, []);
+  return { schedules: out.map((steps) => ({ steps, label: steps.map((s) => `${s.actor}:${s.op}`).join('>') })) };
+}
+
+/** A6 (validated_aircraft_correlation): the oracle's truth must trace to REFERENCE DATA, not to
+ *  developer/AI intuition. A `reference` block is a table of {when:{sensor:val,…}, expect:value}.
+ *  This is the deterministic key for one vector's reference lookup. */
+function refKey(values) {
+  return JSON.stringify(Object.keys(values).sort().map((k) => [k, values[k]]));
+}
+
+/** Find the reference entry whose `when` matches a driven vector exactly (every declared sensor). */
+export function referenceFor(reference, values) {
+  if (!reference || !Array.isArray(reference.data)) return null;
+  const want = refKey(values);
+  return reference.data.find((e) => refKey(e.when || {}) === want) || null;
+}
+
+/** Compare a system output to its reference within tolerance (A6). Numbers: |out-expect| ≤ tol.
+ *  Anything else: strict deep-equal. Returns 'true' | 'false'. The verdict's truth is the REFERENCE,
+ *  so it cannot be an author's intuition about pass/fail. */
+export function compareToReference(output, expect, tolerance = 0) {
+  if (typeof expect === 'number' && typeof output === 'number')
+    return Math.abs(output - expect) <= tolerance ? 'true' : 'false';
+  return JSON.stringify(output) === JSON.stringify(expect) ? 'true' : 'false';
+}
+
+/** A6 AUTHENTICITY (the external trust root): verify a detached ed25519 signature over the reference
+ *  bytes against a configured public key. A valid signature means the reference was attested by
+ *  whoever holds the private key — a party OUTSIDE the AI authorship loop. That externality is the
+ *  independence the gate otherwise lacks. Returns true|false; throws only on malformed key/sig input
+ *  (caller treats a throw as a hard block, never a pass). Uses node:crypto (builtin, zero-dep). */
+export function verifyReferenceSignature(contentBuf, signatureBuf, publicKeyPem) {
+  return verifyEd25519(contentBuf, signatureBuf, publicKeyPem);
+}
+
+export { DEFAULT_MAX_VECTORS };

--- a/keel/src/soak.mjs
+++ b/keel/src/soak.mjs
@@ -1,0 +1,63 @@
+// soak.mjs — the endurance tier core (docs/04 §4.3–4.4, §4.6; issue #643).
+//
+// The break-and-revert loop (escalate→bracket→revert→soak) is a NATIVE HARNESS, not the
+// thin orchestrator's job (docs/04 §4.2): the heavy sustained load runs in compiled per-target
+// code, which emits a content-addressed `capacity-profile/v0` artifact PER load dimension. Keel's
+// job here is the deterministic part: parse that artifact and decide ENVELOPE-RELATIVE acceptance
+// (§4.4) — GO iff measured V_NO ≥ target × margin on EVERY dimension; the limiting dimension is the
+// argmin margin (tropical reduction, §1.6). Keel never prices anything (§4.6) — it emits/consumes
+// the physical characterization; the cost model is a separate downstream projection.
+//
+// This module is the FINAL seam: the harness that produces a capacity profile is deferred behind
+// the soak binding's tool (run-soak.mjs), exactly as a graded atom's score is. A dimension with no
+// measurement is `unknown` (BLOCKS, never a silent pass; docs/02 §2.6).
+
+/** Validate one `capacity-profile/v0` artifact emitted by a soak harness. Returns errors[]. */
+export function validateCapacityProfile(p) {
+  const errs = [];
+  if (p == null || typeof p !== 'object') return ['capacity-profile: not an object'];
+  if (p.schema !== 'capacity-profile/v0') errs.push(`capacity-profile: schema must be 'capacity-profile/v0' (got ${JSON.stringify(p.schema)})`);
+  if (typeof p.dimension !== 'string' || !p.dimension) errs.push('capacity-profile: missing dimension');
+  if (typeof p.v_no !== 'number' || !(p.v_no >= 0)) errs.push('capacity-profile: v_no must be a number ≥ 0 (sustained-safe limit)');
+  if (p.v_ne !== undefined && (typeof p.v_ne !== 'number' || p.v_ne < p.v_no)) errs.push('capacity-profile: v_ne (never-exceed) must be ≥ v_no');
+  if (p.samples !== undefined && !Array.isArray(p.samples)) errs.push('capacity-profile: samples must be an array');
+  return errs;
+}
+
+/**
+ * Envelope-relative acceptance (§4.4). Given per-dimension measured profiles and the declared
+ * envelope, decide the soak verdict.
+ *   required(dim) = envelope.target[dim] × (envelope.margin ?? 1)
+ *   margin_ratio  = v_no / required               (headroom; ≥1 means the dimension holds)
+ *   GO iff every targeted dimension has a measurement AND margin_ratio ≥ 1.
+ *   A targeted dimension with no measurement ⇒ verdict 'unknown' (blocks; unknown ≠ pass).
+ *   limiting = the dimension with the smallest margin_ratio (the spar that gives first).
+ *
+ * @param profiles  Map<dimension, {v_no:number}|null>  (null = harness ran/absent, no measurement)
+ * @param envelope  { target:{[dim]:number}, slo?, margin?:number }
+ * returns { verdict:'true'|'false'|'unknown', dimensions:[…], limiting }
+ */
+export function acceptEnvelope(profiles, envelope) {
+  const target = envelope?.target || {};
+  const marginFactor = typeof envelope?.margin === 'number' ? envelope.margin : 1;
+  const dims = Object.keys(target);
+  if (!dims.length) return { verdict: 'unknown', dimensions: [], limiting: null, reason: 'envelope declares no target dimensions — nothing to accept against' };
+
+  const rows = dims.map((dim) => {
+    const required = target[dim] * marginFactor;
+    const prof = profiles[dim];
+    const v_no = prof && typeof prof.v_no === 'number' ? prof.v_no : null;
+    if (v_no == null) return { dimension: dim, v_no: null, required, margin: null, value: 'unknown', reason: `no capacity measurement for '${dim}' (soak harness unbound or did not report) — unknown ≠ pass` };
+    const ratio = required > 0 ? v_no / required : (v_no > 0 ? Infinity : 0);
+    return { dimension: dim, v_no, required, margin: ratio, value: ratio >= 1 ? 'true' : 'false',
+      reason: ratio >= 1 ? undefined : `holds ${v_no} but needs ${required} (target ${target[dim]} × margin ${marginFactor}) — ${(ratio).toFixed(2)}× of required` };
+  });
+
+  // limiting dimension = smallest margin among MEASURED dims (unknown dims are reported separately)
+  const measured = rows.filter((r) => r.margin != null);
+  const limiting = measured.length ? measured.reduce((a, b) => (b.margin < a.margin ? b : a)) : null;
+  const verdict = rows.some((r) => r.value === 'false') ? 'false'
+    : rows.some((r) => r.value === 'unknown') ? 'unknown'
+    : 'true';
+  return { verdict, dimensions: rows, limiting: limiting ? limiting.dimension : null };
+}

--- a/keel/src/toolqual.mjs
+++ b/keel/src/toolqual.mjs
@@ -1,0 +1,67 @@
+// toolqual.mjs — executable tool qualification (Open Risk #2, docs/15 §15.4).
+//
+// `safety_case.tool_qualification` entries were DECLARATIVE: a `standard:"self-qualified"` row
+// asserted a tool was trustworthy with nothing run to prove it. An evidence tool that does not
+// actually catch defects is a hole under every verdict it produces. This module makes the claim
+// EXECUTABLE: a fixture declares a planted-DEFECTIVE input the tool MUST flag (`detects`, the tool
+// exits non-zero) and a CLEAN input it MUST pass (`accepts`, exit zero). Keel runs both. A tool
+// that misses the planted defect, or flags the clean input, is NOT qualified — same known-bad /
+// known-good discipline Keel turns on itself in qualify.mjs, applied to a target's evidence tools.
+//
+// Determinism/confinement: probes run with a scrubbed, minimal env (no host secrets, HOME, or git
+// config) — the seam Open Risk #3 (execution_policy) tightens with an allowlist. A needed binary
+// that is absent ⇒ `unknown` (skipped, never a false pass).
+
+import { spawnSync } from 'node:child_process';
+
+const MAXBUF = 8 * 1024 * 1024;
+
+/** Minimal hermetic env for a probe — cannot read host secrets/HOME/git. (R#3 narrows further.) */
+function probeEnv(cwd) {
+  return {
+    PATH: process.env.PATH || '/usr/bin:/bin',
+    HOME: cwd, TMPDIR: cwd, LANG: process.env.LANG || 'C',
+    GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null', GIT_TERMINAL_PROMPT: '0',
+  };
+}
+
+function has(bin) {
+  return spawnSync('bash', ['-c', `command -v ${bin}`], { encoding: 'utf8' }).status === 0;
+}
+
+/** Run one probe; return its exit status (or null on launch failure / absent need). */
+function runProbe(tool, probe, cwd) {
+  for (const bin of probe.needs || []) if (!has(bin)) return { status: null, absent: bin };
+  const r = spawnSync(tool, probe.argv, { cwd, env: probeEnv(cwd), encoding: 'utf8', maxBuffer: MAXBUF, timeout: 60_000 });
+  return { status: r.error ? null : r.status, error: r.error };
+}
+
+/**
+ * Execute the fixtures of a safety_case's tool_qualification entries.
+ * Returns one row per entry: { tool, ok, skipped, why }.
+ *   - no fixture            => skipped (validation decides whether one was REQUIRED).
+ *   - needed binary absent  => skipped (unknown, never a false pass).
+ *   - detects exits zero    => NOT ok (the tool missed a planted defect).
+ *   - accepts exits non-zero=> NOT ok (the tool flags clean input — useless gate).
+ *   - detects!=0 && accepts==0 => ok (qualified by demonstration).
+ */
+export function qualifyTools(safetyCase, { cwd = '.' } = {}) {
+  const rows = [];
+  for (const tq of safetyCase?.tool_qualification || []) {
+    if (!tq.fixture) { rows.push({ tool: tq.tool, ok: null, skipped: true, why: 'no executable fixture declared' }); continue; }
+    const det = runProbe(tq.tool, tq.fixture.detects, cwd);
+    if (det.absent) { rows.push({ tool: tq.tool, ok: null, skipped: true, why: `toolchain absent: ${det.absent}` }); continue; }
+    const acc = runProbe(tq.tool, tq.fixture.accepts, cwd);
+    if (acc.absent) { rows.push({ tool: tq.tool, ok: null, skipped: true, why: `toolchain absent: ${acc.absent}` }); continue; }
+    const detectsCaught = det.status !== 0 && det.status !== null; // must FLAG the planted defect
+    const acceptsPassed = acc.status === 0;                        // must PASS the clean input
+    const ok = detectsCaught && acceptsPassed;
+    rows.push({
+      tool: tq.tool, ok, skipped: false,
+      why: ok ? 'fixture: flagged the planted defect and passed the clean input'
+        : !detectsCaught ? `fixture: '${tq.tool}' did NOT flag the planted defect (detects exit ${det.status}) — it cannot be trusted to catch what it claims`
+          : `fixture: '${tq.tool}' rejected the clean input (accepts exit ${acc.status}) — a tool that flags everything proves nothing`,
+    });
+  }
+  return rows;
+}

--- a/keel/src/validate.mjs
+++ b/keel/src/validate.mjs
@@ -1,0 +1,281 @@
+// validate.mjs — the RESTRICTIVE load gate (docs/03 §3.1, issue #648 item 1).
+//
+// A tailoring profile is mechanically validated BEFORE any verification runs: a
+// malformed fill must be refused, not silently half-honoured. This is a purpose-built,
+// zero-dep checker for the draft-07 SUBSET that schema/profile.schema.json actually uses
+// — the same pattern as the kernel's govlog/repo-map checkers (no ajv, no network, the
+// validator itself is auditable in one screen).
+//
+// Supported keywords: type (object|array|string|number|integer|boolean), enum, required,
+// properties, additionalProperties (false | schema), items (schema), minimum, maximum.
+// Metadata keywords ($schema/$id/title/description) are ignored. The profile schema uses
+// no $ref/allOf/if/then, so those are intentionally unsupported — assertSchemaSupported()
+// fails loudly if the schema ever grows a keyword this validator does not interpret, so the
+// gate can never silently under-check (no silent caps; docs/02 §2.6).
+
+import { REFERENCE_KEYS } from './safetyrefs.mjs';
+
+const SUPPORTED = new Set([
+  '$schema', '$id', 'title', 'description',
+  'type', 'enum', 'required', 'properties', 'additionalProperties', 'items',
+  'minimum', 'maximum',
+]);
+
+const typeOk = (t, v) =>
+  t === 'object' ? v != null && typeof v === 'object' && !Array.isArray(v)
+  : t === 'array' ? Array.isArray(v)
+  : t === 'string' ? typeof v === 'string'
+  : t === 'number' ? typeof v === 'number'
+  : t === 'integer' ? Number.isInteger(v)
+  : t === 'boolean' ? typeof v === 'boolean'
+  : true;
+
+/** Guard: refuse to run if the schema uses a keyword this subset-validator can't interpret. */
+export function assertSchemaSupported(schema, path = '(schema)') {
+  if (!schema || typeof schema !== 'object') return;
+  for (const k of Object.keys(schema)) {
+    if (!SUPPORTED.has(k)) throw new Error(`validate.mjs: unsupported schema keyword '${k}' at ${path} — extend the validator before relying on it (no silent under-check)`);
+  }
+  if (schema.properties) for (const [k, s] of Object.entries(schema.properties)) assertSchemaSupported(s, `${path}.properties.${k}`);
+  if (schema.items) assertSchemaSupported(schema.items, `${path}.items`);
+  if (schema.additionalProperties && typeof schema.additionalProperties === 'object') assertSchemaSupported(schema.additionalProperties, `${path}.additionalProperties`);
+}
+
+/** Structural validation of `data` against the (subset) `schema`. Returns an error string[]. */
+export function validate(data, schema, path = '') {
+  const errs = [];
+  const at = path || '(root)';
+  if (schema.type && !typeOk(schema.type, data)) { errs.push(`${at}: expected ${schema.type}`); return errs; }
+  if (schema.enum && !schema.enum.some((e) => e === data)) errs.push(`${at}: ${JSON.stringify(data)} not one of [${schema.enum.join(', ')}]`);
+  if (typeof data === 'number') {
+    if (schema.minimum !== undefined && data < schema.minimum) errs.push(`${at}: ${data} < minimum ${schema.minimum}`);
+    if (schema.maximum !== undefined && data > schema.maximum) errs.push(`${at}: ${data} > maximum ${schema.maximum}`);
+  }
+  if (typeOk('object', data)) {
+    for (const r of schema.required || []) if (!(r in data)) errs.push(`${at}: missing required '${r}'`);
+    const props = schema.properties || {};
+    for (const k of Object.keys(data)) {
+      const sub = `${path}${path ? '.' : ''}${k}`;
+      if (props[k]) errs.push(...validate(data[k], props[k], sub));
+      else if (schema.additionalProperties === false) errs.push(`${sub}: unexpected property (additionalProperties is false)`);
+      else if (schema.additionalProperties && typeof schema.additionalProperties === 'object') errs.push(...validate(data[k], schema.additionalProperties, sub));
+    }
+  }
+  if (Array.isArray(data) && schema.items) data.forEach((v, i) => errs.push(...validate(v, schema.items, `${path}[${i}]`)));
+  return errs;
+}
+
+/**
+ * Full profile gate: structural (schema) + REFERENTIAL constraints the JSON-Schema cannot
+ * express (docs/03 §3.4) —
+ *   · every binding/threshold atom id exists in schema/atoms.json,
+ *   · the gate_concept exists in schema/concepts.json,
+ *   · a threshold may only key a GRADED atom (a boolean atom has no score to cross).
+ * Returns an error string[]; empty == the profile may run.
+ */
+export function validateProfile(profile, { schema, atomsDoc, conceptsDoc }) {
+  assertSchemaSupported(schema);
+  const errs = validate(profile, schema);
+  const atomIds = new Set((atomsDoc?.atoms || []).map((a) => a.id));
+  const gradedIds = new Set((atomsDoc?.atoms || []).filter((a) => a.kind === 'graded').map((a) => a.id));
+  const conceptIds = new Set((conceptsDoc?.concepts || []).map((c) => c.id));
+  for (const [i, b] of (profile.bindings || []).entries()) {
+    if (b?.atom && !atomIds.has(b.atom)) errs.push(`bindings[${i}].atom '${b.atom}' is not a known atom (schema/atoms.json)`);
+    // a score extractor is meaningful only for a graded atom (a boolean atom has no score)
+    if (b?.evidence?.score && b?.atom && atomIds.has(b.atom) && !gradedIds.has(b.atom))
+      errs.push(`bindings[${i}].evidence.score is only valid for a GRADED atom; '${b.atom}' is boolean (docs/02 §2.5)`);
+  }
+  if (profile.gate_concept && !conceptIds.has(profile.gate_concept))
+    errs.push(`gate_concept '${profile.gate_concept}' is not a known concept (schema/concepts.json)`);
+  if (profile.assurance_claim && !conceptIds.has(profile.assurance_claim))
+    errs.push(`assurance_claim '${profile.assurance_claim}' is not a known concept (schema/concepts.json)`);
+  // A6 provenance: a reference oracle's truth must TRACE to a source, not be invented inline.
+  // A gating reference must load from a file (`from`, content-hashed) OR cite a `source_ref` for its
+  // inline data. An untraceable inline table is intuition in a data costume — refused.
+  for (const [i, s] of (profile.simulate || []).entries()) {
+    if (s?.atom && !atomIds.has(s.atom)) errs.push(`simulate[${i}].atom '${s.atom}' is not a known atom`);
+    const ref = s?.reference;
+    if (ref && !ref.from && !ref.source_ref)
+      errs.push(`simulate[${i}].reference is inline with no source_ref — untraceable (A6: model truth is data, not intuition). Add source_ref or load from a file.`);
+  }
+  for (const [i, s] of (profile.sim || []).entries())
+    if (s?.atom && !atomIds.has(s.atom)) errs.push(`sim[${i}].atom '${s.atom}' is not a known atom`);
+  // A5 latency: the budget is the auditor's parameter and must be CITED (no uncited threshold as law).
+  for (const [i, s] of (profile.latency || []).entries()) {
+    if (s?.atom && !atomIds.has(s.atom)) errs.push(`latency[${i}].atom '${s.atom}' is not a known atom`);
+    if (s?.budget && !s.budget.source_ref)
+      errs.push(`latency[${i}].budget has no source_ref — an uncited latency budget is not law (docs/10 §10.3). Cite where the budget came from.`);
+  }
+  for (const [atom] of Object.entries(profile.thresholds || {})) {
+    if (!atomIds.has(atom)) errs.push(`thresholds['${atom}'] is not a known atom`);
+    else if (!gradedIds.has(atom)) errs.push(`thresholds['${atom}'] keys a BOOLEAN atom — only graded atoms cross a threshold (docs/02 §2.5)`);
+  }
+  // Open Risk #3: confinement allowlist. When execution_policy.allow is declared, EVERY tool Keel
+  // will spawn from this profile must be on it — a command outside the allowlist is refused at load
+  // (a runner fault, never run), so a poisoned/typo'd binding cannot execute an unintended binary.
+  const allow = profile.execution_policy?.allow;
+  if (Array.isArray(allow) && allow.length) {
+    const allowed = new Set(allow);
+    const spawned = new Set([...evidenceTools(profile), ...(profile.safety_case?.tool_qualification || []).map((t) => t.tool).filter(Boolean)]);
+    for (const t of spawned)
+      if (!allowed.has(t)) errs.push(`execution_policy.allow does not permit evidence tool '${t}' — every spawned binary must be on the allowlist (confinement; docs/15 §15.4 R#3)`);
+  }
+  errs.push(...validateSafetyCase(profile));
+  return errs;
+}
+
+function validateSafetyCase(profile) {
+  const sc = profile.safety_case;
+  if (!sc) return [];
+  const errs = [];
+  const standards = new Set(sc.standards || []);
+  const intent = sc.certification_intent || 'none';
+  const highIntent = intent === 'internal-assurance' || intent === 'certification-support';
+  const requiredRefs = [
+    'safety_plan_ref',
+    'hazard_analysis_ref',
+    'requirements_traceability_ref',
+    'verification_plan_ref',
+    'configuration_index_ref',
+  ];
+
+  if (standards.has('DO-331') && !standards.has('DO-178C'))
+    errs.push(`safety_case.standards includes DO-331 without DO-178C — DO-331 is a supplement to DO-178C/DO-278A, not a standalone claim`);
+	  if ((standards.has('DO-178B') || standards.has('DO-178C') || standards.has('DO-331')) && !sc.aviation_level)
+	    errs.push(`safety_case.aviation_level is required when a DO-178 standard or supplement is selected`);
+	  if (standards.has('ISO-26262') && !sc.automotive_asil)
+	    errs.push(`safety_case.automotive_asil is required when ISO-26262 is selected`);
+	  if (standards.has('IEC-61508') && !sc.iec_sil)
+	    errs.push(`safety_case.iec_sil is required when IEC-61508 is selected`);
+
+  if (highIntent) {
+    for (const k of requiredRefs) if (!sc[k]) errs.push(`safety_case.${k} is required for ${intent}`);
+    if (!sc.independence?.evidence_ref)
+      errs.push(`safety_case.independence.evidence_ref is required for ${intent} — verification independence must be traceable`);
+    if (!sc.structural_coverage?.source_ref)
+      errs.push(`safety_case.structural_coverage.source_ref is required for ${intent} — coverage claims must trace to a report`);
+    if (!Array.isArray(sc.tool_qualification) || sc.tool_qualification.length === 0)
+      errs.push(`safety_case.tool_qualification must list evidence-producing tools for ${intent}`);
+  }
+
+	  const cov = sc.structural_coverage || {};
+	  if ((cov.scope || []).includes('learned_model') && (cov.statement || cov.decision || cov.mcdc))
+	    errs.push(`safety_case.structural_coverage.scope includes learned_model, but statement/decision/MC/DC are source-code control-flow criteria; neural/model coverage cannot be counted as MC/DC`);
+	  const level = sc.aviation_level;
+  if (level === 'A' && !(cov.statement && cov.decision && cov.mcdc))
+    errs.push(`safety_case.structural_coverage for DO-178 Level A must declare statement, decision, and MC/DC coverage`);
+  if (level === 'B' && !(cov.statement && cov.decision))
+    errs.push(`safety_case.structural_coverage for DO-178 Level B must declare statement and decision coverage`);
+  if (level === 'C' && !cov.statement)
+    errs.push(`safety_case.structural_coverage for DO-178 Level C must declare statement coverage`);
+
+  const asil = sc.automotive_asil;
+  if (asil === 'D' && !(cov.statement && cov.decision && cov.mcdc))
+    errs.push(`safety_case.structural_coverage for ISO-26262 ASIL D must declare statement, decision, and MC/DC coverage under Keel's stricter floor`);
+  if (asil === 'C' && !(cov.statement && cov.decision))
+    errs.push(`safety_case.structural_coverage for ISO-26262 ASIL C must declare statement and decision coverage under Keel's stricter floor`);
+	  if ((asil === 'A' || asil === 'B') && !cov.statement)
+	    errs.push(`safety_case.structural_coverage for ISO-26262 ASIL ${asil} must declare statement coverage under Keel's stricter floor`);
+	  const sil = sc.iec_sil;
+	  if ((sil === 'SIL3' || sil === 'SIL4') && !(cov.statement && cov.decision && cov.mcdc))
+	    errs.push(`safety_case.structural_coverage for IEC 61508 ${sil} must declare statement, decision, and MC/DC under Keel's stricter floor`);
+	  if ((sil === 'SIL1' || sil === 'SIL2') && !cov.statement)
+	    errs.push(`safety_case.structural_coverage for IEC 61508 ${sil} must declare statement coverage under Keel's stricter floor`);
+
+  if (standards.has('DO-331')) {
+    for (const k of ['model_ref', 'model_verification_ref', 'model_code_trace_ref', 'simulation_correlation_ref']) {
+      if (!sc.model_based?.[k]) errs.push(`safety_case.model_based.${k} is required when DO-331 is selected`);
+    }
+  }
+
+  const qualifiedTools = new Set((sc.tool_qualification || []).map((t) => t.tool));
+  for (const t of evidenceTools(profile)) {
+    if (!qualifiedTools.has(t))
+      errs.push(`safety_case.tool_qualification is missing evidence tool '${t}'`);
+  }
+	  for (const [i, tq] of (sc.tool_qualification || []).entries()) {
+    if (tq.standard === 'DO-330' && !tq.tql)
+      errs.push(`safety_case.tool_qualification[${i}] uses DO-330 but has no tql`);
+    if (tq.standard === 'ISO-26262-8' && !tq.tcl)
+      errs.push(`safety_case.tool_qualification[${i}] uses ISO-26262-8 but has no tcl`);
+    if (tq.standard === 'unqualified' && highIntent)
+      errs.push(`safety_case.tool_qualification[${i}] lists '${tq.tool}' as unqualified under ${intent}; high-criticality evidence tools must be qualified, self-qualified, or independently justified`);
+    // Open Risk #2: a self-qualified claim is a DECLARATION unless it carries an executable
+    // fixture Keel can run to prove the tool catches defects. Under high intent, require one.
+    if (tq.standard === 'self-qualified' && highIntent && !(tq.fixture?.detects && tq.fixture?.accepts))
+      errs.push(`safety_case.tool_qualification[${i}] '${tq.tool}' is self-qualified under ${intent} but has no executable fixture (fixture.detects + fixture.accepts); self-qualification must be demonstrated, not declared`);
+	  }
+
+  // Open Risk #1: reference_integrity must name real reference fields, and a declared signature
+  // must have a trust anchor to verify against (an unverifiable signature is not trust). The
+  // existence/hash/signature checks themselves run against the tree at runtime (safetyrefs.mjs).
+  for (const [key, spec] of Object.entries(sc.reference_integrity || {})) {
+    if (!REFERENCE_KEYS.includes(key))
+      errs.push(`safety_case.reference_integrity['${key}'] is not a known reference field (${REFERENCE_KEYS.join(', ')}) — a typo'd key would be silently unverified`);
+    if (spec?.signature_file && !sc.trust_anchor?.public_key_file)
+      errs.push(`safety_case.reference_integrity['${key}'] declares a signature_file but safety_case.trust_anchor.public_key_file is absent — a signature with no anchor cannot be verified`);
+  }
+	  errs.push(...validateLearningEnabled(sc, { standards, highIntent }));
+
+	  return errs;
+	}
+
+function validateLearningEnabled(sc, { standards, highIntent }) {
+  const le = sc.learning_enabled;
+  if (!le) return [];
+  const errs = [];
+  const present = le.present === true || (Array.isArray(le.components) && le.components.length > 0);
+  if (!present) return [];
+
+  if (!Array.isArray(le.components) || le.components.length === 0)
+    errs.push(`safety_case.learning_enabled.components must list each learned component when learning_enabled.present is true`);
+
+  const required = [
+    'certification_position',
+    'ml_lifecycle_ref',
+    'data_requirements_ref',
+    'data_collection_ref',
+    'data_preprocessing_ref',
+    'training_process_ref',
+    'validation_dataset_ref',
+    'test_oracle_ref',
+    'operational_design_domain_ref',
+    'ood_detection_ref',
+    'uncertainty_calibration_ref',
+    'robustness_ref',
+    'post_deployment_monitoring_ref',
+    'assumptions_ref',
+  ];
+  if (highIntent) for (const k of required) if (!le[k]) errs.push(`safety_case.learning_enabled.${k} is required for learning-enabled ${sc.certification_intent}`);
+
+  const safetyRoles = new Set((le.components || []).map((c) => c.safety_role));
+  if (safetyRoles.has('guarded') || safetyRoles.has('direct-control')) {
+    if (!le.runtime_monitor_ref)
+      errs.push(`safety_case.learning_enabled.runtime_monitor_ref is required when learned logic is guarded or direct-control`);
+    if (!le.fallback_safe_state_ref)
+      errs.push(`safety_case.learning_enabled.fallback_safe_state_ref is required when learned logic is guarded or direct-control`);
+  }
+
+  const aviationHigh = ['A', 'B', 'C'].includes(sc.aviation_level);
+  if ((standards.has('DO-178B') || standards.has('DO-178C')) && aviationHigh && le.certification_position !== 'accepted-means-of-compliance')
+    errs.push(`learning-enabled DO-178 Level ${sc.aviation_level} cannot rely on Keel's ordinary structural-coverage floor; DAL C+ requires learning_enabled.certification_position='accepted-means-of-compliance' plus accepted_means_of_compliance_ref`);
+  if (le.certification_position === 'accepted-means-of-compliance' && !le.accepted_means_of_compliance_ref)
+    errs.push(`safety_case.learning_enabled.accepted_means_of_compliance_ref is required when certification_position is accepted-means-of-compliance`);
+  if (sc.certification_intent === 'certification-support' && le.certification_position !== 'accepted-means-of-compliance')
+    errs.push(`learning-enabled certification-support requires accepted means of compliance; use internal-assurance or lower until an authority-accepted basis exists`);
+  if (le.neural_coverage_ref && !(le.assumptions_ref && le.test_oracle_ref))
+    errs.push(`safety_case.learning_enabled.neural_coverage_ref requires assumptions_ref and test_oracle_ref; neural coverage is not a substitute for MC/DC or oracle quality`);
+
+  return errs;
+}
+
+function evidenceTools(profile) {
+  const tools = new Set();
+  const add = (ev) => { if (ev?.tool) tools.add(ev.tool); };
+  for (const b of profile.bindings || []) add(b?.evidence);
+  for (const s of profile.soak || []) add(s?.evidence);
+  for (const s of profile.simulate || []) add(s?.harness);
+  for (const s of profile.latency || []) add(s?.harness);
+  for (const s of profile.sim || []) add(s?.harness);
+  return [...tools].sort();
+}

--- a/keel/src/verify-seal.mjs
+++ b/keel/src/verify-seal.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// verify-seal.mjs — transparency-record verifier (Open Risk #5, docs/15 §15.4).
+//
+// Verifies a Keel seal chain (.keel/_chain.jsonl) two ways:
+//   INTEGRITY  — the chain is append-only and intact: each entry's `prev` equals the previous
+//                entry's `manifest_hash`. A reordered, truncated, or rewritten history fails here.
+//   AUTHENTICITY — each SIGNED entry's `sig` verifies against the release public key over its
+//                manifest_hash. An unsigned entry is reported `self_asserted` (honest; never a
+//                silent pass). A signed entry with a bad/forged signature FAILS.
+//
+// Exit 0 = chain intact and every signed seal verified · 1 = a broken link or invalid signature ·
+// 2 = usage/IO fault. Determinism: pure over the chain bytes + the public key.
+//
+// Usage:  node src/verify-seal.mjs [--chain <_chain.jsonl>] [--pubkey <ed25519-public.pem>]
+
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { verifySealSig } from './sign.mjs';
+
+/**
+ * Verify a parsed chain (array of {run, manifest_hash, prev, sig?}) against an optional public key.
+ * Returns { ok, entries, signed, unsigned, problems[] }. Pure — no IO, unit-testable.
+ */
+export function verifyChain(entries, publicPem = null) {
+  const problems = [];
+  let signed = 0, unsigned = 0;
+  // Append-only DAG, not a strict line: a deterministic (content-addressed) re-seal of unchanged
+  // source produces an identical seal whose `prev` is the chain tip when that run STARTED — so two
+  // siblings can legitimately share a parent. The integrity invariant is therefore that every
+  // non-null `prev` references SOME earlier seal's manifest_hash (a real ancestor), and only the
+  // genesis seal has prev=null. A `prev` that points at no earlier seal is a fabricated/dangling
+  // link — a rewritten or out-of-order history. (Tail truncation cannot be detected from the chain
+  // alone without an external tip witness — the honest residual, like the kernel-trust residual.)
+  const earlier = new Set();
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    if (i === 0) {
+      if ((e.prev ?? null) !== null) problems.push(`entry 0 (run ${e.run}): genesis seal must have prev=null, found ${e.prev}`);
+    } else if (e.prev == null) {
+      problems.push(`entry ${i} (run ${e.run}): prev=null but this is not the genesis seal (a second genesis = a rewritten chain)`);
+    } else if (!earlier.has(e.prev)) {
+      problems.push(`entry ${i} (run ${e.run}): prev=${e.prev} references no earlier seal — dangling/fabricated link (history rewritten or reordered)`);
+    }
+    // AUTHENTICITY: a signed entry must verify; an unsigned one is honest-but-unattested.
+    if (e.sig) {
+      signed++;
+      if (!publicPem) problems.push(`entry ${i} (run ${e.run}): signed but no public key supplied to verify it`);
+      else if (!verifySealSig(e.manifest_hash, e.sig, publicPem))
+        problems.push(`entry ${i} (run ${e.run}): INVALID signature — not produced by the release key (forged or tampered)`);
+    } else {
+      unsigned++;
+    }
+    earlier.add(e.manifest_hash);
+  }
+  return { ok: problems.length === 0, entries: entries.length, signed, unsigned, problems };
+}
+
+/** Parse a _chain.jsonl file into entries (skips blank lines). */
+export function readChain(path) {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const arg = (f) => { const i = argv.indexOf(f); return i >= 0 ? argv[i + 1] : null; };
+  const HERE = dirname(fileURLToPath(import.meta.url));
+  const chainPath = arg('--chain') || join(HERE, '..', '.keel', '_chain.jsonl');
+  const pubFile = arg('--pubkey') || process.env.KEEL_RELEASE_PUBKEY || null;
+  let entries, pub = null;
+  try { entries = readChain(chainPath); }
+  catch (e) { console.error(`verify-seal: cannot read chain ${chainPath}: ${e.message}`); process.exit(2); }
+  if (pubFile) { try { pub = readFileSync(pubFile, 'utf8'); } catch (e) { console.error(`verify-seal: cannot read pubkey ${pubFile}: ${e.message}`); process.exit(2); } }
+
+  const r = verifyChain(entries, pub);
+  console.log(`verify-seal: ${r.entries} seal(s) — ${r.signed} signed, ${r.unsigned} self-asserted${pub ? '' : ' (no public key supplied — signatures not checked)'}`);
+  if (!r.ok) {
+    for (const p of r.problems) console.error(`  ✗ ${p}`);
+    console.error('TRANSPARENCY VERIFICATION FAILED — the seal chain is not trustworthy.');
+    process.exit(1);
+  }
+  console.log('✓ chain intact (append-only links verified)' + (r.signed && pub ? ' and every signed seal authenticated.' : '.'));
+  process.exit(0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/keel-floor.sh
+++ b/scripts/keel-floor.sh
@@ -7,11 +7,11 @@
 # Usage:  scripts/keel-floor.sh [--concept <id>]
 #         (defaults to NotSlop gate concept)
 #
-# Requires: node (>=22), cargo, the keel repo at ~/keel (or KEEL_ROOT).
+# Requires: node (>=22), cargo, keel vendored at keel/ (or KEEL_ROOT).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-KEEL="${KEEL_ROOT:-$HOME/keel}"
+KEEL="${KEEL_ROOT:-$ROOT/keel}"
 PROFILE="$ROOT/braid.profile.json"
 
 if [ ! -f "$KEEL/src/run.mjs" ]; then

--- a/scripts/keel-floor.sh
+++ b/scripts/keel-floor.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Braid U-SA — run Keel safety-assurance floor against the workspace.
+#
+# Produces the Tier-2 semantic verdict: reads Tier-1 evidence (cargo test,
+# clippy, etc.) and evaluates the NotSlop concept via Keel's engine.
+#
+# Usage:  scripts/keel-floor.sh [--concept <id>]
+#         (defaults to NotSlop gate concept)
+#
+# Requires: node (>=22), cargo, the keel repo at ~/keel (or KEEL_ROOT).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KEEL="${KEEL_ROOT:-$HOME/keel}"
+PROFILE="$ROOT/braid.profile.json"
+
+if [ ! -f "$KEEL/src/run.mjs" ]; then
+  echo "Keel not found at $KEEL (set KEEL_ROOT to override)" >&2
+  exit 2
+fi
+
+if [ ! -f "$PROFILE" ]; then
+  echo "braid.profile.json not found at $PROFILE" >&2
+  exit 2
+fi
+
+CONCEPT="${1:-}"
+if [ "$CONCEPT" = "--concept" ] && [ -n "${2:-}" ]; then
+  CONCEPT_FLAG=(--concept "$2")
+  shift 2
+else
+  CONCEPT_FLAG=()
+fi
+
+echo "Keel safety-assurance floor (profile: $PROFILE)"
+echo "  keel:    $KEEL"
+echo "  concept: ${CONCEPT_FLAG[1]:-NotSlop (default)}"
+echo ""
+
+node "$KEEL/src/run.mjs" --profile "$PROFILE" "${CONCEPT_FLAG[@]+"${CONCEPT_FLAG[@]}"}"


### PR DESCRIPTION
## What

Adds the Tier-2 semantic floor to Braid's CI pipeline — the `NotSlop` gate via Keel.

**Files:**
- `braid.profile.json` — Keel tailoring profile binding 8 atoms to Braid's Tier-1 tools
- `scripts/keel-floor.sh` — helper to run Keel locally
- `.github/workflows/ci.yml` — `tier2-semantic` job (runs after `test`)

## Gate concept: NotSlop

```
referential_truth ∧ type_soundness ∧ totality_or_controlled_partiality ∧ specification_fidelity
∧ invariant_preservation ∧ security_by_construction ∧ testability_falsifiability ∧ change_locality
```

All 8 atoms pass on the current tree (verified locally, GO verdict).

## Honest gaps (three-valued discipline)

Graded atoms without mechanical numeric extraction are left unbound:
`boundary_completeness`, `minimal_sufficient_complexity`, `algorithmic_efficiency`,
`state_minimization`, `observability`. These evaluate `unknown`, which blocks `Excellent`
but passes `NotSlop`. They'll be bound as the toolchain matures.

## Dependency

**Requires [Keel PR #1](https://github.com/srinji-kaggss/keel/pull/1)** (NotSlop concept) to merge first.

Closes `spec/braid/SAFETY_ASSURANCE_CI_SPEC.md` (D32).