### PR TITLE
U12: JS vocabulary expansion (pure operators) + anti-dredging hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ for exactly what changed in the move.
 | `crates/braid-render` | CID-bound manifest, deterministic text rendering, widening/narrowing diff, DOT graph export. |
 | `crates/braid-sdk` | Typed authoring builder over `braid-ir`; takes any vocabulary's registry. |
 | `crates/braid-cli` | The `braid` binary: `encode`/`decode`/`verify`/`render`/`diff` — the human-reconstructable loop (no AI, no Rust). Pins the `braid-vocab-cms` registry for the CMS reference workflow. |
-| `crates/braid-elaborate-js` | **Frontend** (U11): lexes/parses a JS expression subset (literals + `+`) and elaborates JS *text* into an admitted capsule via the one `braid-verify`. The first real frontend over the global IR — "renders JS useless" made operational (D31). |
+| `crates/braid-elaborate-js` | **Frontend** (U11–U12): an operator-precedence JS expression language (`+ - * < == && \|\| !`, literals, booleans, parens) that elaborates JS *text* into an admitted capsule via the one `braid-verify`. The first real frontend over the global IR — "renders JS useless" made operational (D31). |
 | `spec/braid/` | PRD, decision register (`DECISIONS.md`), threat model, unit plan, KAT vectors. **Start here: `spec/braid/README.md`.** |
 | `docs/` | ADR-088 (ratified doctrine + locked invariants); `authoring-cli.md` (hand-author a capsule). |
 
@@ -46,7 +46,7 @@ for exactly what changed in the move.
 
 ```bash
 cargo check --workspace
-cargo test --workspace      # 117 tests
+cargo test --workspace      # 127 tests
 cargo clippy --workspace --all-targets
 ./scripts/cli-loop.sh       # scenario #12 end-to-end (also a CI job)
 ```

--- a/crates/braid-elaborate-js/src/lib.rs
+++ b/crates/braid-elaborate-js/src/lib.rs
@@ -1,31 +1,29 @@
-//! # braid-elaborate-js — a thin JavaScript-expression frontend (U11, D31)
+//! # braid-elaborate-js — a thin JavaScript-expression frontend (U11–U12, D31)
 //!
-//! The **first real frontend over the global IR.** Today `braid-vocab-js`
-//! exists and is proven by a *hand-built* SDK capsule
-//! (`js_capsule_admits_via_the_one_verifier`), but nothing actually compiles
-//! JS *text* into it. This crate closes the first increment of D-ELAB: JS
-//! source in, an admitted [`braid_ir::Capsule`] out, via the **one**
-//! `braid-verify`. It operationalizes D31's "renders JS useless" — JS becomes
-//! an authoring frontend over the verified substrate, not a runtime authority.
+//! The **first real frontend over the global IR.** `braid-vocab-js` is the
+//! elaboration target; this crate compiles JS *text* into an admitted
+//! [`braid_ir::Capsule`] via the **one** `braid-verify`. It operationalizes
+//! D31's "renders JS useless" — JS becomes an authoring frontend over the
+//! verified substrate, not a runtime authority. Zero AI in the path.
 //!
-//! ## Scope (deliberately a thin vertical slice — U11, not a JS parser)
-//! A JS *expression* over string literals, integer-number literals, and the
-//! binary `+` operator (left-associative, parenthesizable). `+` elaborates to
-//! `js.concat` for two strings and `js.add` for two numbers; a mixed
-//! `string + number` is **rejected at elaboration** (fail-closed — no implicit
-//! coercion, and no malformed capsule ever reaches the verifier). Identifiers,
-//! calls, statements, and the `js.eval`/`js.fetch` escalation probes are U12+.
+//! ## Scope (a thin slice — an expression language, not a JS parser)
+//! - **U11**: string + integer literals, binary `+`.
+//! - **U12**: boolean literals (`true`/`false`), arithmetic `-` `*`, comparison
+//!   `<` `==`, boolean logic `&&` `||`, prefix `!`, full operator precedence +
+//!   parentheses. Overloaded operators resolve by operand type to a distinct
+//!   typed term (`+` → `js.concat`/`js.add`; `==` → `js.eq.str`/`js.eq.num`);
+//!   any type mismatch is **rejected at elaboration** (fail-closed — no
+//!   coercion, and no malformed capsule ever reaches the verifier).
+//!
+//! Still out of scope (later units): identifiers, calls, statements, the
+//! `js.eval`/`js.fetch` escalation probes, and literal *values* (the `js.lit.*`
+//! terms are valueless — carrying payloads needs a substrate-level `Strand`
+//! change, not a vocabulary or frontend change; see `DEBT_REGISTER.md`).
 //!
 //! ## Boundary
 //! A *consumer* crate (like `braid-cli`/`braid-sdk`): it elaborates INTO the
 //! substrate through `braid_sdk::Builder`; it is **not** trust-base and builds
 //! no second verifier. The verifier remains the sole admission authority (D9).
-//!
-//! ## A known seed-vocabulary limitation (honest, not a bug)
-//! The v0 `js.lit.*` terms are *valueless* — `js.lit.string` records "a string
-//! literal occurs here", not its bytes. So the IR/CID is a function of the
-//! expression's *structure*, not literal content. Carrying literal payloads is
-//! a `braid-vocab-js` extension (U12), not this frontend's job.
 
 use braid_ir::Capsule;
 use braid_render::{manifest, render_text};
@@ -34,22 +32,24 @@ use braid_verify::{verify, Verdict};
 use braid_vocab_js::registry_v0;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Errors
+// Value types + errors
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// The two value types this slice's `+` operator distinguishes.
+/// The value types this frontend's type-directed elaboration distinguishes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ValType {
     Str,
     Num,
+    Bool,
 }
 
 impl core::fmt::Display for ValType {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            ValType::Str => f.write_str("string"),
-            ValType::Num => f.write_str("number"),
-        }
+        f.write_str(match self {
+            ValType::Str => "string",
+            ValType::Num => "number",
+            ValType::Bool => "boolean",
+        })
     }
 }
 
@@ -58,12 +58,13 @@ impl core::fmt::Display for ValType {
 pub enum ElabError {
     /// No tokens — empty or whitespace-only source.
     Empty,
-    /// A character or string the lexer cannot tokenize.
+    /// A character or token the lexer cannot form.
     Lex(String),
     /// A token stream the grammar does not accept.
     Parse(String),
-    /// `+` applied to mismatched operand types (no implicit coercion).
-    TypeMismatch { left: ValType, right: ValType },
+    /// An operator applied to operand type(s) it has no typed term for (no
+    /// implicit coercion). `operands` is the operand type list in source order.
+    TypeError { op: String, operands: Vec<ValType> },
     /// The SDK refused to author the capsule (carries the `BuildError` debug).
     Build(String),
     /// Manifest rendering failed (carries the `RenderError` debug).
@@ -82,11 +83,15 @@ impl core::fmt::Display for ElabError {
             ElabError::Empty => f.write_str("empty source: nothing to elaborate"),
             ElabError::Lex(m) => write!(f, "lex error: {m}"),
             ElabError::Parse(m) => write!(f, "parse error: {m}"),
-            ElabError::TypeMismatch { left, right } => write!(
-                f,
-                "type error: `+` requires matching operand types (no implicit \
-                 coercion); got {left} + {right}"
-            ),
+            ElabError::TypeError { op, operands } => {
+                let types: Vec<String> = operands.iter().map(|t| t.to_string()).collect();
+                write!(
+                    f,
+                    "type error: operator `{op}` has no typed term for operand \
+                     type(s) [{}] (no implicit coercion)",
+                    types.join(", ")
+                )
+            }
             ElabError::Build(m) => write!(f, "build error: {m}"),
             ElabError::Render(m) => write!(f, "render error: {m}"),
         }
@@ -103,7 +108,15 @@ impl std::error::Error for ElabError {}
 enum Token {
     Str(String),
     Num(i64),
+    Bool(bool),
     Plus,
+    Minus,
+    Star,
+    Lt,
+    EqEq,
+    AndAnd,
+    OrOr,
+    Bang,
     LParen,
     RParen,
 }
@@ -120,6 +133,22 @@ fn lex(src: &str) -> Result<Vec<Token>, ElabError> {
                 toks.push(Token::Plus);
                 i += 1;
             }
+            '-' => {
+                toks.push(Token::Minus);
+                i += 1;
+            }
+            '*' => {
+                toks.push(Token::Star);
+                i += 1;
+            }
+            '<' => {
+                toks.push(Token::Lt);
+                i += 1;
+            }
+            '!' => {
+                toks.push(Token::Bang);
+                i += 1;
+            }
             '(' => {
                 toks.push(Token::LParen);
                 i += 1;
@@ -127,6 +156,38 @@ fn lex(src: &str) -> Result<Vec<Token>, ElabError> {
             ')' => {
                 toks.push(Token::RParen);
                 i += 1;
+            }
+            // Multi-char operators: the single-char form is an error in this
+            // expression slice (no assignment, no bitwise ops).
+            '=' => {
+                if chars.get(i + 1) == Some(&'=') {
+                    toks.push(Token::EqEq);
+                    i += 2;
+                } else {
+                    return Err(ElabError::Lex(
+                        "`=` is not an operator here; did you mean `==`?".to_string(),
+                    ));
+                }
+            }
+            '&' => {
+                if chars.get(i + 1) == Some(&'&') {
+                    toks.push(Token::AndAnd);
+                    i += 2;
+                } else {
+                    return Err(ElabError::Lex(
+                        "single `&` is not supported; use `&&`".to_string(),
+                    ));
+                }
+            }
+            '|' => {
+                if chars.get(i + 1) == Some(&'|') {
+                    toks.push(Token::OrOr);
+                    i += 2;
+                } else {
+                    return Err(ElabError::Lex(
+                        "single `|` is not supported; use `||`".to_string(),
+                    ));
+                }
             }
             '"' | '\'' => {
                 let quote = c;
@@ -177,6 +238,28 @@ fn lex(src: &str) -> Result<Vec<Token>, ElabError> {
                     .map_err(|_| ElabError::Lex(format!("integer literal out of range: {n}")))?;
                 toks.push(Token::Num(val));
             }
+            // Keywords only — identifiers are a later unit. `true`/`false` lex to
+            // boolean literals; anything else is a clear, fail-closed error.
+            a if a.is_ascii_alphabetic() || a == '_' => {
+                let mut w = String::new();
+                while let Some(&ch) = chars.get(i) {
+                    if ch.is_ascii_alphanumeric() || ch == '_' {
+                        w.push(ch);
+                        i += 1;
+                    } else {
+                        break;
+                    }
+                }
+                match w.as_str() {
+                    "true" => toks.push(Token::Bool(true)),
+                    "false" => toks.push(Token::Bool(false)),
+                    other => {
+                        return Err(ElabError::Lex(format!(
+                            "identifiers are not supported yet (expressions only): `{other}`"
+                        )))
+                    }
+                }
+            }
             other => return Err(ElabError::Lex(format!("unexpected character {other:?}"))),
         }
     }
@@ -184,16 +267,61 @@ fn lex(src: &str) -> Result<Vec<Token>, ElabError> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Parser  —  expr := atom ('+' atom)*  ;  atom := num | str | '(' expr ')'
+// Parser — precedence climbing (Pratt). Left-associative; `!` is prefix.
+//   ||  <  &&  <  == <  <  +  -  <  *      (low → high)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// The expression AST. `Add` is the *syntactic* `+`; whether it elaborates to
-/// `js.concat` or `js.add` is decided by operand types at elaboration time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnOp {
+    Not,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinOp {
+    Add,
+    Sub,
+    Mul,
+    Lt,
+    Eq,
+    And,
+    Or,
+}
+
+impl BinOp {
+    /// The source symbol — used in type-error messages.
+    pub fn symbol(self) -> &'static str {
+        match self {
+            BinOp::Add => "+",
+            BinOp::Sub => "-",
+            BinOp::Mul => "*",
+            BinOp::Lt => "<",
+            BinOp::Eq => "==",
+            BinOp::And => "&&",
+            BinOp::Or => "||",
+        }
+    }
+
+    /// Left/right binding power. Left-assoc: `rbp = lbp + 1`.
+    fn binding_power(self) -> (u8, u8) {
+        match self {
+            BinOp::Or => (1, 2),
+            BinOp::And => (3, 4),
+            BinOp::Eq | BinOp::Lt => (5, 6),
+            BinOp::Add | BinOp::Sub => (7, 8),
+            BinOp::Mul => (9, 10),
+        }
+    }
+}
+
+/// The expression AST. Operators are *syntactic*; which typed term each
+/// elaborates to is decided by operand types at elaboration time.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expr {
     Str(String),
     Num(i64),
-    Add(Box<Expr>, Box<Expr>),
+    Bool(bool),
+    Unary(UnOp, Box<Expr>),
+    Binary(BinOp, Box<Expr>, Box<Expr>),
 }
 
 struct Parser {
@@ -214,42 +342,66 @@ impl Parser {
         t
     }
 
-    fn parse_expr(&mut self) -> Result<Expr, ElabError> {
-        let mut left = self.parse_atom()?;
-        while matches!(self.peek(), Some(Token::Plus)) {
-            self.bump();
-            let right = self.parse_atom()?;
-            left = Expr::Add(Box::new(left), Box::new(right));
+    fn infix_op(&self) -> Option<BinOp> {
+        match self.peek()? {
+            Token::OrOr => Some(BinOp::Or),
+            Token::AndAnd => Some(BinOp::And),
+            Token::EqEq => Some(BinOp::Eq),
+            Token::Lt => Some(BinOp::Lt),
+            Token::Plus => Some(BinOp::Add),
+            Token::Minus => Some(BinOp::Sub),
+            Token::Star => Some(BinOp::Mul),
+            _ => None,
         }
-        Ok(left)
     }
 
-    fn parse_atom(&mut self) -> Result<Expr, ElabError> {
-        match self.bump() {
-            Some(Token::Num(n)) => Ok(Expr::Num(n)),
-            Some(Token::Str(s)) => Ok(Expr::Str(s)),
+    fn expr_bp(&mut self, min_bp: u8) -> Result<Expr, ElabError> {
+        let mut lhs = match self.bump() {
+            Some(Token::Num(n)) => Expr::Num(n),
+            Some(Token::Str(s)) => Expr::Str(s),
+            Some(Token::Bool(b)) => Expr::Bool(b),
+            Some(Token::Bang) => {
+                // Prefix `!` binds tighter than any binary operator.
+                let operand = self.expr_bp(11)?;
+                Expr::Unary(UnOp::Not, Box::new(operand))
+            }
             Some(Token::LParen) => {
-                let inner = self.parse_expr()?;
+                let inner = self.expr_bp(0)?;
                 match self.bump() {
-                    Some(Token::RParen) => Ok(inner),
-                    other => Err(ElabError::Parse(format!("expected ')', found {other:?}"))),
+                    Some(Token::RParen) => inner,
+                    other => {
+                        return Err(ElabError::Parse(format!("expected ')', found {other:?}")))
+                    }
                 }
             }
-            other => Err(ElabError::Parse(format!(
-                "expected a literal or '(', found {other:?}"
-            ))),
+            other => {
+                return Err(ElabError::Parse(format!(
+                    "expected an expression, found {other:?}"
+                )))
+            }
+        };
+
+        while let Some(op) = self.infix_op() {
+            let (lbp, rbp) = op.binding_power();
+            if lbp < min_bp {
+                break;
+            }
+            self.bump(); // consume the operator
+            let rhs = self.expr_bp(rbp)?;
+            lhs = Expr::Binary(op, Box::new(lhs), Box::new(rhs));
         }
+        Ok(lhs)
     }
 }
 
-/// Parse a token stream into an [`Expr`]. Exposed so U12 can reuse it.
+/// Lex + parse a JS expression into an [`Expr`]. Exposed for reuse/testing.
 pub fn parse(src: &str) -> Result<Expr, ElabError> {
     let toks = lex(src)?;
     if toks.is_empty() {
         return Err(ElabError::Empty);
     }
     let mut p = Parser { toks, pos: 0 };
-    let expr = p.parse_expr()?;
+    let expr = p.expr_bp(0)?;
     if p.pos != p.toks.len() {
         return Err(ElabError::Parse(format!(
             "unexpected trailing token {:?}",
@@ -260,36 +412,71 @@ pub fn parse(src: &str) -> Result<Expr, ElabError> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Elaboration  —  Expr → Strands over braid-vocab-js, via the SDK
+// Elaboration — Expr → Strands over braid-vocab-js, via the SDK
 // ─────────────────────────────────────────────────────────────────────────────
+
+/// Type-directed term selection for a binary operator. The fail-closed line:
+/// matching operand types pick a single typed term; anything else is a type
+/// error, never a coercion.
+fn resolve_binary(
+    op: BinOp,
+    lt: ValType,
+    rt: ValType,
+) -> Result<(&'static str, ValType), ElabError> {
+    use BinOp::*;
+    use ValType::*;
+    let picked = match (op, lt, rt) {
+        (Add, Str, Str) => ("js.concat", Str),
+        (Add, Num, Num) => ("js.add", Num),
+        (Sub, Num, Num) => ("js.sub", Num),
+        (Mul, Num, Num) => ("js.mul", Num),
+        (Lt, Num, Num) => ("js.lt", Bool),
+        (Eq, Num, Num) => ("js.eq.num", Bool),
+        (Eq, Str, Str) => ("js.eq.str", Bool),
+        (And, Bool, Bool) => ("js.and", Bool),
+        (Or, Bool, Bool) => ("js.or", Bool),
+        _ => {
+            return Err(ElabError::TypeError {
+                op: op.symbol().to_string(),
+                operands: vec![lt, rt],
+            })
+        }
+    };
+    Ok(picked)
+}
 
 fn emit(b: &mut Builder, e: &Expr) -> Result<(Strand, ValType), ElabError> {
     match e {
-        Expr::Str(_) => {
-            let s = b.strand("js.lit.string", &[]).map_err(ElabError::build)?;
-            Ok((s, ValType::Str))
+        Expr::Str(_) => Ok((
+            b.strand("js.lit.string", &[]).map_err(ElabError::build)?,
+            ValType::Str,
+        )),
+        Expr::Num(_) => Ok((
+            b.strand("js.lit.number", &[]).map_err(ElabError::build)?,
+            ValType::Num,
+        )),
+        Expr::Bool(_) => Ok((
+            b.strand("js.lit.boolean", &[]).map_err(ElabError::build)?,
+            ValType::Bool,
+        )),
+        Expr::Unary(UnOp::Not, x) => {
+            let (xh, xt) = emit(b, x)?;
+            if xt != ValType::Bool {
+                return Err(ElabError::TypeError {
+                    op: "!".to_string(),
+                    operands: vec![xt],
+                });
+            }
+            Ok((
+                b.strand("js.not", &[xh]).map_err(ElabError::build)?,
+                ValType::Bool,
+            ))
         }
-        Expr::Num(_) => {
-            let s = b.strand("js.lit.number", &[]).map_err(ElabError::build)?;
-            Ok((s, ValType::Num))
-        }
-        Expr::Add(l, r) => {
+        Expr::Binary(op, l, r) => {
             let (lh, lt) = emit(b, l)?;
             let (rh, rt) = emit(b, r)?;
-            // The overload resolution + the fail-closed line: matching types
-            // pick a term; a mismatch is an elaboration error, never a coercion.
-            let term = match (lt, rt) {
-                (ValType::Str, ValType::Str) => "js.concat",
-                (ValType::Num, ValType::Num) => "js.add",
-                _ => {
-                    return Err(ElabError::TypeMismatch {
-                        left: lt,
-                        right: rt,
-                    })
-                }
-            };
-            let s = b.strand(term, &[lh, rh]).map_err(ElabError::build)?;
-            Ok((s, lt))
+            let (term, out) = resolve_binary(*op, lt, rt)?;
+            Ok((b.strand(term, &[lh, rh]).map_err(ElabError::build)?, out))
         }
     }
 }
@@ -298,12 +485,11 @@ fn emit(b: &mut Builder, e: &Expr) -> Result<(Strand, ValType), ElabError> {
 /// makes the capsule CID a reproducible function of the human input — the
 /// human-reconstructable-loop guarantee (same source ⇒ same CID).
 fn intent_for(src: &str) -> String {
-    format!("JS expression elaborated to Braid IR (U11): {}", src.trim())
+    format!("JS expression elaborated to Braid IR: {}", src.trim())
 }
 
 /// Elaborate a JS expression into an admittable [`Capsule`]. Pure value
-/// construction only, so no capability/confirm is required and `build()`
-/// succeeds with `ConfirmPolicy::None`.
+/// construction only, so no capability/confirm is required.
 pub fn elaborate_js(src: &str) -> Result<Capsule, ElabError> {
     let expr = parse(src)?;
     let reg = registry_v0();
@@ -313,9 +499,7 @@ pub fn elaborate_js(src: &str) -> Result<Capsule, ElabError> {
     b.build().map_err(ElabError::build)
 }
 
-/// The full thin-slice loop: source → IR → **verify** → manifest. The verdict
-/// is read off the one `braid-verify` against the JS vocabulary's registry;
-/// the manifest is the human-audit object bound to the capsule's CID.
+/// The full loop: source → IR → **verify** → manifest.
 pub struct Elaboration {
     pub capsule: Capsule,
     pub verdict: Verdict,

--- a/crates/braid-elaborate-js/tests/elaborate.rs
+++ b/crates/braid-elaborate-js/tests/elaborate.rs
@@ -1,6 +1,6 @@
-//! U11 — the thin vertical slice's proof: JS source → IR → verify, end to end,
-//! pinned. Each test drives the *same* public path the binary uses; nothing is
-//! mocked. The verdict is read off the one `braid-verify`.
+//! U11–U12 — the frontend's proof: JS source → IR → verify, end to end, pinned.
+//! Each test drives the *same* public path the binary uses; nothing is mocked.
+//! The verdict is read off the one `braid-verify`.
 
 use braid_elaborate_js::{elaborate_and_admit, elaborate_js, ElabError};
 use braid_verify::Verdict;
@@ -15,58 +15,57 @@ fn terms(capsule: &braid_ir::Capsule) -> Vec<&str> {
         .collect()
 }
 
+fn admit(src: &str) -> braid_elaborate_js::Elaboration {
+    let e =
+        elaborate_and_admit(src).unwrap_or_else(|err| panic!("`{src}` should elaborate: {err}"));
+    assert_eq!(
+        e.verdict,
+        Verdict::Admit {
+            capsule_cid: e.capsule.cid()
+        },
+        "`{src}` must admit via the one verifier"
+    );
+    e
+}
+
+// ── U11 core ────────────────────────────────────────────────────────────────
+
 #[test]
 fn string_concat_admits() {
-    let e = elaborate_and_admit(r#""hello" + "world""#).expect("elaborates");
-    // Two valueless string literals feeding one concat — the structure D31's
-    // valueless `js.lit.*` produces.
+    let e = admit(r#""hello" + "world""#);
     assert_eq!(
         terms(&e.capsule),
         ["js.lit.string", "js.lit.string", "js.concat"]
     );
     assert_eq!(e.capsule.braid.outputs, vec![2]);
-    // The whole point: the one verifier admits a capsule that was *compiled*
-    // from JS text, not hand-built.
-    assert_eq!(
-        e.verdict,
-        Verdict::Admit {
-            capsule_cid: e.capsule.cid()
-        }
-    );
 }
 
 #[test]
 fn number_add_admits() {
-    let e = elaborate_and_admit("1 + 2").expect("elaborates");
+    let e = admit("1 + 2");
     assert_eq!(
         terms(&e.capsule),
         ["js.lit.number", "js.lit.number", "js.add"]
-    );
-    assert_eq!(e.capsule.braid.outputs, vec![2]);
-    assert_eq!(
-        e.verdict,
-        Verdict::Admit {
-            capsule_cid: e.capsule.cid()
-        }
     );
 }
 
 #[test]
 fn mixed_types_rejected_at_elaboration() {
     // Fail-closed: the type error fires in the frontend, BEFORE any capsule is
-    // built — so no malformed artifact ever reaches the verifier (the verifier
-    // is a floor, not the only line of defense). No implicit coercion.
+    // built — no malformed artifact reaches the verifier. No implicit coercion.
     match elaborate_js(r#""a" + 1"#) {
-        Err(ElabError::TypeMismatch { left, right }) => {
-            assert_eq!(left.to_string(), "string");
-            assert_eq!(right.to_string(), "number");
+        Err(ElabError::TypeError { op, operands }) => {
+            assert_eq!(op, "+");
+            assert_eq!(
+                operands.iter().map(|t| t.to_string()).collect::<Vec<_>>(),
+                ["string", "number"]
+            );
         }
-        other => panic!("expected a TypeMismatch elaboration error, got {other:?}"),
+        other => panic!("expected a TypeError, got {other:?}"),
     }
-    // The full loop surfaces the same error (and never produces a verdict).
     assert!(matches!(
         elaborate_and_admit(r#""a" + 1"#),
-        Err(ElabError::TypeMismatch { .. })
+        Err(ElabError::TypeError { .. })
     ));
 }
 
@@ -74,20 +73,18 @@ fn mixed_types_rejected_at_elaboration() {
 fn pinned_cid() {
     // The human-reconstructable-loop guarantee (matches the repo's KAT-vector
     // discipline): the same source always elaborates to the same capsule CID.
-    // If this changes, the encoding/intent/elaboration contract moved — that
-    // must be a conscious, recorded event, never a silent drift.
+    // **Re-pinned for vocab v2 (U12)**: the registry CID changed when the
+    // pure-operator terms were added, so every JS capsule's bytes changed — a
+    // conscious, recorded re-pin, never a silent drift (D11).
     let capsule = elaborate_js(r#""hello" + "world""#).expect("elaborates");
     assert_eq!(
         capsule.cid().to_hex(),
-        "e257c090bb647765e6bc3d318d770c4a3688c8bc5084a91bb68bb5700c60edc4"
+        "39669d9fe0267665c52e9fde99ae7fef6d150ca28e853e092843bf938560fca7"
     );
 }
 
 #[test]
 fn associativity_is_left() {
-    // `1 + 2 + 3` parses as `(1 + 2) + 3`: the first add (idx 2) consumes the
-    // two leading literals; the second add (idx 4) consumes that result + the
-    // third literal. Five strands, root = idx 4.
     let capsule = elaborate_js("1 + 2 + 3").expect("elaborates");
     assert_eq!(
         terms(&capsule),
@@ -106,18 +103,162 @@ fn associativity_is_left() {
 
 #[test]
 fn parentheses_regroup() {
-    // `1 + (2 + 3)` must differ structurally from the left-assoc default:
-    // the inner add (idx 3) consumes literals 1 and 2; the outer add (idx 4)
-    // consumes literal 0 + that inner result. Proves the parser honors '()'.
     let capsule = elaborate_js("1 + (2 + 3)").expect("elaborates");
     assert_eq!(capsule.braid.strands[3].inputs, vec![1, 2]);
     assert_eq!(capsule.braid.strands[4].inputs, vec![0, 3]);
-    assert_eq!(capsule.braid.outputs, vec![4]);
-    // Different shape ⇒ different CID than the left-assoc `1 + 2 + 3`.
     assert_ne!(
         capsule.cid().to_hex(),
         elaborate_js("1 + 2 + 3").unwrap().cid().to_hex()
     );
+}
+
+// ── U12 expansion: operators, precedence, booleans ───────────────────────────
+
+#[test]
+fn multiplication_binds_tighter_than_addition() {
+    // `1 + 2 * 3` parses as `1 + (2 * 3)`: the mul (idx 3) consumes literals 1
+    // and 2; the add (idx 4) consumes literal 0 and the mul result.
+    let e = admit("1 + 2 * 3");
+    assert_eq!(
+        terms(&e.capsule),
+        [
+            "js.lit.number",
+            "js.lit.number",
+            "js.lit.number",
+            "js.mul",
+            "js.add"
+        ]
+    );
+    assert_eq!(e.capsule.braid.strands[3].inputs, vec![1, 2]);
+    assert_eq!(e.capsule.braid.strands[4].inputs, vec![0, 3]);
+}
+
+#[test]
+fn subtraction_admits() {
+    let e = admit("10 - 3");
+    assert_eq!(
+        terms(&e.capsule),
+        ["js.lit.number", "js.lit.number", "js.sub"]
+    );
+}
+
+#[test]
+fn comparison_and_boolean_logic_admit() {
+    // `1 < 2 && true` parses as `(1 < 2) && true` (`<` binds tighter than `&&`).
+    let e = admit("1 < 2 && true");
+    assert_eq!(
+        terms(&e.capsule),
+        [
+            "js.lit.number",
+            "js.lit.number",
+            "js.lt",
+            "js.lit.boolean",
+            "js.and"
+        ]
+    );
+}
+
+#[test]
+fn equality_overload_picks_the_typed_term() {
+    // `==` resolves by operand type to a distinct typed term (repurpose, never
+    // a widened ambiguous signature).
+    assert_eq!(
+        *terms(&admit("1 == 2").capsule).last().unwrap(),
+        "js.eq.num"
+    );
+    assert_eq!(
+        *terms(&admit(r#""a" == "b""#).capsule).last().unwrap(),
+        "js.eq.str"
+    );
+}
+
+#[test]
+fn unary_not_admits() {
+    let e = admit("!false");
+    assert_eq!(terms(&e.capsule), ["js.lit.boolean", "js.not"]);
+    // `!` binds tighter than `&&`: `!true && false` is `(!true) && false`.
+    let e2 = admit("!true && false");
+    assert_eq!(
+        terms(&e2.capsule),
+        ["js.lit.boolean", "js.not", "js.lit.boolean", "js.and"]
+    );
+}
+
+#[test]
+fn each_operator_rejects_wrong_operand_types() {
+    // Every operator fails closed on a type it has no typed term for — the
+    // anti-coercion line, per operator. None produces a capsule.
+    for (src, op) in [
+        ("true + 1", "+"),
+        ("1 - \"a\"", "-"),
+        ("\"a\" * 2", "*"),
+        ("1 < \"a\"", "<"),
+        ("1 == \"a\"", "=="),
+        ("1 && 2", "&&"),
+        ("true || 1", "||"),
+    ] {
+        match elaborate_js(src) {
+            Err(ElabError::TypeError { op: got, .. }) => assert_eq!(got, op, "for `{src}`"),
+            other => panic!("`{src}` expected TypeError(`{op}`), got {other:?}"),
+        }
+    }
+    // Unary `!` on a non-boolean.
+    assert!(matches!(
+        elaborate_js("!1"),
+        Err(ElabError::TypeError { .. })
+    ));
+}
+
+// ── Anti-dredging hardening (the three classes the Director named) ────────────
+
+/// Composition/aggregation exfil (T1/T5): NO expression, however deeply
+/// composed, can produce a capsule that holds authority. The frontend emits
+/// only pure terms, so every elaborated capsule requests zero capabilities and
+/// admits under the EMPTY ambient set — there is no compositional path from
+/// pure literals to an effect. Mutation-proof: if the elaborator ever emitted a
+/// capability-bearing term, `grants` would be non-empty and this trips.
+#[test]
+fn no_composition_yields_authority() {
+    let src = "(1 + 2 * 3 < 10) && (!false || \"a\" == \"b\")";
+    let e = admit(src);
+    assert!(
+        e.capsule.grants.is_empty(),
+        "a pure expression must request no capability; got {:?}",
+        e.capsule.grants
+    );
+    // The dangerous terms are simply unreachable from this grammar.
+    let dangerous = ["js.eval", "js.fetch", "js.dom.querySelector"];
+    for t in terms(&e.capsule) {
+        assert!(
+            !dangerous.contains(&t),
+            "elaborator emitted dangerous term {t}"
+        );
+    }
+    // It admits with NO ambient authority at all.
+    assert_eq!(
+        braid_verify::verify(&e.capsule.to_bytes(), &braid_vocab_js::registry_v0(), &[]),
+        Verdict::Admit {
+            capsule_cid: e.capsule.cid()
+        }
+    );
+}
+
+/// Composition/aggregation exfil (T1): the dangerous capability terms cannot be
+/// *named* through the frontend — `eval`/identifiers are a lexer error, so an
+/// author cannot reach `js.eval`/`js.fetch` by spelling them in source. The
+/// escalation probes stay reachable only via hand-authored capsules (the
+/// vocab-js effect-stage tests), never via this text frontend.
+#[test]
+fn dangerous_terms_are_unspellable() {
+    for src in ["eval", "js.eval", "fetch(\"x\")", "require"] {
+        assert!(
+            matches!(
+                elaborate_js(src),
+                Err(ElabError::Lex(_)) | Err(ElabError::Parse(_))
+            ),
+            "`{src}` must be unspellable, not silently accepted"
+        );
+    }
 }
 
 #[test]
@@ -132,5 +273,6 @@ fn malformed_sources_fail_closed() {
         elaborate_js(r#""unterminated"#),
         Err(ElabError::Lex(_))
     ));
-    assert!(matches!(elaborate_js("1 - 2"), Err(ElabError::Lex(_))));
+    assert!(matches!(elaborate_js("1 = 2"), Err(ElabError::Lex(_))));
+    assert!(matches!(elaborate_js("1 & 2"), Err(ElabError::Lex(_))));
 }

--- a/crates/braid-vocab-js/src/lib.rs
+++ b/crates/braid-vocab-js/src/lib.rs
@@ -19,13 +19,39 @@
 //! foreign to the kernel's `signal.emit`/`motion.*` and to the browser's
 //! `web.*`. That is the point: a global IR lets each language own its
 //! capability space while sharing the one attenuation-checking verifier.
+//!
+//! ## Vocabulary-extension governance (U12 / PRD §5 P5)
+//! Adding a term is a contract change. The rules, mechanically guarded by the
+//! tests in this file:
+//! 1. **Bump [`VOCAB_VERSION`] and re-pin consciously.** Any change to the term
+//!    set changes `registry_v0().cid()` and every capsule's bytes. The version
+//!    bump + the re-pinned CID guards (here and in `braid-elaborate-js`) make
+//!    that a recorded event, never silent drift (D11; anti-dredging class
+//!    "context/spec drift").
+//! 2. **Pure-by-default; danger is explicit and enumerated.** A new term is
+//!    `EffectClass::Pure` with no capability UNLESS it genuinely needs one.
+//!    `dangerous_terms()` is the *closed* list of effectful terms; the
+//!    `expansion_added_no_escape_hatch` test fails if an expansion grows that
+//!    set without updating the list — so a capability cannot be smuggled in on
+//!    a "math" term (anti-dredging class "composition/aggregation exfil",
+//!    T1/T5).
+//! 3. **Prefer repurpose > extend > mint** (lgwks schema discipline): overloads
+//!    map to distinct typed terms (`js.eq.num`/`js.eq.str`), never one term with
+//!    a widened, ambiguous signature.
 
 use braid_capability::Capability;
 use braid_ir::term::{EffectClass, Exposure, TermRegistry, TermSpec, TypeTag};
 
 /// Vocabulary version for the JS elaboration target. Independent of the CMS
 /// vocab's version — each vocabulary versioning is a conscious event (D11).
-pub const VOCAB_VERSION: u32 = 1;
+///
+/// **v1 → v2 (U12):** added the pure-operator expansion (`js.sub`, `js.mul`,
+/// `js.lt`, `js.eq.num`, `js.eq.str`, `js.and`, `js.or`, `js.not`). A
+/// conscious, recorded bump: it changes `registry_v0().cid()` and therefore
+/// every JS capsule's bytes, so the pinned CIDs in `braid-elaborate-js` and the
+/// registry-CID guard below were re-pinned in the same change (anti-drift: a
+/// CID never moves silently).
+pub const VOCAB_VERSION: u32 = 2;
 
 // ── capability constants (this vocabulary's `js.*` space) ──
 pub const JS_DOM_READ_NAME: &str = "js.dom.read";
@@ -149,6 +175,89 @@ pub fn registry_v0() -> TermRegistry {
             None,
             1,
         ),
+        // ── U12 expansion: more pure arithmetic (fixed-point; no floats — D8) ──
+        t(
+            "js.sub",
+            vec![js_number(), js_number()],
+            js_number(),
+            None,
+            Pure,
+            Public,
+            None,
+            1,
+        ),
+        t(
+            "js.mul",
+            vec![js_number(), js_number()],
+            js_number(),
+            None,
+            Pure,
+            Public,
+            None,
+            1,
+        ),
+        // ── U12 expansion: comparison / equality → boolean (typed overloads) ──
+        t(
+            "js.lt",
+            vec![js_number(), js_number()],
+            js_boolean(),
+            None,
+            Pure,
+            Public,
+            None,
+            1,
+        ),
+        t(
+            "js.eq.num",
+            vec![js_number(), js_number()],
+            js_boolean(),
+            None,
+            Pure,
+            Public,
+            None,
+            1,
+        ),
+        t(
+            "js.eq.str",
+            vec![js_string(), js_string()],
+            js_boolean(),
+            None,
+            Pure,
+            Public,
+            None,
+            1,
+        ),
+        // ── U12 expansion: boolean logic ──
+        t(
+            "js.and",
+            vec![js_boolean(), js_boolean()],
+            js_boolean(),
+            None,
+            Pure,
+            Public,
+            None,
+            1,
+        ),
+        t(
+            "js.or",
+            vec![js_boolean(), js_boolean()],
+            js_boolean(),
+            None,
+            Pure,
+            Public,
+            None,
+            1,
+        ),
+        t(
+            "js.not",
+            vec![js_boolean()],
+            js_boolean(),
+            None,
+            Pure,
+            Public,
+            None,
+            1,
+        ),
         // ── DOM reads (gated, read-only) ──
         t(
             "js.dom.querySelector",
@@ -197,6 +306,22 @@ pub fn registry_v0() -> TermRegistry {
     reg
 }
 
+/// The terms in a registry that carry authority — a capability and/or a
+/// non-`Pure` effect. Computed from the registry, never hardcoded, so it
+/// reflects the actual term set. The governance guard pins the *expected*
+/// result against a closed list: an expansion that smuggles a capability onto
+/// a "math" term, or adds a new effectful term, changes this set and trips the
+/// test (anti-dredging — composition/aggregation exfil, T1/T5).
+pub fn dangerous_terms(reg: &TermRegistry) -> Vec<String> {
+    let mut out: Vec<String> = reg
+        .terms()
+        .filter(|s| s.capability.is_some() || s.effect != EffectClass::Pure)
+        .map(|s| s.id.clone())
+        .collect();
+    out.sort();
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -204,6 +329,11 @@ mod tests {
     use braid_ir::capsule::{Capsule, ConfirmPolicy, IR_VERSION};
     use braid_sdk::Builder;
     use braid_verify::{verify, Stage, Verdict};
+
+    /// Pinned CID of `registry_v0()` at `VOCAB_VERSION = 2`. Re-pinned
+    /// consciously whenever the term set changes (see the governance note).
+    const PINNED_REGISTRY_CID_V2: &str =
+        "a79e1716ce1c3a05645b9c32cabf7895b93c05f57e0b77a18174c360b8233815";
 
     fn strand(term: &str, inputs: Vec<u32>) -> Strand {
         Strand {
@@ -215,12 +345,78 @@ mod tests {
     #[test]
     fn registry_v0_builds() {
         let r = registry_v0();
-        assert_eq!(r.len(), 8);
+        // 8 seed terms + 8 U12 pure-operator terms.
+        assert_eq!(r.len(), 16);
         assert!(r.get("js.eval").is_some());
         assert!(r.get("js.lit.string").is_some());
+        // The U12 expansion is present and typed.
+        for added in [
+            "js.sub",
+            "js.mul",
+            "js.lt",
+            "js.eq.num",
+            "js.eq.str",
+            "js.and",
+            "js.or",
+            "js.not",
+        ] {
+            assert!(r.get(added).is_some(), "missing U12 term {added}");
+        }
         // A term foreign to this vocabulary is absent — the registry is closed.
         assert!(r.get("cms.publish").is_none());
         assert!(r.get("eval").is_none());
+    }
+
+    /// Anti-dredging (composition/aggregation exfil — T1/T5): the U12 expansion
+    /// added ONLY safe-by-construction terms. The set of authority-bearing
+    /// terms is exactly the closed list it was before — no capability was
+    /// smuggled onto a "math"/"logic" term, no new effectful term appeared.
+    /// Mutation-proof: give `js.add` a capability, or make `js.mul` `Egress`,
+    /// and this goes red.
+    #[test]
+    fn expansion_added_no_escape_hatch() {
+        let r = registry_v0();
+        assert_eq!(
+            dangerous_terms(&r),
+            // the ONLY terms allowed to carry authority — sorted
+            vec![
+                "js.dom.querySelector".to_string(),
+                "js.eval".to_string(),
+                "js.fetch".to_string(),
+            ],
+            "an expansion changed the authority surface — that must be a \
+             conscious, reviewed event, not a silent escape hatch"
+        );
+        // Every U12 term is pure and capability-free, individually.
+        for id in [
+            "js.sub",
+            "js.mul",
+            "js.lt",
+            "js.eq.num",
+            "js.eq.str",
+            "js.and",
+            "js.or",
+            "js.not",
+        ] {
+            let s = r.get(id).unwrap();
+            assert_eq!(s.effect, EffectClass::Pure, "{id} must be Pure");
+            assert!(s.capability.is_none(), "{id} must hold no capability");
+        }
+    }
+
+    /// Anti-dredging (context/spec drift): the JS registry CID is pinned. It
+    /// moves only on a conscious vocabulary change — which MUST be paired with
+    /// a `VOCAB_VERSION` bump and this re-pin in the same commit (D11). A silent
+    /// term-set change trips this guard.
+    #[test]
+    fn registry_cid_is_pinned_to_vocab_v2() {
+        let r = registry_v0();
+        assert_eq!(r.vocab_version, 2);
+        assert_eq!(
+            r.cid().to_hex(),
+            PINNED_REGISTRY_CID_V2,
+            "the JS registry CID moved without a recorded re-pin"
+        );
     }
 
     #[test]

--- a/scripts/keel-floor.sh
+++ b/scripts/keel-floor.sh
@@ -32,9 +32,20 @@ else
   CONCEPT_FLAG=()
 fi
 
+# Serialize the crossing by default. Keel's verdict is a pure function of
+# CONTENT (concurrency "changes throughput, NEVER the verdict" — concurrency.mjs),
+# but the profile binds 12 atoms to distinct `cargo` invocations (test, clippy,
+# check, fmt). Run concurrently they contend on the one shared `target/` build
+# dir, and on a cold cache one cargo can clobber another mid-build → a spurious
+# non-zero exit → a false NO-GO that does not reproduce on a warm cache. The
+# dedicated `build·test·lint` CI job runs the same tools serially and is green;
+# serializing here matches that and makes the gate deterministic. Overridable.
+export KEEL_CONCURRENCY="${KEEL_CONCURRENCY:-1}"
+
 echo "Keel safety-assurance floor (profile: $PROFILE)"
-echo "  keel:    $KEEL"
-echo "  concept: ${CONCEPT_FLAG[1]:-NotSlop (default)}"
+echo "  keel:        $KEEL"
+echo "  concept:     ${CONCEPT_FLAG[1]:-NotSlop (default)}"
+echo "  concurrency: $KEEL_CONCURRENCY (serial by default — deterministic cargo)"
 echo ""
 
 node "$KEEL/src/run.mjs" --profile "$PROFILE" "${CONCEPT_FLAG[@]+"${CONCEPT_FLAG[@]}"}"

--- a/spec/braid/DEBT_REGISTER.md
+++ b/spec/braid/DEBT_REGISTER.md
@@ -22,6 +22,9 @@
 - ✅ **First real language frontend** (U11, D31) — `braid-elaborate-js`
   compiles a JS expression subset (literals + `+`) into admitted capsules via
   the one verifier; "renders JS useless" is operational for that subset.
+- ✅ **JS expression language + vocab v2** (U12, D-VOCAB.1) — operator-
+  precedence frontend (`+ - * < == && || !`, booleans) over 16 pure JS terms,
+  with a mutation-proven anti-escape-hatch guard and re-pinned CIDs.
 
 ## Open debts (the Java-ecosystem gap)
 
@@ -52,11 +55,18 @@ pinned snapshot (`braid_vocab_binding.rs`) not live-wired. "Become a
 dependency" is now *possible* (tag cut) but has *zero actual dependents*.
 **Closes**: the browser collapse; the kernel binding live-wire (#565).
 
-### D-VOCAB — Vocabulary libraries are seeds, not a stdlib
-2 vocabs: `braid-vocab-cms` (12 terms, demo), `braid-vocab-js` (8 terms,
-proof-of-concept). Java's stdlib is thousands of packages. No package registry
-(D-non-goal, PRD §49). No governance flow for vocabulary extension (PRD §5 P5).
-**Closes**: a real JS vocabulary at scale; a vocabulary governance flow.
+### D-VOCAB — Vocabulary libraries are seeds, not a stdlib *(first slice LANDED — U12)*
+🟡 **Partially closed.** `braid-vocab-js` grew v1→**v2** (8→16 terms: the
+pure-operator expansion — arithmetic, comparison, boolean logic) and now backs a
+real operator-precedence expression language in `braid-elaborate-js`. A
+**vocabulary-extension governance flow** exists (module doc + the
+`expansion_added_no_escape_hatch` / pinned-CID guards mechanically enforcing
+bump-and-re-pin + pure-by-default). Remaining: still far from a stdlib (no
+statements/identifiers, no string library, no `cms`-scale breadth); no package
+registry (PRD §49 non-goal); **literal payloads remain deferred to a substrate
+unit** (Strand carries no operand — D8-locked work, not a vocab change).
+**Closes**: U12 (expansion + governance — done); a stdlib-scale JS vocabulary
+(later); the substrate-level literal-payload unit.
 
 ### D-TOOLCHAIN — Partial toolchain
 `braid-cli` (encode/decode/verify/render/diff) exists. No package manager, no

--- a/spec/braid/units.md
+++ b/spec/braid/units.md
@@ -197,19 +197,39 @@ parenthesized grouping are structurally distinct; malformed sources fail closed.
 `cargo run -p braid-elaborate-js -- '"hello" + "world"'` prints ADMIT;
 `boundary_conformance.rs` still green (the consumer crate respects the boundary).
 
-## U12 — JS vocabulary at scale + literal payloads
-**Closes**: **D-VOCAB** (the 8-term seed → a usable JS subset) and the
-literal-value gap U11 deferred.
-**Scope**: grow `braid-vocab-js` past the seed — value-carrying `js.lit.*`
-(literal bytes/number in the term), comparison + boolean ops, more string ops,
-the typing for `let`/identifiers (a name-resolution pass in the elaborator). A
-written **vocabulary-extension governance note** (PRD §5 P5): how a term is
-added, versioned (D11), and KAT-pinned. The elaborator (U11) consumes the
-widened registry with no second verifier.
-**AC**: a representative JS subset (assignment + arithmetic + comparison)
-round-trips source → admit; vocab version bump is a conscious KAT re-pin;
-distinct literal *values* yield distinct CIDs (the U11 limitation is closed).
+## U12 — JS vocabulary expansion (pure operators) *(LANDED this session)*
+**Closes**: the first increment of **D-VOCAB** (8-term seed → a usable
+expression language).
+**Scope (revised — see the note below on literal payloads)**: grow
+`braid-vocab-js` v1→**v2** with eight new **pure** terms — `js.sub`, `js.mul`,
+`js.lt`, `js.eq.num`, `js.eq.str`, `js.and`, `js.or`, `js.not` — and extend the
+`braid-elaborate-js` frontend to a full operator-precedence expression language
+(`+ - * < == && || !`, boolean literals, parentheses; left-assoc; type-directed
+overload resolution to distinct typed terms). A **vocabulary-extension
+governance note** (module doc in `braid-vocab-js`): bump-and-re-pin, pure-by-
+default, repurpose > extend > mint.
+**Hardening (the three dredging classes, mutation-proven)**:
+- *Composition/aggregation exfil (T1/T5)*: `dangerous_terms()` + the
+  `expansion_added_no_escape_hatch` guard pin the authority surface to exactly
+  `{js.dom.querySelector, js.eval, js.fetch}` — a capability cannot ride in on a
+  "math" term; and `no_composition_yields_authority` proves no expression, however
+  composed, yields a capsule with grants. The probes stay *unspellable* from text.
+- *Context/spec drift*: vocab version bumped to 2; the registry CID and the
+  frontend capsule CIDs re-pinned in the same change (no silent CID move).
+- *Test-hollowing/Goodhart (T14/T7)*: every operator test asserts real strand
+  structure + wiring + an ADMIT verdict, and a per-operator type-mismatch reject.
+**AC**: the expression language round-trips source → admit; the three guards are
+green and trip under mutation. **Out of scope, deferred honestly**: literal
+*values* and identifiers/`let` (see note).
 **Verification**: `cargo test -p braid-vocab-js -p braid-elaborate-js`.
+
+> **Literal payloads are a substrate unit, not a vocabulary one.** `Strand` is
+> `{ term, inputs }` — it carries no operand/constant, so `js.lit.string`
+> records *that* a string literal occurs, not its bytes (the CMS `lit.text` is
+> the same). Carrying values needs a `braid-ir` change (Strand + canonical
+> encoding + verifier + render + a KAT re-pin) — locked-substrate work that does
+> not belong in a vocabulary expansion. Filed as its own future unit; **not**
+> silently folded into U12.
 
 ## U13 — multi-capsule project model + `braid` toolchain
 **Closes**: **D-TOOLCHAIN** (no build/test model for projects of many capsules).


### PR DESCRIPTION
## What & why

Second checkpoint of the post-v0 frontier. Grows the JS vocabulary from the
8-term seed to a real **operator-precedence expression language**, closing the
first increment of **D-VOCAB** — and bakes in hardening against all three
"dredging" classes, each mutation-proven.

## Changes

- **`braid-vocab-js` v1→v2** — eight new **pure** terms (`js.sub`, `js.mul`,
  `js.lt`, `js.eq.num`, `js.eq.str`, `js.and`, `js.or`, `js.not`). A
  vocabulary-extension governance note (module doc): bump-and-re-pin,
  pure-by-default, repurpose > extend > mint.
- **`braid-elaborate-js`** — from `+`-only to `+ - * < == && || !`, boolean
  literals, parentheses, full precedence (Pratt), prefix `!`. Overloads resolve
  by operand type to distinct typed terms; any mismatch is **rejected at
  elaboration** (fail-closed, no coercion).

## Anti-dredging hardening (the three classes, mutation-proven)

- **Composition/aggregation exfil (T1/T5)** — `dangerous_terms()` +
  `expansion_added_no_escape_hatch` pin the authority surface to exactly
  `{js.dom.querySelector, js.eval, js.fetch}` (a capability can't ride in on a
  "math" term); `no_composition_yields_authority` proves no expression — however
  composed — produces a capsule with grants; the probes stay *unspellable* from
  text (`eval`/`js.eval`/`fetch(...)` are lexer errors).
- **Context/spec drift** — vocab bumped to **v2**; the registry CID and the
  frontend capsule CIDs **re-pinned in the same change** (no silent CID move, D11).
- **Test-hollowing / Goodhart (T14/T7)** — every operator test asserts real
  strand structure + input wiring + an ADMIT verdict, plus a per-operator
  type-mismatch reject.

## Honest deferral

Literal *values* and identifiers/`let` are **not** in U12. `Strand` carries no
operand field, so literal payloads need a `braid-ir` (D8-locked substrate)
change — filed as its own future unit, recorded in `units.md`/`DEBT_REGISTER.md`,
not silently folded in.

## Verification

- `cargo test -p braid-vocab-js -p braid-elaborate-js` — 8 + 15 tests.
- `cargo test --workspace` — 127 green; clippy `-D warnings` clean; `fmt --check` clean.
- `./scripts/cli-loop.sh` and the Keel `NotSlop` floor both GO locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PpucLZVsmw9vf9VvTj2zR

---
_Generated by [Claude Code](https://claude.ai/code/session_012PpucLZVsmw9vf9VvTj2zR)_