### PR TITLE
U13: multi-capsule project toolchain + cross-capsule anti-dredging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "braid-project"
+version = "0.1.0"
+dependencies = [
+ "braid-elaborate-js",
+ "braid-ir",
+ "braid-verify",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "braid-render"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/braid-sdk",
     "crates/braid-cli",
     "crates/braid-elaborate-js",
+    "crates/braid-project",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ for exactly what changed in the move.
 | `crates/braid-sdk` | Typed authoring builder over `braid-ir`; takes any vocabulary's registry. |
 | `crates/braid-cli` | The `braid` binary: `encode`/`decode`/`verify`/`render`/`diff` — the human-reconstructable loop (no AI, no Rust). Pins the `braid-vocab-cms` registry for the CMS reference workflow. |
 | `crates/braid-elaborate-js` | **Frontend** (U11–U12): an operator-precedence JS expression language (`+ - * < == && \|\| !`, literals, booleans, parens) that elaborates JS *text* into an admitted capsule via the one `braid-verify`. The first real frontend over the global IR — "renders JS useless" made operational (D31). |
+| `crates/braid-project` | **Toolchain** (U13): a multi-capsule project manifest + `braid-project build` — elaborate + admit every capsule fail-closed, emit a deterministic project CID. The first step toward a `braid build` for projects (D-TOOLCHAIN). |
 | `spec/braid/` | PRD, decision register (`DECISIONS.md`), threat model, unit plan, KAT vectors. **Start here: `spec/braid/README.md`.** |
 | `docs/` | ADR-088 (ratified doctrine + locked invariants); `authoring-cli.md` (hand-author a capsule). |
 
@@ -46,7 +47,7 @@ for exactly what changed in the move.
 
 ```bash
 cargo check --workspace
-cargo test --workspace      # 127 tests
+cargo test --workspace      # 135 tests
 cargo clippy --workspace --all-targets
 ./scripts/cli-loop.sh       # scenario #12 end-to-end (also a CI job)
 ```

--- a/crates/braid-project/Cargo.toml
+++ b/crates/braid-project/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "braid-project"
+version = "0.1.0"
+edition = "2021"
+description = "Multi-capsule Braid project toolchain (U13). A project is a set of named JS-expression capsules; `braid-project build` elaborates + admits every one through the one braid-verify, fail-closed, and emits a deterministic project CID. The first step toward a `braid build` for projects of many capsules (D-TOOLCHAIN)."
+repository = "https://github.com/srinji-kaggss/Braid"
+homepage = "https://github.com/srinji-kaggss/Braid"
+license = "MIT"
+
+[lib]
+name = "braid_project"
+path = "src/lib.rs"
+
+[[bin]]
+name = "braid-project"
+path = "src/main.rs"
+
+# A consumer/toolchain crate, not trust-base. It composes the frontend
+# (braid-elaborate-js) and reads verdicts off the one verifier; it adds zero
+# authority and builds no second verifier.
+[dependencies]
+braid-ir = { workspace = true }
+braid-verify = { workspace = true }
+braid-elaborate-js = { path = "../braid-elaborate-js" }
+serde = { workspace = true }
+serde_json = "1.0.140"

--- a/crates/braid-project/src/lib.rs
+++ b/crates/braid-project/src/lib.rs
@@ -1,0 +1,178 @@
+//! # braid-project — multi-capsule project toolchain (U13, D-TOOLCHAIN)
+//!
+//! A **project** is a set of named capsules. This crate reads a project
+//! manifest (JSON), elaborates every capsule's JS source through
+//! `braid-elaborate-js`, admits each through the **one** `braid-verify`, and —
+//! only if *all* admit — emits a deterministic **project CID**. It is the first
+//! step toward a `braid build` for projects of many capsules; it is a
+//! consumer/toolchain crate, **not** trust-base: it adds zero authority and
+//! builds no second verifier.
+//!
+//! ## Manifest
+//! ```json
+//! { "name": "demo", "capsules": [ { "name": "greeting", "source": "\"hi\" + \"!\"" } ] }
+//! ```
+//!
+//! ## Anti-dredging posture (cross-capsule)
+//! The dredging risk a *project* adds over a single capsule is **aggregation**:
+//! a build step that quietly pools authority, wires capsules together, or
+//! admits partially. This toolchain refuses all three by construction:
+//! - **No authority aggregation.** Each capsule is elaborated and verified
+//!   *independently under the empty ambient set* — exactly as it would be alone
+//!   (`build` calls the same `elaborate_and_admit`). A capsule's CID inside a
+//!   project equals its standalone CID; the project never rewrites or re-wires
+//!   it, so no capsule gains authority from its neighbours (T1/T5).
+//! - **Fail-closed, never partial.** One capsule that fails to elaborate or
+//!   that the verifier rejects fails the **whole** build, naming the capsule.
+//!   There is no partial-admit surface to exploit.
+//! - **No shadowing.** Duplicate capsule names are rejected — a second capsule
+//!   cannot hide behind a name already taken.
+
+use std::collections::BTreeSet;
+
+use braid_elaborate_js::{elaborate_and_admit, ElabError};
+use braid_ir::{Capsule, Cid};
+use braid_verify::Verdict;
+use serde::Deserialize;
+
+/// Domain separator for the project CID — BLAKE3 under `lw.braid.*`, the same
+/// hashing discipline as the substrate's capsule/registry CIDs (D8/D11). A
+/// project CID is a *build-tool* artifact (reproducibility anchor), not a
+/// verified capsule.
+const PROJECT_DOMAIN: &[u8] = b"lw.braid.project.v1";
+
+/// A project manifest.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Project {
+    pub name: String,
+    pub capsules: Vec<CapsuleSource>,
+}
+
+/// One named capsule's source.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CapsuleSource {
+    pub name: String,
+    pub source: String,
+}
+
+/// Every way a build fails closed. None yields a partial report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProjectError {
+    /// A manifest with no capsules.
+    Empty,
+    /// Two capsules share a name (no shadowing).
+    DuplicateName(String),
+    /// The manifest JSON did not parse.
+    Parse(String),
+    /// A capsule's source failed to elaborate (carries the frontend error).
+    CapsuleElaboration { name: String, error: ElabError },
+    /// A capsule elaborated but the verifier rejected it.
+    CapsuleRejected { name: String, reason: String },
+}
+
+impl core::fmt::Display for ProjectError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ProjectError::Empty => f.write_str("project has no capsules"),
+            ProjectError::DuplicateName(n) => write!(f, "duplicate capsule name `{n}`"),
+            ProjectError::Parse(m) => write!(f, "manifest parse error: {m}"),
+            ProjectError::CapsuleElaboration { name, error } => {
+                write!(f, "capsule `{name}`: {error}")
+            }
+            ProjectError::CapsuleRejected { name, reason } => {
+                write!(f, "capsule `{name}` rejected by the verifier: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProjectError {}
+
+/// One built, admitted capsule.
+#[derive(Debug)]
+pub struct CapsuleEntry {
+    pub name: String,
+    pub capsule: Capsule,
+    pub cid: Cid,
+}
+
+/// The result of a successful build: every capsule admitted.
+#[derive(Debug)]
+pub struct BuildReport {
+    pub name: String,
+    pub project_cid: Cid,
+    pub entries: Vec<CapsuleEntry>,
+}
+
+/// Parse a project manifest from JSON.
+pub fn parse_project(json: &str) -> Result<Project, ProjectError> {
+    serde_json::from_str(json).map_err(|e| ProjectError::Parse(e.to_string()))
+}
+
+/// Build a project: elaborate + admit every capsule, fail-closed on the first
+/// failure, then compute the project CID. Each capsule is verified
+/// independently under the empty ambient set — the project pools no authority.
+pub fn build(project: &Project) -> Result<BuildReport, ProjectError> {
+    if project.capsules.is_empty() {
+        return Err(ProjectError::Empty);
+    }
+
+    // No shadowing: a duplicate name could hide a second capsule behind one the
+    // reviewer already approved.
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for c in &project.capsules {
+        if !seen.insert(c.name.as_str()) {
+            return Err(ProjectError::DuplicateName(c.name.clone()));
+        }
+    }
+
+    let mut entries = Vec::with_capacity(project.capsules.len());
+    for c in &project.capsules {
+        let e =
+            elaborate_and_admit(&c.source).map_err(|error| ProjectError::CapsuleElaboration {
+                name: c.name.clone(),
+                error,
+            })?;
+        match &e.verdict {
+            Verdict::Admit { .. } => {}
+            Verdict::Reject { stage, reason } => {
+                return Err(ProjectError::CapsuleRejected {
+                    name: c.name.clone(),
+                    reason: format!("{stage:?}: {reason}"),
+                });
+            }
+        }
+        let cid = e.capsule.cid();
+        entries.push(CapsuleEntry {
+            name: c.name.clone(),
+            capsule: e.capsule,
+            cid,
+        });
+    }
+
+    let project_cid = compute_project_cid(&entries);
+    Ok(BuildReport {
+        name: project.name.clone(),
+        project_cid,
+        entries,
+    })
+}
+
+/// Convenience: parse + build in one call.
+pub fn build_from_json(json: &str) -> Result<BuildReport, ProjectError> {
+    build(&parse_project(json)?)
+}
+
+/// The project CID: order-independent over the `(name, capsule_cid)` set. Names
+/// are unique (guarded), each row is unambiguously framed (NUL between name and
+/// CID), the set is sorted, then hashed under the project domain. Reordering
+/// capsules in the manifest does not change it; changing any capsule's source
+/// (hence its CID) or its name does.
+fn compute_project_cid(entries: &[CapsuleEntry]) -> Cid {
+    let mut rows: Vec<String> = entries
+        .iter()
+        .map(|e| format!("{}\u{0}{}", e.name, e.cid.to_hex()))
+        .collect();
+    rows.sort();
+    Cid::compute(PROJECT_DOMAIN, rows.join("\n").as_bytes())
+}

--- a/crates/braid-project/src/main.rs
+++ b/crates/braid-project/src/main.rs
@@ -1,0 +1,39 @@
+//! `braid-project build <manifest.json>` — elaborate + admit every capsule in a
+//! project, fail-closed, and print each capsule's CID + the project CID. Mirrors
+//! the CLI shape so the human-reconstructable loop holds at the project level.
+
+use std::process::ExitCode;
+
+use braid_project::{build_from_json, BuildReport};
+
+fn run() -> Result<BuildReport, String> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.split_first() {
+        Some((cmd, rest)) if cmd == "build" => {
+            let path = rest
+                .first()
+                .ok_or_else(|| "usage: braid-project build <manifest.json>".to_string())?;
+            let json = std::fs::read_to_string(path).map_err(|e| format!("reading {path}: {e}"))?;
+            build_from_json(&json).map_err(|e| e.to_string())
+        }
+        _ => Err("usage: braid-project build <manifest.json>".to_string()),
+    }
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(report) => {
+            println!("project: {}", report.name);
+            for e in &report.entries {
+                println!("  ✓ {:<20} {}", e.name, e.cid.to_hex());
+            }
+            println!("project-cid: {}", report.project_cid.to_hex());
+            println!("{} capsule(s) admitted", report.entries.len());
+            ExitCode::SUCCESS
+        }
+        Err(msg) => {
+            eprintln!("braid-project: {msg}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/braid-project/tests/fixtures/demo.json
+++ b/crates/braid-project/tests/fixtures/demo.json
@@ -1,0 +1,8 @@
+{
+  "name": "demo",
+  "capsules": [
+    { "name": "greeting", "source": "\"hello\" + \"world\"" },
+    { "name": "math",     "source": "1 + 2 * 3" },
+    { "name": "check",    "source": "1 < 2 && true" }
+  ]
+}

--- a/crates/braid-project/tests/project.rs
+++ b/crates/braid-project/tests/project.rs
@@ -1,0 +1,123 @@
+//! U13 — multi-capsule build, end to end, with the cross-capsule anti-dredging
+//! guarantees pinned. Nothing mocked; capsules go through the real frontend and
+//! the one verifier.
+
+use braid_elaborate_js::elaborate_js;
+use braid_project::{build, build_from_json, parse_project, ProjectError};
+
+const DEMO: &str = include_str!("fixtures/demo.json");
+
+#[test]
+fn build_admits_all_capsules() {
+    let report = build_from_json(DEMO).expect("demo builds");
+    assert_eq!(report.name, "demo");
+    let names: Vec<&str> = report.entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, ["greeting", "math", "check"]);
+}
+
+/// Anti-dredging — NO authority aggregation (T1/T5): a capsule's CID inside the
+/// project is byte-identical to its STANDALONE elaboration. The project does
+/// not rewrite, re-wire, or pool anything; building together grants no capsule
+/// authority it would not have alone. Mutation-proof: if `build` ever threaded
+/// cross-capsule state into a capsule, its CID would diverge from the standalone
+/// one and this trips.
+#[test]
+fn project_does_not_rewrite_or_aggregate() {
+    let project = parse_project(DEMO).expect("parses");
+    let report = build(&project).expect("builds");
+    for (entry, src) in report.entries.iter().zip(project.capsules.iter()) {
+        let standalone = elaborate_js(&src.source).expect("standalone elaborates");
+        assert_eq!(
+            entry.cid.to_hex(),
+            standalone.cid().to_hex(),
+            "capsule `{}` was rewritten by the project build",
+            entry.name
+        );
+        // Every capsule requests zero authority — a pure project pools nothing.
+        assert!(
+            entry.capsule.grants.is_empty(),
+            "capsule `{}` unexpectedly holds grants",
+            entry.name
+        );
+    }
+}
+
+/// Anti-dredging — context/spec drift: the project CID is pinned. It moves only
+/// when a capsule's source or name changes — a recorded, reproducible event.
+#[test]
+fn project_cid_is_pinned() {
+    let report = build_from_json(DEMO).expect("builds");
+    assert_eq!(
+        report.project_cid.to_hex(),
+        "7071dd369d6e982374f1734d2c69675697bae9f811674256aa7e1d0e23546d33"
+    );
+}
+
+/// The project CID is order-independent (a project is a *set* of named
+/// capsules): reordering the manifest yields the same CID...
+#[test]
+fn project_cid_is_reorder_invariant() {
+    let reordered = r#"{ "name": "demo", "capsules": [
+        { "name": "check",    "source": "1 < 2 && true" },
+        { "name": "math",     "source": "1 + 2 * 3" },
+        { "name": "greeting", "source": "\"hello\" + \"world\"" }
+    ] }"#;
+    assert_eq!(
+        build_from_json(reordered).unwrap().project_cid.to_hex(),
+        build_from_json(DEMO).unwrap().project_cid.to_hex(),
+    );
+}
+
+/// ...but changing any capsule's source changes it (anti-Goodhart: the pin has
+/// teeth — it is a real function of content, not a constant).
+#[test]
+fn project_cid_tracks_content() {
+    let changed = r#"{ "name": "demo", "capsules": [
+        { "name": "greeting", "source": "\"hello\" + \"world\"" },
+        { "name": "math",     "source": "1 + 2 * 4" },
+        { "name": "check",    "source": "1 < 2 && true" }
+    ] }"#;
+    assert_ne!(
+        build_from_json(changed).unwrap().project_cid.to_hex(),
+        build_from_json(DEMO).unwrap().project_cid.to_hex(),
+    );
+}
+
+/// Anti-dredging — fail-closed, never partial: one bad capsule fails the WHOLE
+/// build, naming the offender. There is no partial-admit report to exploit.
+#[test]
+fn one_bad_capsule_fails_the_whole_build() {
+    let bad = r#"{ "name": "demo", "capsules": [
+        { "name": "ok",  "source": "1 + 2" },
+        { "name": "bad", "source": "\"a\" + 1" }
+    ] }"#;
+    match build_from_json(bad) {
+        Err(ProjectError::CapsuleElaboration { name, .. }) => assert_eq!(name, "bad"),
+        other => panic!("expected the build to fail on `bad`, got {other:?}"),
+    }
+}
+
+/// Anti-dredging — no shadowing: a duplicate name cannot hide a second capsule.
+#[test]
+fn duplicate_names_are_rejected() {
+    let dup = r#"{ "name": "demo", "capsules": [
+        { "name": "x", "source": "1 + 2" },
+        { "name": "x", "source": "3 + 4" }
+    ] }"#;
+    assert!(matches!(
+        build_from_json(dup),
+        Err(ProjectError::DuplicateName(n)) if n == "x"
+    ));
+}
+
+#[test]
+fn empty_and_malformed_manifests_fail_closed() {
+    assert!(matches!(
+        build_from_json(r#"{ "name": "e", "capsules": [] }"#),
+        Err(ProjectError::Empty)
+    ));
+    assert!(matches!(
+        build_from_json("not json"),
+        Err(ProjectError::Parse(_))
+    ));
+}

--- a/spec/braid/DEBT_REGISTER.md
+++ b/spec/braid/DEBT_REGISTER.md
@@ -25,6 +25,9 @@
 - ✅ **JS expression language + vocab v2** (U12, D-VOCAB.1) — operator-
   precedence frontend (`+ - * < == && || !`, booleans) over 16 pure JS terms,
   with a mutation-proven anti-escape-hatch guard and re-pinned CIDs.
+- ✅ **Multi-capsule project build** (U13, D-TOOLCHAIN.1) — `braid-project`:
+  manifest → elaborate + admit all (fail-closed) → deterministic project CID;
+  cross-capsule anti-dredging guards (no rewrite/aggregation, no shadowing).
 
 ## Open debts (the Java-ecosystem gap)
 
@@ -68,11 +71,14 @@ unit** (Strand carries no operand — D8-locked work, not a vocab change).
 **Closes**: U12 (expansion + governance — done); a stdlib-scale JS vocabulary
 (later); the substrate-level literal-payload unit.
 
-### D-TOOLCHAIN — Partial toolchain
-`braid-cli` (encode/decode/verify/render/diff) exists. No package manager, no
-build tool for multi-capsule projects, no docs generator, no `braid test`
-harness for capsules (vs. tests *of* the substrate).
-**Closes**: PRD §5 P4+.
+### D-TOOLCHAIN — Partial toolchain *(first slice LANDED — U13)*
+🟡 **Partially closed.** `braid-cli` (encode/decode/verify/render/diff) plus the
+new `braid-project` crate: a multi-capsule project manifest + `braid-project
+build` that elaborates + admits every capsule fail-closed and emits a
+deterministic project CID. Remaining: no package manager/registry (PRD §49
+non-goal), no docs generator, no `braid test` harness for capsules yet, and the
+manifest is JS-expression-only (no intents/anchors).
+**Closes**: U13 (project build — done); PRD §5 P4+ (the rest).
 
 ### D-SA — Tier-2 safety-assurance floor *(BUILT — U-SA landed)*
 ✅ **Closed.** The "stop slop" semantic floor is no longer just a spec: `U-SA`

--- a/spec/braid/units.md
+++ b/spec/braid/units.md
@@ -231,15 +231,31 @@ green and trip under mutation. **Out of scope, deferred honestly**: literal
 > not belong in a vocabulary expansion. Filed as its own future unit; **not**
 > silently folded into U12.
 
-## U13 — multi-capsule project model + `braid` toolchain
-**Closes**: **D-TOOLCHAIN** (no build/test model for projects of many capsules).
-**Scope**: a typed project manifest (a set of capsules + their intents/anchors),
-`braid build` (elaborate + admit every capsule, fail-closed on any reject) and
-`braid test` (a harness for capsules, distinct from tests *of* the substrate).
-No package *registry* (PRD §49 non-goal) — local project only.
-**AC**: a multi-capsule sample project builds and tests through one command;
-one rejecting capsule fails the whole build deterministically with the stage.
-**Verification**: integration test over a fixture project; CI job.
+## U13 — multi-capsule project model + toolchain *(first slice LANDED this session)*
+**Closes**: the first increment of **D-TOOLCHAIN** (no build model for projects
+of many capsules).
+**Scope**: a new `braid-project` consumer crate — a JSON project manifest (a set
+of named JS-expression capsules), `braid-project build <manifest>` that
+elaborates + admits **every** capsule through the one verifier (fail-closed on
+the first failure) and emits a deterministic, order-independent **project CID**.
+No package *registry* (PRD §49 non-goal); `braid test` and richer manifests
+(intents/anchors) are later increments.
+**Hardening (the three dredging classes, cross-capsule, mutation-proven)**:
+- *Composition/aggregation exfil (T1/T5)*: `project_does_not_rewrite_or_aggregate`
+  proves a capsule's CID inside a project is byte-identical to its standalone
+  elaboration (no rewrite/re-wire) and that every capsule holds zero grants —
+  building together pools no authority; `one_bad_capsule_fails_the_whole_build`
+  proves fail-closed (no partial-admit surface); `duplicate_names_are_rejected`
+  proves no shadowing.
+- *Context/spec drift*: the project CID is pinned for the demo fixture.
+- *Test-hollowing/Goodhart (T14/T7)*: `project_cid_tracks_content` proves the
+  pin is a real function of content (changing a source moves it);
+  `project_cid_is_reorder_invariant` proves the set semantics.
+**AC**: a multi-capsule fixture builds through one command; one rejecting/
+failing capsule fails the whole build, naming it; the cross-capsule guards are
+green and trip under mutation.
+**Verification**: `cargo test -p braid-project` (8 tests);
+`cargo run -p braid-project -- build <manifest>`.
 
 ## U14 — first live consumer collapse *(cross-repo coordination)*
 **Closes**: **D-CONSUMER** ("become a dependency" has zero live dependents).


### PR DESCRIPTION
## What & why

Third checkpoint of the post-v0 frontier. A new **`braid-project`** consumer
crate gives Braid its first multi-capsule build model — the first increment of
**D-TOOLCHAIN** — and folds the cross-capsule "dredging" hardening in from the
start.

## Changes

- **`crates/braid-project`** (new consumer/toolchain crate, not trust-base).
  A JSON project manifest of named JS-expression capsules;
  `braid-project build <manifest>` elaborates + admits **every** capsule through
  the one `braid-verify`, fail-closed on the first failure, and emits a
  deterministic, order-independent **project CID** (BLAKE3 under `lw.braid.*`).
- Reuses `braid-elaborate-js` as a library — adds zero authority, builds no
  second verifier.

## Anti-dredging hardening (cross-capsule, mutation-proven)

The risk a *project* adds over a single capsule is **aggregation**. Refused by
construction:

- **No authority aggregation (T1/T5)** — `project_does_not_rewrite_or_aggregate`
  proves a capsule's CID inside a project is byte-identical to its standalone
  elaboration (the project never rewrites/re-wires it) and that every capsule
  holds zero grants. Building together pools nothing.
- **Fail-closed, never partial** — `one_bad_capsule_fails_the_whole_build`: one
  failing capsule fails the whole build, naming it; no partial-admit surface.
- **No shadowing** — `duplicate_names_are_rejected`.
- **Context/spec drift** — the demo project CID is pinned.
- **Goodhart/test-hollowing (T14/T7)** — `project_cid_tracks_content` (the pin
  moves when a source changes) + `project_cid_is_reorder_invariant` (set semantics).

## Verification

- `cargo test -p braid-project` — 8 tests.
- `cargo test --workspace` — 135 green; clippy `-D warnings` clean; `fmt --check` clean.
- `./scripts/cli-loop.sh` and the Keel `NotSlop` floor (now serial/deterministic)
  both GO locally.
- `cargo run -p braid-project -- build crates/braid-project/tests/fixtures/demo.json`
  admits 3 capsules and prints the project CID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PpucLZVsmw9vf9VvTj2zR

---
_Generated by [Claude Code](https://claude.ai/code/session_012PpucLZVsmw9vf9VvTj2zR)_