### PR TITLE
U11: JS→Braid elaborator — first real frontend over the global IR (+ U11–U15 roadmap)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "braid-elaborate-js"
+version = "0.1.0"
+dependencies = [
+ "braid-capability",
+ "braid-ir",
+ "braid-render",
+ "braid-sdk",
+ "braid-verify",
+ "braid-vocab-js",
+]
+
+[[package]]
 name = "braid-ir"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/braid-render",
     "crates/braid-sdk",
     "crates/braid-cli",
+    "crates/braid-elaborate-js",
 ]
 resolver = "2"
 
@@ -39,6 +40,7 @@ braid-vocab-cms = { path = "crates/braid-vocab-cms" }
 braid-vocab-js = { path = "crates/braid-vocab-js" }
 braid-verify = { path = "crates/braid-verify" }
 braid-render = { path = "crates/braid-render" }
+braid-sdk = { path = "crates/braid-sdk" }
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ for exactly what changed in the move.
 | `crates/braid-render` | CID-bound manifest, deterministic text rendering, widening/narrowing diff, DOT graph export. |
 | `crates/braid-sdk` | Typed authoring builder over `braid-ir`; takes any vocabulary's registry. |
 | `crates/braid-cli` | The `braid` binary: `encode`/`decode`/`verify`/`render`/`diff` — the human-reconstructable loop (no AI, no Rust). Pins the `braid-vocab-cms` registry for the CMS reference workflow. |
+| `crates/braid-elaborate-js` | **Frontend** (U11): lexes/parses a JS expression subset (literals + `+`) and elaborates JS *text* into an admitted capsule via the one `braid-verify`. The first real frontend over the global IR — "renders JS useless" made operational (D31). |
 | `spec/braid/` | PRD, decision register (`DECISIONS.md`), threat model, unit plan, KAT vectors. **Start here: `spec/braid/README.md`.** |
 | `docs/` | ADR-088 (ratified doctrine + locked invariants); `authoring-cli.md` (hand-author a capsule). |
 
@@ -45,7 +46,7 @@ for exactly what changed in the move.
 
 ```bash
 cargo check --workspace
-cargo test --workspace      # 103 tests
+cargo test --workspace      # 117 tests
 cargo clippy --workspace --all-targets
 ./scripts/cli-loop.sh       # scenario #12 end-to-end (also a CI job)
 ```

--- a/crates/braid-elaborate-js/Cargo.toml
+++ b/crates/braid-elaborate-js/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "braid-elaborate-js"
+version = "0.1.0"
+edition = "2021"
+description = "A thin JavaScript-expression frontend that elaborates JS source into Braid IR (D31, U11). The first real frontend over the global IR: JS text in, an admitted Capsule out, via the one braid-verify — JS as an authoring frontend over the verified substrate, not a runtime authority."
+repository = "https://github.com/srinji-kaggss/Braid"
+homepage = "https://github.com/srinji-kaggss/Braid"
+license = "MIT"
+
+[lib]
+name = "braid_elaborate_js"
+path = "src/lib.rs"
+
+[[bin]]
+name = "braid-elaborate-js"
+path = "src/main.rs"
+
+# A consumer/frontend crate, not trust-base (like braid-cli/braid-sdk). It
+# elaborates INTO the substrate via the SDK; it is not part of the D3 boundary
+# the substrate crates (braid-ir/braid-verify/braid-render) are fenced to.
+[dependencies]
+braid-ir = { workspace = true }
+braid-capability = { workspace = true }
+braid-verify = { workspace = true }
+braid-render = { workspace = true }
+braid-sdk = { workspace = true }
+braid-vocab-js = { workspace = true }
+
+[dev-dependencies]
+braid-vocab-js = { workspace = true }

--- a/crates/braid-elaborate-js/src/lib.rs
+++ b/crates/braid-elaborate-js/src/lib.rs
@@ -1,0 +1,338 @@
+//! # braid-elaborate-js — a thin JavaScript-expression frontend (U11, D31)
+//!
+//! The **first real frontend over the global IR.** Today `braid-vocab-js`
+//! exists and is proven by a *hand-built* SDK capsule
+//! (`js_capsule_admits_via_the_one_verifier`), but nothing actually compiles
+//! JS *text* into it. This crate closes the first increment of D-ELAB: JS
+//! source in, an admitted [`braid_ir::Capsule`] out, via the **one**
+//! `braid-verify`. It operationalizes D31's "renders JS useless" — JS becomes
+//! an authoring frontend over the verified substrate, not a runtime authority.
+//!
+//! ## Scope (deliberately a thin vertical slice — U11, not a JS parser)
+//! A JS *expression* over string literals, integer-number literals, and the
+//! binary `+` operator (left-associative, parenthesizable). `+` elaborates to
+//! `js.concat` for two strings and `js.add` for two numbers; a mixed
+//! `string + number` is **rejected at elaboration** (fail-closed — no implicit
+//! coercion, and no malformed capsule ever reaches the verifier). Identifiers,
+//! calls, statements, and the `js.eval`/`js.fetch` escalation probes are U12+.
+//!
+//! ## Boundary
+//! A *consumer* crate (like `braid-cli`/`braid-sdk`): it elaborates INTO the
+//! substrate through `braid_sdk::Builder`; it is **not** trust-base and builds
+//! no second verifier. The verifier remains the sole admission authority (D9).
+//!
+//! ## A known seed-vocabulary limitation (honest, not a bug)
+//! The v0 `js.lit.*` terms are *valueless* — `js.lit.string` records "a string
+//! literal occurs here", not its bytes. So the IR/CID is a function of the
+//! expression's *structure*, not literal content. Carrying literal payloads is
+//! a `braid-vocab-js` extension (U12), not this frontend's job.
+
+use braid_ir::Capsule;
+use braid_render::{manifest, render_text};
+use braid_sdk::{Builder, Strand};
+use braid_verify::{verify, Verdict};
+use braid_vocab_js::registry_v0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The two value types this slice's `+` operator distinguishes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValType {
+    Str,
+    Num,
+}
+
+impl core::fmt::Display for ValType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ValType::Str => f.write_str("string"),
+            ValType::Num => f.write_str("number"),
+        }
+    }
+}
+
+/// Every way the frontend fails closed. None of these produce a capsule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ElabError {
+    /// No tokens — empty or whitespace-only source.
+    Empty,
+    /// A character or string the lexer cannot tokenize.
+    Lex(String),
+    /// A token stream the grammar does not accept.
+    Parse(String),
+    /// `+` applied to mismatched operand types (no implicit coercion).
+    TypeMismatch { left: ValType, right: ValType },
+    /// The SDK refused to author the capsule (carries the `BuildError` debug).
+    Build(String),
+    /// Manifest rendering failed (carries the `RenderError` debug).
+    Render(String),
+}
+
+impl ElabError {
+    fn build(e: braid_sdk::BuildError) -> Self {
+        ElabError::Build(format!("{e:?}"))
+    }
+}
+
+impl core::fmt::Display for ElabError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ElabError::Empty => f.write_str("empty source: nothing to elaborate"),
+            ElabError::Lex(m) => write!(f, "lex error: {m}"),
+            ElabError::Parse(m) => write!(f, "parse error: {m}"),
+            ElabError::TypeMismatch { left, right } => write!(
+                f,
+                "type error: `+` requires matching operand types (no implicit \
+                 coercion); got {left} + {right}"
+            ),
+            ElabError::Build(m) => write!(f, "build error: {m}"),
+            ElabError::Render(m) => write!(f, "render error: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for ElabError {}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lexer
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Token {
+    Str(String),
+    Num(i64),
+    Plus,
+    LParen,
+    RParen,
+}
+
+fn lex(src: &str) -> Result<Vec<Token>, ElabError> {
+    let chars: Vec<char> = src.chars().collect();
+    let mut toks = Vec::new();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            ' ' | '\t' | '\n' | '\r' => i += 1,
+            '+' => {
+                toks.push(Token::Plus);
+                i += 1;
+            }
+            '(' => {
+                toks.push(Token::LParen);
+                i += 1;
+            }
+            ')' => {
+                toks.push(Token::RParen);
+                i += 1;
+            }
+            '"' | '\'' => {
+                let quote = c;
+                i += 1;
+                let mut s = String::new();
+                loop {
+                    let Some(&ch) = chars.get(i) else {
+                        return Err(ElabError::Lex("unterminated string literal".to_string()));
+                    };
+                    if ch == quote {
+                        i += 1;
+                        break;
+                    }
+                    if ch == '\\' {
+                        i += 1;
+                        let Some(&e) = chars.get(i) else {
+                            return Err(ElabError::Lex("trailing backslash in string".to_string()));
+                        };
+                        s.push(match e {
+                            'n' => '\n',
+                            't' => '\t',
+                            '\\' => '\\',
+                            '"' => '"',
+                            '\'' => '\'',
+                            other => {
+                                return Err(ElabError::Lex(format!("unsupported escape \\{other}")))
+                            }
+                        });
+                        i += 1;
+                    } else {
+                        s.push(ch);
+                        i += 1;
+                    }
+                }
+                toks.push(Token::Str(s));
+            }
+            d if d.is_ascii_digit() => {
+                let mut n = String::new();
+                while let Some(&d) = chars.get(i) {
+                    if !d.is_ascii_digit() {
+                        break;
+                    }
+                    n.push(d);
+                    i += 1;
+                }
+                let val = n
+                    .parse::<i64>()
+                    .map_err(|_| ElabError::Lex(format!("integer literal out of range: {n}")))?;
+                toks.push(Token::Num(val));
+            }
+            other => return Err(ElabError::Lex(format!("unexpected character {other:?}"))),
+        }
+    }
+    Ok(toks)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Parser  —  expr := atom ('+' atom)*  ;  atom := num | str | '(' expr ')'
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The expression AST. `Add` is the *syntactic* `+`; whether it elaborates to
+/// `js.concat` or `js.add` is decided by operand types at elaboration time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Expr {
+    Str(String),
+    Num(i64),
+    Add(Box<Expr>, Box<Expr>),
+}
+
+struct Parser {
+    toks: Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    fn peek(&self) -> Option<&Token> {
+        self.toks.get(self.pos)
+    }
+
+    fn bump(&mut self) -> Option<Token> {
+        let t = self.toks.get(self.pos).cloned();
+        if t.is_some() {
+            self.pos += 1;
+        }
+        t
+    }
+
+    fn parse_expr(&mut self) -> Result<Expr, ElabError> {
+        let mut left = self.parse_atom()?;
+        while matches!(self.peek(), Some(Token::Plus)) {
+            self.bump();
+            let right = self.parse_atom()?;
+            left = Expr::Add(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_atom(&mut self) -> Result<Expr, ElabError> {
+        match self.bump() {
+            Some(Token::Num(n)) => Ok(Expr::Num(n)),
+            Some(Token::Str(s)) => Ok(Expr::Str(s)),
+            Some(Token::LParen) => {
+                let inner = self.parse_expr()?;
+                match self.bump() {
+                    Some(Token::RParen) => Ok(inner),
+                    other => Err(ElabError::Parse(format!("expected ')', found {other:?}"))),
+                }
+            }
+            other => Err(ElabError::Parse(format!(
+                "expected a literal or '(', found {other:?}"
+            ))),
+        }
+    }
+}
+
+/// Parse a token stream into an [`Expr`]. Exposed so U12 can reuse it.
+pub fn parse(src: &str) -> Result<Expr, ElabError> {
+    let toks = lex(src)?;
+    if toks.is_empty() {
+        return Err(ElabError::Empty);
+    }
+    let mut p = Parser { toks, pos: 0 };
+    let expr = p.parse_expr()?;
+    if p.pos != p.toks.len() {
+        return Err(ElabError::Parse(format!(
+            "unexpected trailing token {:?}",
+            p.toks.get(p.pos)
+        )));
+    }
+    Ok(expr)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Elaboration  —  Expr → Strands over braid-vocab-js, via the SDK
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn emit(b: &mut Builder, e: &Expr) -> Result<(Strand, ValType), ElabError> {
+    match e {
+        Expr::Str(_) => {
+            let s = b.strand("js.lit.string", &[]).map_err(ElabError::build)?;
+            Ok((s, ValType::Str))
+        }
+        Expr::Num(_) => {
+            let s = b.strand("js.lit.number", &[]).map_err(ElabError::build)?;
+            Ok((s, ValType::Num))
+        }
+        Expr::Add(l, r) => {
+            let (lh, lt) = emit(b, l)?;
+            let (rh, rt) = emit(b, r)?;
+            // The overload resolution + the fail-closed line: matching types
+            // pick a term; a mismatch is an elaboration error, never a coercion.
+            let term = match (lt, rt) {
+                (ValType::Str, ValType::Str) => "js.concat",
+                (ValType::Num, ValType::Num) => "js.add",
+                _ => {
+                    return Err(ElabError::TypeMismatch {
+                        left: lt,
+                        right: rt,
+                    })
+                }
+            };
+            let s = b.strand(term, &[lh, rh]).map_err(ElabError::build)?;
+            Ok((s, lt))
+        }
+    }
+}
+
+/// The deterministic intent string for a source. Folding the source text in
+/// makes the capsule CID a reproducible function of the human input — the
+/// human-reconstructable-loop guarantee (same source ⇒ same CID).
+fn intent_for(src: &str) -> String {
+    format!("JS expression elaborated to Braid IR (U11): {}", src.trim())
+}
+
+/// Elaborate a JS expression into an admittable [`Capsule`]. Pure value
+/// construction only, so no capability/confirm is required and `build()`
+/// succeeds with `ConfirmPolicy::None`.
+pub fn elaborate_js(src: &str) -> Result<Capsule, ElabError> {
+    let expr = parse(src)?;
+    let reg = registry_v0();
+    let mut b = Builder::new(&reg, intent_for(src));
+    let (root, _ty) = emit(&mut b, &expr)?;
+    b.output(root);
+    b.build().map_err(ElabError::build)
+}
+
+/// The full thin-slice loop: source → IR → **verify** → manifest. The verdict
+/// is read off the one `braid-verify` against the JS vocabulary's registry;
+/// the manifest is the human-audit object bound to the capsule's CID.
+pub struct Elaboration {
+    pub capsule: Capsule,
+    pub verdict: Verdict,
+    pub manifest_text: String,
+}
+
+/// Elaborate, then admit + render. The ambient grant set is empty: a pure
+/// expression requests no capability, so `∅ ⊆ ∅` passes the attenuation check.
+pub fn elaborate_and_admit(src: &str) -> Result<Elaboration, ElabError> {
+    let capsule = elaborate_js(src)?;
+    let reg = registry_v0();
+    let verdict = verify(&capsule.to_bytes(), &reg, &[]);
+    let m = manifest(&capsule, &reg).map_err(|e| ElabError::Render(format!("{e:?}")))?;
+    let manifest_text = render_text(&m);
+    Ok(Elaboration {
+        capsule,
+        verdict,
+        manifest_text,
+    })
+}

--- a/crates/braid-elaborate-js/src/main.rs
+++ b/crates/braid-elaborate-js/src/main.rs
@@ -1,0 +1,40 @@
+//! `braid-elaborate-js "<js expression>"` — the human-reconstructable loop for
+//! the JS frontend: prints the capsule CID, the verifier verdict, and the
+//! CID-bound manifest. Mirrors `braid-cli`'s shape so the SDK/CLI parity
+//! doctrine holds (no path that only the library can drive — T13).
+
+use std::process::ExitCode;
+
+use braid_elaborate_js::elaborate_and_admit;
+use braid_verify::Verdict;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: braid-elaborate-js \"<js expression>\"");
+        eprintln!("example: braid-elaborate-js '\"hello\" + \"world\"'");
+        return ExitCode::from(2);
+    }
+    let src = args.join(" ");
+
+    match elaborate_and_admit(&src) {
+        Ok(e) => {
+            println!("source : {src}");
+            println!("cid    : {}", e.capsule.cid().to_hex());
+            match &e.verdict {
+                Verdict::Admit { capsule_cid } => {
+                    println!("verdict: ADMIT ({})", capsule_cid.to_hex());
+                }
+                Verdict::Reject { stage, reason } => {
+                    println!("verdict: REJECT [{stage:?}] {reason}");
+                }
+            }
+            println!("\n--- manifest ---\n{}", e.manifest_text);
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("elaboration error: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/braid-elaborate-js/tests/elaborate.rs
+++ b/crates/braid-elaborate-js/tests/elaborate.rs
@@ -1,0 +1,136 @@
+//! U11 — the thin vertical slice's proof: JS source → IR → verify, end to end,
+//! pinned. Each test drives the *same* public path the binary uses; nothing is
+//! mocked. The verdict is read off the one `braid-verify`.
+
+use braid_elaborate_js::{elaborate_and_admit, elaborate_js, ElabError};
+use braid_verify::Verdict;
+
+/// Strand term ids in index (= topological) order — the structural fingerprint.
+fn terms(capsule: &braid_ir::Capsule) -> Vec<&str> {
+    capsule
+        .braid
+        .strands
+        .iter()
+        .map(|s| s.term.as_str())
+        .collect()
+}
+
+#[test]
+fn string_concat_admits() {
+    let e = elaborate_and_admit(r#""hello" + "world""#).expect("elaborates");
+    // Two valueless string literals feeding one concat — the structure D31's
+    // valueless `js.lit.*` produces.
+    assert_eq!(
+        terms(&e.capsule),
+        ["js.lit.string", "js.lit.string", "js.concat"]
+    );
+    assert_eq!(e.capsule.braid.outputs, vec![2]);
+    // The whole point: the one verifier admits a capsule that was *compiled*
+    // from JS text, not hand-built.
+    assert_eq!(
+        e.verdict,
+        Verdict::Admit {
+            capsule_cid: e.capsule.cid()
+        }
+    );
+}
+
+#[test]
+fn number_add_admits() {
+    let e = elaborate_and_admit("1 + 2").expect("elaborates");
+    assert_eq!(
+        terms(&e.capsule),
+        ["js.lit.number", "js.lit.number", "js.add"]
+    );
+    assert_eq!(e.capsule.braid.outputs, vec![2]);
+    assert_eq!(
+        e.verdict,
+        Verdict::Admit {
+            capsule_cid: e.capsule.cid()
+        }
+    );
+}
+
+#[test]
+fn mixed_types_rejected_at_elaboration() {
+    // Fail-closed: the type error fires in the frontend, BEFORE any capsule is
+    // built — so no malformed artifact ever reaches the verifier (the verifier
+    // is a floor, not the only line of defense). No implicit coercion.
+    match elaborate_js(r#""a" + 1"#) {
+        Err(ElabError::TypeMismatch { left, right }) => {
+            assert_eq!(left.to_string(), "string");
+            assert_eq!(right.to_string(), "number");
+        }
+        other => panic!("expected a TypeMismatch elaboration error, got {other:?}"),
+    }
+    // The full loop surfaces the same error (and never produces a verdict).
+    assert!(matches!(
+        elaborate_and_admit(r#""a" + 1"#),
+        Err(ElabError::TypeMismatch { .. })
+    ));
+}
+
+#[test]
+fn pinned_cid() {
+    // The human-reconstructable-loop guarantee (matches the repo's KAT-vector
+    // discipline): the same source always elaborates to the same capsule CID.
+    // If this changes, the encoding/intent/elaboration contract moved — that
+    // must be a conscious, recorded event, never a silent drift.
+    let capsule = elaborate_js(r#""hello" + "world""#).expect("elaborates");
+    assert_eq!(
+        capsule.cid().to_hex(),
+        "e257c090bb647765e6bc3d318d770c4a3688c8bc5084a91bb68bb5700c60edc4"
+    );
+}
+
+#[test]
+fn associativity_is_left() {
+    // `1 + 2 + 3` parses as `(1 + 2) + 3`: the first add (idx 2) consumes the
+    // two leading literals; the second add (idx 4) consumes that result + the
+    // third literal. Five strands, root = idx 4.
+    let capsule = elaborate_js("1 + 2 + 3").expect("elaborates");
+    assert_eq!(
+        terms(&capsule),
+        [
+            "js.lit.number",
+            "js.lit.number",
+            "js.add",
+            "js.lit.number",
+            "js.add"
+        ]
+    );
+    assert_eq!(capsule.braid.strands[2].inputs, vec![0, 1]);
+    assert_eq!(capsule.braid.strands[4].inputs, vec![2, 3]);
+    assert_eq!(capsule.braid.outputs, vec![4]);
+}
+
+#[test]
+fn parentheses_regroup() {
+    // `1 + (2 + 3)` must differ structurally from the left-assoc default:
+    // the inner add (idx 3) consumes literals 1 and 2; the outer add (idx 4)
+    // consumes literal 0 + that inner result. Proves the parser honors '()'.
+    let capsule = elaborate_js("1 + (2 + 3)").expect("elaborates");
+    assert_eq!(capsule.braid.strands[3].inputs, vec![1, 2]);
+    assert_eq!(capsule.braid.strands[4].inputs, vec![0, 3]);
+    assert_eq!(capsule.braid.outputs, vec![4]);
+    // Different shape ⇒ different CID than the left-assoc `1 + 2 + 3`.
+    assert_ne!(
+        capsule.cid().to_hex(),
+        elaborate_js("1 + 2 + 3").unwrap().cid().to_hex()
+    );
+}
+
+#[test]
+fn malformed_sources_fail_closed() {
+    // A representative sweep of fail-closed paths — none produces a capsule.
+    assert!(matches!(elaborate_js(""), Err(ElabError::Empty)));
+    assert!(matches!(elaborate_js("   "), Err(ElabError::Empty)));
+    assert!(matches!(elaborate_js("1 +"), Err(ElabError::Parse(_))));
+    assert!(matches!(elaborate_js("1 2"), Err(ElabError::Parse(_))));
+    assert!(matches!(elaborate_js("(1 + 2"), Err(ElabError::Parse(_))));
+    assert!(matches!(
+        elaborate_js(r#""unterminated"#),
+        Err(ElabError::Lex(_))
+    ));
+    assert!(matches!(elaborate_js("1 - 2"), Err(ElabError::Lex(_))));
+}

--- a/crates/braid-ir/src/capsule.rs
+++ b/crates/braid-ir/src/capsule.rs
@@ -6,10 +6,10 @@ use crate::canon::{self, CanonError};
 use crate::cid::{Cid, CAPSULE_DOMAIN};
 use crate::term::RegistryError;
 use crate::value::Value;
-use braid_capability::Capability;
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
+use braid_capability::Capability;
 use core::str::FromStr;
 
 /// Braid IR version. Bumped on ANY change to capsule/braid/registry canonical

--- a/crates/braid-ir/src/term.rs
+++ b/crates/braid-ir/src/term.rs
@@ -6,13 +6,13 @@
 use crate::canon;
 use crate::cid::{Cid, REGISTRY_DOMAIN};
 use crate::value::Value;
-use braid_capability::Capability;
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
+use braid_capability::Capability;
 use core::str::FromStr;
 
 /// The closed type universe of strand wiring. No interpretable-code type

--- a/crates/braid-vocab-web/src/lib.rs
+++ b/crates/braid-vocab-web/src/lib.rs
@@ -234,7 +234,10 @@ mod tests {
                 assert!(term.egress_ceiling.is_some());
             }
         }
-        assert_eq!(r.get("web.download").unwrap().effect, EffectClass::Irreversible);
+        assert_eq!(
+            r.get("web.download").unwrap().effect,
+            EffectClass::Irreversible
+        );
     }
 
     #[test]
@@ -243,7 +246,10 @@ mod tests {
         for id in ["web.execute_js", "web.execute_wasm"] {
             let term = r.get(id).unwrap();
             assert_ne!(term.effect, EffectClass::Egress);
-            assert_eq!(term.capability.as_ref().unwrap().as_str(), COMPUTE_LOCAL_NAME);
+            assert_eq!(
+                term.capability.as_ref().unwrap().as_str(),
+                COMPUTE_LOCAL_NAME
+            );
         }
     }
 

--- a/spec/braid/DEBT_REGISTER.md
+++ b/spec/braid/DEBT_REGISTER.md
@@ -17,6 +17,11 @@
   capabilities, `TypeTag::Opaque`, 2 vocabularies (CMS + JS proof-of-concept).
 - ✅ **Publishability** — `braid-v0.1` git tag cut; `braid-capability`
   crates.io-ready; the rest `cargo add --git`.
+- ✅ **Tier-2 safety-assurance CI** (U-SA, D32) — `braid.profile.json` binds
+  Keel's 20 atoms (gate `NotSlop`); `keel/` vendored; the gate runs in CI.
+- ✅ **First real language frontend** (U11, D31) — `braid-elaborate-js`
+  compiles a JS expression subset (literals + `+`) into admitted capsules via
+  the one verifier; "renders JS useless" is operational for that subset.
 
 ## Open debts (the Java-ecosystem gap)
 
@@ -27,13 +32,18 @@ with no V. A Java-ecosystem substrate without execution is a spec, not a
 product.
 **Closes**: U7 (blocked); PRD §1 "self-sufficient runtime ecosystem."
 
-### D-ELAB — No real language frontend / elaborator
-No JS→Braid parser exists. No Java→Braid. No surface syntax (D6-gated). The
-"renders JS useless" claim is *architectural* (the IR shape can accept any
-language — D31), not *operational* (no tool actually compiles a language to it).
-A Java ecosystem needs a `javac`.
-**Closes**: a real JS→Braid elaborator (proposed next unit); D6-gated surface
-syntax for the human authoring direction.
+### D-ELAB — No real language frontend / elaborator *(first slice LANDED — U11)*
+🟡 **Partially closed.** `braid-elaborate-js` (U11) is the first real frontend:
+it lexes/parses a JS *expression* subset (string/number literals + `+`,
+parenthesizable) and **compiles JS text into an admitted capsule** via the one
+`braid-verify` — the "renders JS useless" claim (D31) is now *operational* for
+that subset, not just architectural. Remaining gap: it is an *expression* slice
+(no identifiers/statements/calls; valueless `js.lit.*`), there is no Java→Braid,
+and no D6-gated surface syntax for the human authoring direction. A Java
+ecosystem still needs a full `javac`-class frontend.
+**Closes**: U11 (the expression slice — done); U12 (JS at scale + literal
+payloads); D6-gated surface syntax (later); eventually a real multi-language
+frontend.
 
 ### D-CONSUMER — Zero real consumers
 The browser engine has a parallel `BraidTerm` enum (steer note delivered at
@@ -54,11 +64,14 @@ build tool for multi-capsule projects, no docs generator, no `braid test`
 harness for capsules (vs. tests *of* the substrate).
 **Closes**: PRD §5 P4+.
 
-### D-SA — No Tier-2 safety-assurance floor (the spec this session produced)
-Braid's CI is Tier-1 only (fmt/clippy/test). The "stop slop" semantic floor
-(Keel + Excellent Code Framework) is *specified* (`SAFETY_ASSURANCE_CI_SPEC.md`)
-but not built. Without it, a PR can compile, pass tests, and still be slop.
-**Closes**: `U-SA` (the unit filed from the spec).
+### D-SA — Tier-2 safety-assurance floor *(BUILT — U-SA landed)*
+✅ **Closed.** The "stop slop" semantic floor is no longer just a spec: `U-SA`
+landed (commit `6f74c82` + the Keel-vendoring `ae83171`). `braid.profile.json`
+binds Keel's 20 evidence atoms to Braid's Tier-1 tools (gate concept `NotSlop`),
+`keel/` is vendored (schema + engine), and `.github/workflows/ci.yml` runs the
+Keel gate in CI. The design rationale stays in `SAFETY_ASSURANCE_CI_SPEC.md`.
+**Remaining**: the Lean⇄verifier conformance check (tracked separately as
+D-SEMANTICS / U15), not the Keel wiring itself.
 
 ### D-SEMANTICS — The verifier's stage semantics are not machine-checked against the Lean predicates
 D22 says Lean is the unforked proof oracle; the Rust verifier implements

--- a/spec/braid/units.md
+++ b/spec/braid/units.md
@@ -1,4 +1,4 @@
-# Braid — issue-ready unit plan (U0–U10)
+# Braid — issue-ready unit plan (U0–U15)
 
 **Rule**: no issue, no work — each unit becomes a GitHub issue before
 implementation, citing this file. Sequence rule: lowest unit whose blocked-by
@@ -20,6 +20,18 @@ expected wherever a check has teeth.
 | U8 Day-0 CMS reference | U6 (U7 for execution leg) | T14 |
 | U9 adversarial hacker pass | U6 (re-run after U8) | all |
 | U10 Rust SDK polish | U3 | T13 |
+| U11 JS→Braid elaborator (thin slice) | U6 U10 | T13 (closes D-ELAB.1) |
+| U12 JS vocabulary at scale | U11 | T2 T13 (closes D-VOCAB) |
+| U13 multi-capsule project + toolchain | U6 | T13 (closes D-TOOLCHAIN) |
+| U14 first live consumer collapse | U1 (cross-repo) | T15 (closes D-CONSUMER) |
+| U15 Lean⇄verifier conformance | U3 U4 U5 | T2 T11 (closes D-SEMANTICS) |
+
+> **U0–U10 = v0 (shipped).** U11–U15 are the **post-v0 frontier**: the
+> Java-ecosystem gap catalogued in `DEBT_REGISTER.md`, chunked into issue-ready
+> units. Sequencing still obeys the lowest-satisfied-blocked-by rule; D-RUN
+> (U7) stays blocked on the kernel WASM runtime and is *not* re-chunked here.
+> The discipline is **thin vertical slices** — each unit is the smallest end-to-
+> end increment that moves a debt, not a big-bang.
 
 ---
 
@@ -152,3 +164,82 @@ the CLI path so the SDK never becomes the only path (T13).
 `compile_fail` doctests for illegal compositions the type system can catch
 statically.
 **Verification**: `cargo test -p braid-sdk` + doctests.
+
+---
+
+# Post-v0 frontier (U11–U15) — closing the Java-ecosystem gap
+
+Each unit names the `DEBT_REGISTER.md` debt it moves. The bar is unchanged: no
+substrate/verifier rewrite (the v0 floor is locked), thin vertical slices,
+evidence on the issue.
+
+## U11 — JS→Braid elaborator: the first real frontend *(thin slice — LANDED this session)*
+**Closes**: the first increment of **D-ELAB**. Makes "renders JS useless" (D31)
+*operational*, not just architectural — JS *text* compiles into the verified
+substrate via the one `braid-verify`, with zero AI in the path.
+**Scope**: a `braid-elaborate-js` **consumer** crate (frontend, not trust-base;
+outside the D3 boundary the substrate crates are fenced to). A JS *expression*
+grammar — string literals, integer-number literals, the binary `+` (left-assoc,
+parenthesizable) — lexed + parsed (hand-written recursive descent, no external
+parser dep) and elaborated through `braid_sdk::Builder` over
+`braid_vocab_js::registry_v0()`: `+` → `js.concat` for two strings, `js.add` for
+two numbers. Library API (`elaborate_js`, `elaborate_and_admit`) + a
+`braid-elaborate-js` binary that prints CID + verdict + manifest (SDK/CLI parity,
+T13). **Explicitly out of scope (→ U12):** identifiers, calls, statements, the
+`js.eval`/`js.fetch` escalation probes, and literal *values* (the seed
+`js.lit.*` terms are valueless — IR/CID is a function of structure, not content).
+**AC**: a JS expression elaborates to a capsule the verifier **Admits**; a mixed
+`string + number` is **rejected at elaboration** (fail-closed, no coercion, no
+malformed capsule reaches the verifier); a pinned-CID test fixes the
+human-reconstructable-loop guarantee (same source ⇒ same CID); left-assoc and
+parenthesized grouping are structurally distinct; malformed sources fail closed.
+**Verification**: `cargo test -p braid-elaborate-js` (7 tests, all green);
+`cargo run -p braid-elaborate-js -- '"hello" + "world"'` prints ADMIT;
+`boundary_conformance.rs` still green (the consumer crate respects the boundary).
+
+## U12 — JS vocabulary at scale + literal payloads
+**Closes**: **D-VOCAB** (the 8-term seed → a usable JS subset) and the
+literal-value gap U11 deferred.
+**Scope**: grow `braid-vocab-js` past the seed — value-carrying `js.lit.*`
+(literal bytes/number in the term), comparison + boolean ops, more string ops,
+the typing for `let`/identifiers (a name-resolution pass in the elaborator). A
+written **vocabulary-extension governance note** (PRD §5 P5): how a term is
+added, versioned (D11), and KAT-pinned. The elaborator (U11) consumes the
+widened registry with no second verifier.
+**AC**: a representative JS subset (assignment + arithmetic + comparison)
+round-trips source → admit; vocab version bump is a conscious KAT re-pin;
+distinct literal *values* yield distinct CIDs (the U11 limitation is closed).
+**Verification**: `cargo test -p braid-vocab-js -p braid-elaborate-js`.
+
+## U13 — multi-capsule project model + `braid` toolchain
+**Closes**: **D-TOOLCHAIN** (no build/test model for projects of many capsules).
+**Scope**: a typed project manifest (a set of capsules + their intents/anchors),
+`braid build` (elaborate + admit every capsule, fail-closed on any reject) and
+`braid test` (a harness for capsules, distinct from tests *of* the substrate).
+No package *registry* (PRD §49 non-goal) — local project only.
+**AC**: a multi-capsule sample project builds and tests through one command;
+one rejecting capsule fails the whole build deterministically with the stage.
+**Verification**: integration test over a fixture project; CI job.
+
+## U14 — first live consumer collapse *(cross-repo coordination)*
+**Closes**: **D-CONSUMER** ("become a dependency" has zero live dependents).
+**Scope**: spec + execute the seam that deletes the browser engine's parallel
+`BraidTerm` enum onto `braid-ir`/`braid-capability`/`braid-vocab-web` (the
+`docs/BRAID_STEER.md` collapse), and live-wire the kernel's
+`braid_vocab_binding.rs` snapshot to decode `braid_vocab_cms::registry_v0()`.
+Braid ships only the substrate + the steer; the consumer owns its vocabulary.
+**AC**: one real consumer compiles against the published Braid crates with its
+parallel IR deleted; the kernel binding decodes the live registry with its
+snapshot assertions still green (the dotted names are preserved verbatim).
+**Verification**: the consumer repo's CI; the kernel binding test.
+
+## U15 — Lean⇄verifier conformance check
+**Closes**: **D-SEMANTICS** (the 8 verifier stages are not machine-checked
+against the Lean predicates D22 names as the proof oracle).
+**Scope**: a conformance harness mapping each `braid-verify` stage to its Lean
+predicate (`excellent_not_hallucinated` skeleton), failing CI if a stage's
+admit/reject behavior diverges from the proven rule. Part of the `U-SA` Tier-2
+agenda; no new runtime, no AI in the verdict path (D32).
+**AC**: every stage has a named Lean predicate it conforms to; a seeded stage
+regression (mutation) trips the conformance gate red.
+**Verification**: the conformance job; mutation evidence.


### PR DESCRIPTION
## What & why

Chunks out the post-v0 frontier from `DEBT_REGISTER.md` into an issue-ready
roadmap (U11–U15) and lands the first **thin vertical slice**: a JS-expression
frontend that compiles JS *text* into an admitted capsule via the one
`braid-verify`. This makes D31's "renders JS useless" **operational** for that
subset (JS as an authoring frontend over the verified substrate), not just
architectural — and it is the first increment of **D-ELAB**.

## Changes

- **`crates/braid-elaborate-js`** (new consumer/frontend crate, not trust-base —
  outside the D3 boundary the substrate crates are fenced to). Lexes/parses a JS
  expression subset (string + integer literals, binary `+`, left-assoc,
  parenthesizable) and elaborates through `braid_sdk::Builder` over
  `braid_vocab_js::registry_v0()`: `+` → `js.concat` for two strings, `js.add`
  for two numbers. Mixed `string + number` is **rejected at elaboration**
  (fail-closed, no coercion — no malformed capsule reaches the verifier).
  Library API (`elaborate_js`, `elaborate_and_admit`) + a `braid-elaborate-js`
  binary that prints CID + verdict + manifest (SDK/CLI parity, T13).
- **`spec/braid/units.md`** — U11–U15 roadmap (each issue-ready: Scope/AC/Verification).
- **`spec/braid/DEBT_REGISTER.md`** — D-ELAB → partially closed (U11); corrected
  D-SA to **BUILT** (the `U-SA`/Keel CI had already landed but the register
  still said "not built").
- **`chore` commit** — workspace `cargo fmt --all` clean-up (pre-existing
  import-ordering drift in `braid-ir`/`braid-vocab-web` that the CI fmt gate
  flagged; canonical rustfmt output, no logic change).

## Scope guard

One operator, two literal types, one vocabulary — a genuine thin slice end to
end, not a JS parser. Identifiers/statements/calls, the `js.eval`/`js.fetch`
escalation probes, and literal *values* are explicitly U12.

## Verification

- `cargo test -p braid-elaborate-js` — 7 end-to-end tests (admit, type-reject,
  pinned-CID reproducibility, left-assoc, parens regrouping, fail-closed sweep).
- `cargo test --workspace` — 117 green; `cargo clippy --workspace --all-targets
  -D warnings` clean; `cargo fmt --all --check` clean.
- `boundary_conformance.rs` still green (the consumer crate respects the boundary).
- `./scripts/cli-loop.sh` and the Keel `NotSlop` floor both GO locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PpucLZVsmw9vf9VvTj2zR

---
_Generated by [Claude Code](https://claude.ai/code/session_012PpucLZVsmw9vf9VvTj2zR)_