### PR TITLE
fix(braid-ir,braid-capability): make the canonical core no_std+alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ resolver = "2"
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.dependencies]
 # Content-addressed hash chain (BLAKE3 CIDs under lw.braid.*).
-blake3 = "1.8.5"
+blake3 = { version = "1.8.5", default-features = false }
 
 # The capability token newtype uses serde for canonical round-trip; no strum
 # needed (D31: string-tagged capabilities replaced the kernel enum mirror).
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { version = "1.0.228", default-features = false, features = ["derive", "alloc"] }
 
 # Test-only.
 hex = "0.4.3"

--- a/crates/braid-capability/src/lib.rs
+++ b/crates/braid-capability/src/lib.rs
@@ -20,9 +20,13 @@
 //! verbatim; no normalization) so `Capability::new("web.dom.read")` and
 //! `Capability::from_str("web.dom.read")` produce the same bytes.
 
+#![no_std]
+extern crate alloc;
+
+use alloc::string::{String, ToString};
+use core::fmt;
+use core::str::FromStr;
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::str::FromStr;
 
 /// A capability permission token — a dotted string name drawn from a
 /// vocabulary's declared capability space. Capabilities are compared by name;
@@ -51,7 +55,7 @@ impl fmt::Display for Capability {
 }
 
 impl FromStr for Capability {
-    type Err = std::convert::Infallible;
+    type Err = core::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(s.to_string()))
     }

--- a/crates/braid-ir/src/braid.rs
+++ b/crates/braid-ir/src/braid.rs
@@ -7,6 +7,9 @@
 
 use crate::term::RegistryError;
 use crate::value::Value;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 
 /// One term application. `inputs[i]` is the index of the strand whose output
 /// feeds this strand's i-th parameter.

--- a/crates/braid-ir/src/canon.rs
+++ b/crates/braid-ir/src/canon.rs
@@ -15,7 +15,9 @@
 //! - no trailing bytes; nesting depth capped.
 
 use crate::value::Value;
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 /// Maximum nesting depth (fail-closed resource bound, not a tunable).
 pub const MAX_DEPTH: usize = 64;
@@ -45,7 +47,7 @@ pub enum CanonError {
 /// Canonical key order: length first, then bytewise — equals RFC 8949
 /// deterministic encoding order for definite-length text keys (the length is
 /// in the head byte(s), so encoded-byte comparison sees it first).
-pub fn key_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+pub fn key_cmp(a: &str, b: &str) -> core::cmp::Ordering {
     a.len()
         .cmp(&b.len())
         .then_with(|| a.as_bytes().cmp(b.as_bytes()))
@@ -223,7 +225,7 @@ impl<'a> Reader<'a> {
             2 => Ok(Value::Bytes(self.take(n as usize)?.to_vec())),
             3 => {
                 let raw = self.take(n as usize)?;
-                let s = std::str::from_utf8(raw).map_err(|_| CanonError::Utf8)?;
+                let s = core::str::from_utf8(raw).map_err(|_| CanonError::Utf8)?;
                 Ok(Value::Text(s.to_string()))
             }
             4 => {
@@ -252,11 +254,11 @@ impl<'a> Reader<'a> {
                     }
                     let kn = self.arg(kb)?;
                     let raw = self.take(kn as usize)?;
-                    let k = std::str::from_utf8(raw)
+                    let k = core::str::from_utf8(raw)
                         .map_err(|_| CanonError::Utf8)?
                         .to_string();
                     if let Some(p) = &prev {
-                        if key_cmp(p, &k) != std::cmp::Ordering::Less {
+                        if key_cmp(p, &k) != core::cmp::Ordering::Less {
                             return Err(CanonError::KeyOrder);
                         }
                     }

--- a/crates/braid-ir/src/capsule.rs
+++ b/crates/braid-ir/src/capsule.rs
@@ -7,7 +7,10 @@ use crate::cid::{Cid, CAPSULE_DOMAIN};
 use crate::term::RegistryError;
 use crate::value::Value;
 use braid_capability::Capability;
-use std::str::FromStr;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::str::FromStr;
 
 /// Braid IR version. Bumped on ANY change to capsule/braid/registry canonical
 /// shape; admission refuses a mismatch (D11). Pinned by `tests/kat.rs`.

--- a/crates/braid-ir/src/cid.rs
+++ b/crates/braid-ir/src/cid.rs
@@ -3,6 +3,9 @@
 //! `state-fabric::compute_content_hash` (domain ‖ framed fields), under Braid's
 //! own `lw.braid.*` namespace so a Braid hash can never collide a fact hash.
 
+use alloc::format;
+use alloc::string::String;
+
 /// Domain for a capsule's content address.
 pub const CAPSULE_DOMAIN: &[u8] = b"lw.braid.capsule.v0";
 /// Domain for a term-registry's content address (pinned inside every capsule —
@@ -38,7 +41,7 @@ impl Cid {
         }
         let mut out = [0u8; 32];
         for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
-            let s = std::str::from_utf8(chunk).ok()?;
+            let s = core::str::from_utf8(chunk).ok()?;
             out[i] = u8::from_str_radix(s, 16).ok()?;
         }
         Some(Cid(out))

--- a/crates/braid-ir/src/lib.rs
+++ b/crates/braid-ir/src/lib.rs
@@ -23,6 +23,9 @@
 //! Boundary covenant (D3): this crate depends only on `blake3` and
 //! `braid-capability`. Enforced by `tests/boundary_conformance.rs`.
 
+#![no_std]
+extern crate alloc;
+
 pub mod braid;
 pub mod canon;
 pub mod capsule;

--- a/crates/braid-ir/src/term.rs
+++ b/crates/braid-ir/src/term.rs
@@ -7,8 +7,13 @@ use crate::canon;
 use crate::cid::{Cid, REGISTRY_DOMAIN};
 use crate::value::Value;
 use braid_capability::Capability;
-use std::collections::BTreeMap;
-use std::str::FromStr;
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::str::FromStr;
 
 /// The closed type universe of strand wiring. No interpretable-code type
 /// exists (T1) and no float type exists (T8) — by construction, not by check.

--- a/crates/braid-ir/src/value.rs
+++ b/crates/braid-ir/src/value.rs
@@ -5,7 +5,9 @@
 //! in `Int` with term-level scaling. The absence of the variant — not a
 //! runtime check — is what makes a float unrepresentable.
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 /// A value in the Braid IR. Closed; every variant has exactly one canonical
 /// byte form under [`crate::canon`].


### PR DESCRIPTION
## Root cause (not a paper-over)
`braid-ir` and `braid-capability` were **std-only** (`std::collections::BTreeMap`, `std::fmt`/`str`/`convert`). Consequence: **no `no_std` substrate could depend on them** — so both the kernel (`canvas-syscall`) and the `next-gen-browser-engine` core **re-declared / snapshotted the canonical IR** instead of consuming it. That duplication is the symptom; the std posture is the root cause.

This makes Braid genuinely consumable as the one canonical core by every substrate (all of which are `no_std`, per kernel A18 / browser A18).

## Change
- `braid-ir` + `braid-capability`: `#![no_std]` + `extern crate alloc`; every `std::` site → `core::`/`alloc::` (no std-only functionality existed — no io/HashMap/threads, only `BTreeMap`/`fmt`/`str`/`convert`).
- Workspace `blake3` → `default-features = false` (only `braid-ir` uses it; mirrors the kernel pin `blake3 = { version = "1.8.5", default-features = false }`).
- Workspace `serde` → `default-features = false, features = ["derive", "alloc"]` (blast-radius checked: only `braid-capability` + the std `braid-cli` binary use serde; no crate serializes std-only types).

## Verification
- `cargo test -p braid-ir -p braid-capability` — green (all suites).
- `cargo build --workspace` — green (cli/verify/render/sdk/vocab unaffected by the serde change).
- **`cargo build -p braid-ir -p braid-capability --target x86_64-unknown-none`** — compiles for bare-metal (no `std`): the gold-standard `no_std` proof.

## Unblocks
A real `braid-ir` dependency from both consumers: deletes the browser's re-declared `Cid`/`WebAnchor`/`TermFamily`/`braid_bridge` shadow (+ `okf.py` → `braid-render`), and retires the kernel's pinned-snapshot seam (#565/#602) for a live `registry_v0()` decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)