### PR TITLE
feat: enforce Keel governance envelopes before authoring effects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/braid-cli",
     "crates/braid-elaborate-js",
     "crates/braid-project",
+    "crates/braid-governance",
 ]
 resolver = "2"
 

--- a/crates/braid-governance/Cargo.toml
+++ b/crates/braid-governance/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "braid-governance"
+version = "0.1.0"
+edition = "2021"
+description = "Fail-closed generation-time enforcement of Keel ChangeEnvelopes"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = "1.0"
+sha2 = "0.10"
+hex = "0.4"
+ed25519-dalek = "2.2"
+thiserror = "2.0"

--- a/crates/braid-governance/src/lib.rs
+++ b/crates/braid-governance/src/lib.rs
@@ -166,22 +166,44 @@ impl ChangeEnvelope {
         Ok(hex::encode(hasher.finalize()))
     }
 
-    pub fn validate_commitment(&self, commitment: &DesignCommitment) -> Result<(), GovernanceError> {
+    pub fn validate_commitment(
+        &self,
+        commitment: &DesignCommitment,
+    ) -> Result<(), GovernanceError> {
         if commitment.change_id != self.change_id {
             return Err(GovernanceError::InvalidCommitment("change_id"));
         }
-        require_subset("requirements", &commitment.requirement_refs, &self.requirement_refs)
-            .map_err(|_| GovernanceError::InvalidCommitment("requirements"))?;
-        require_subset("invariants", &commitment.invariant_refs, &self.invariant_refs)
-            .map_err(|_| GovernanceError::InvalidCommitment("invariants"))?;
+        require_subset(
+            "requirements",
+            &commitment.requirement_refs,
+            &self.requirement_refs,
+        )
+        .map_err(|_| GovernanceError::InvalidCommitment("requirements"))?;
+        require_subset(
+            "invariants",
+            &commitment.invariant_refs,
+            &self.invariant_refs,
+        )
+        .map_err(|_| GovernanceError::InvalidCommitment("invariants"))?;
         require_subset("paths", &commitment.intended_paths, &self.allowed_paths)
             .map_err(|_| GovernanceError::InvalidCommitment("paths"))?;
-        require_subset("symbols", &commitment.intended_symbols, &self.allowed_symbols)
-            .map_err(|_| GovernanceError::InvalidCommitment("symbols"))?;
-        require_subset("effects", &commitment.intended_effects, &self.allowed_effects)
-            .map_err(|_| GovernanceError::InvalidCommitment("effects"))?;
+        require_subset(
+            "symbols",
+            &commitment.intended_symbols,
+            &self.allowed_symbols,
+        )
+        .map_err(|_| GovernanceError::InvalidCommitment("symbols"))?;
+        require_subset(
+            "effects",
+            &commitment.intended_effects,
+            &self.allowed_effects,
+        )
+        .map_err(|_| GovernanceError::InvalidCommitment("effects"))?;
 
-        if !commitment.evidence_plan.is_superset(&self.required_evidence) {
+        if !commitment
+            .evidence_plan
+            .is_superset(&self.required_evidence)
+        {
             return Err(GovernanceError::InvalidCommitment("evidence plan"));
         }
         if self.foundation_tier >= FoundationTier::T3TrustBoundary
@@ -256,7 +278,9 @@ impl GovernanceSession {
                     )));
                 }
                 if !envelope.allowed_paths.contains(path) {
-                    return Err(GovernanceError::Denied(format!("path not admitted: {path}")));
+                    return Err(GovernanceError::Denied(format!(
+                        "path not admitted: {path}"
+                    )));
                 }
                 self.usage.distinct_written_paths.insert(path.to_string());
                 if self.usage.distinct_written_paths.len() as u32
@@ -293,8 +317,7 @@ impl GovernanceSession {
                     )));
                 }
                 self.usage.added_dependencies.insert(name.to_string());
-                if self.usage.added_dependencies.len() as u32
-                    > envelope.budget.max_new_dependencies
+                if self.usage.added_dependencies.len() as u32 > envelope.budget.max_new_dependencies
                 {
                     return Err(GovernanceError::BudgetExceeded("max_new_dependencies"));
                 }
@@ -319,12 +342,8 @@ impl GovernanceSession {
                 if effectful {
                     self.usage.effectful_tool_calls =
                         self.usage.effectful_tool_calls.saturating_add(1);
-                    if self.usage.effectful_tool_calls
-                        > envelope.budget.max_effectful_tool_calls
-                    {
-                        return Err(GovernanceError::BudgetExceeded(
-                            "max_effectful_tool_calls",
-                        ));
+                    if self.usage.effectful_tool_calls > envelope.budget.max_effectful_tool_calls {
+                        return Err(GovernanceError::BudgetExceeded("max_effectful_tool_calls"));
                     }
                 }
                 if envelope.forbidden_operations.contains(name) {
@@ -422,7 +441,10 @@ mod tests {
     fn signature_detects_changed_governance() {
         let mut signed = signed_envelope();
         assert!(signed.verify().is_ok());
-        signed.envelope.allowed_effects.insert("network.egress".into());
+        signed
+            .envelope
+            .allowed_effects
+            .insert("network.egress".into());
         assert_eq!(signed.verify(), Err(GovernanceError::InvalidSignature));
     }
 
@@ -493,9 +515,7 @@ mod tests {
                 name: "write",
                 effectful: true,
             }),
-            Err(GovernanceError::BudgetExceeded(
-                "max_effectful_tool_calls"
-            ))
+            Err(GovernanceError::BudgetExceeded("max_effectful_tool_calls"))
         );
     }
 }

--- a/crates/braid-governance/src/lib.rs
+++ b/crates/braid-governance/src/lib.rs
@@ -1,0 +1,501 @@
+//! Braid-side enforcement for Keel generation governance.
+//!
+//! This crate is intentionally outside `braid-ir` and `braid-verify`: Keel
+//! governance is an authoring constraint, not part of Braid's universal IR or
+//! capsule admission semantics.  The adapter verifies the signed Keel
+//! envelope, then fail-closes every proposed authoring action against it.
+
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use thiserror::Error;
+
+pub const CHANGE_ENVELOPE_VERSION: u32 = 1;
+const DIGEST_DOMAIN: &[u8] = b"keel.change-envelope.v1\0";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub enum FoundationTier {
+    T0Cosmetic,
+    T1Application,
+    T2SharedOrPersistent,
+    T3TrustBoundary,
+    T4FoundationalAuthority,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceBudget {
+    pub max_files_changed: u32,
+    pub max_new_dependencies: u32,
+    pub max_tool_calls: u32,
+    pub max_effectful_tool_calls: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChangeEnvelope {
+    pub version: u32,
+    pub change_id: String,
+    pub parent_digest_sha256: Option<String>,
+    pub source_baseline_sha256: String,
+    pub policy_sha256: String,
+    pub intent: String,
+    pub non_goals: BTreeSet<String>,
+    pub foundation_tier: FoundationTier,
+    pub allowed_repositories: BTreeSet<String>,
+    pub allowed_paths: BTreeSet<String>,
+    pub allowed_symbols: BTreeSet<String>,
+    pub allowed_effects: BTreeSet<String>,
+    pub allowed_capabilities: BTreeSet<String>,
+    pub forbidden_operations: BTreeSet<String>,
+    pub requirement_refs: BTreeSet<String>,
+    pub invariant_refs: BTreeSet<String>,
+    pub required_evidence: BTreeSet<String>,
+    pub read_only_evidence_paths: BTreeSet<String>,
+    pub budget: ResourceBudget,
+    pub expires_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SignedChangeEnvelope {
+    pub envelope: ChangeEnvelope,
+    pub signer_key_id: String,
+    pub verifying_key_hex: String,
+    pub signature_hex: String,
+}
+
+/// Structured explain-before-author commitment for high-risk work.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DesignCommitment {
+    pub change_id: String,
+    pub requirement_refs: BTreeSet<String>,
+    pub invariant_refs: BTreeSet<String>,
+    pub intended_paths: BTreeSet<String>,
+    pub intended_symbols: BTreeSet<String>,
+    pub intended_effects: BTreeSet<String>,
+    pub evidence_plan: BTreeSet<String>,
+    pub unresolved_assumptions: BTreeSet<String>,
+}
+
+/// An operation requested by an AI authoring harness.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GenerationAction<'a> {
+    WritePath(&'a str),
+    TouchSymbol(&'a str),
+    UseEffect(&'a str),
+    UseCapability(&'a str),
+    AddDependency(&'a str),
+    ReadEvidencePath(&'a str),
+    ModifyEvidencePath(&'a str),
+    InvokeTool { name: &'a str, effectful: bool },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SessionUsage {
+    pub distinct_written_paths: BTreeSet<String>,
+    pub added_dependencies: BTreeSet<String>,
+    pub tool_calls: u32,
+    pub effectful_tool_calls: u32,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum GovernanceError {
+    #[error("unsupported change-envelope version {0}")]
+    UnsupportedVersion(u32),
+    #[error("missing required field: {0}")]
+    MissingField(&'static str),
+    #[error("invalid SHA-256 field: {0}")]
+    InvalidSha256(&'static str),
+    #[error("invalid hex field: {0}")]
+    InvalidHex(&'static str),
+    #[error("invalid Ed25519 verifying key")]
+    InvalidVerifyingKey,
+    #[error("invalid Ed25519 signature")]
+    InvalidSignature,
+    #[error("serialization failed: {0}")]
+    Serialization(String),
+    #[error("generation action denied: {0}")]
+    Denied(String),
+    #[error("design commitment is outside the admitted envelope: {0}")]
+    InvalidCommitment(&'static str),
+    #[error("resource budget exceeded: {0}")]
+    BudgetExceeded(&'static str),
+}
+
+impl ChangeEnvelope {
+    pub fn validate(&self) -> Result<(), GovernanceError> {
+        if self.version != CHANGE_ENVELOPE_VERSION {
+            return Err(GovernanceError::UnsupportedVersion(self.version));
+        }
+        for (name, value) in [
+            ("change_id", self.change_id.as_str()),
+            ("intent", self.intent.as_str()),
+            ("expires_at", self.expires_at.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                return Err(GovernanceError::MissingField(name));
+            }
+        }
+        validate_sha256("source_baseline_sha256", &self.source_baseline_sha256)?;
+        validate_sha256("policy_sha256", &self.policy_sha256)?;
+        if let Some(parent) = &self.parent_digest_sha256 {
+            validate_sha256("parent_digest_sha256", parent)?;
+        }
+        if self.allowed_repositories.is_empty() {
+            return Err(GovernanceError::MissingField("allowed_repositories"));
+        }
+        if self.requirement_refs.is_empty() {
+            return Err(GovernanceError::MissingField("requirement_refs"));
+        }
+        if self.invariant_refs.is_empty() {
+            return Err(GovernanceError::MissingField("invariant_refs"));
+        }
+        if self.required_evidence.is_empty() {
+            return Err(GovernanceError::MissingField("required_evidence"));
+        }
+        Ok(())
+    }
+
+    pub fn digest_sha256(&self) -> Result<String, GovernanceError> {
+        self.validate()?;
+        let bytes = serde_json::to_vec(self)
+            .map_err(|error| GovernanceError::Serialization(error.to_string()))?;
+        let mut hasher = Sha256::new();
+        hasher.update(DIGEST_DOMAIN);
+        hasher.update(bytes);
+        Ok(hex::encode(hasher.finalize()))
+    }
+
+    pub fn validate_commitment(&self, commitment: &DesignCommitment) -> Result<(), GovernanceError> {
+        if commitment.change_id != self.change_id {
+            return Err(GovernanceError::InvalidCommitment("change_id"));
+        }
+        require_subset("requirements", &commitment.requirement_refs, &self.requirement_refs)
+            .map_err(|_| GovernanceError::InvalidCommitment("requirements"))?;
+        require_subset("invariants", &commitment.invariant_refs, &self.invariant_refs)
+            .map_err(|_| GovernanceError::InvalidCommitment("invariants"))?;
+        require_subset("paths", &commitment.intended_paths, &self.allowed_paths)
+            .map_err(|_| GovernanceError::InvalidCommitment("paths"))?;
+        require_subset("symbols", &commitment.intended_symbols, &self.allowed_symbols)
+            .map_err(|_| GovernanceError::InvalidCommitment("symbols"))?;
+        require_subset("effects", &commitment.intended_effects, &self.allowed_effects)
+            .map_err(|_| GovernanceError::InvalidCommitment("effects"))?;
+
+        if !commitment.evidence_plan.is_superset(&self.required_evidence) {
+            return Err(GovernanceError::InvalidCommitment("evidence plan"));
+        }
+        if self.foundation_tier >= FoundationTier::T3TrustBoundary
+            && (!commitment.unresolved_assumptions.is_empty())
+        {
+            return Err(GovernanceError::InvalidCommitment(
+                "unresolved assumptions require re-admission for T3/T4",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl SignedChangeEnvelope {
+    pub fn from_json_and_verify(bytes: &[u8]) -> Result<Self, GovernanceError> {
+        let signed: SignedChangeEnvelope = serde_json::from_slice(bytes)
+            .map_err(|error| GovernanceError::Serialization(error.to_string()))?;
+        signed.verify()?;
+        Ok(signed)
+    }
+
+    pub fn verify(&self) -> Result<String, GovernanceError> {
+        if self.signer_key_id.trim().is_empty() {
+            return Err(GovernanceError::MissingField("signer_key_id"));
+        }
+        let digest = self.envelope.digest_sha256()?;
+        let key_bytes = decode_fixed::<32>("verifying_key_hex", &self.verifying_key_hex)?;
+        let signature_bytes = decode_fixed::<64>("signature_hex", &self.signature_hex)?;
+        let verifying_key = VerifyingKey::from_bytes(&key_bytes)
+            .map_err(|_| GovernanceError::InvalidVerifyingKey)?;
+        let signature = Signature::from_bytes(&signature_bytes);
+        verifying_key
+            .verify(digest.as_bytes(), &signature)
+            .map_err(|_| GovernanceError::InvalidSignature)?;
+        Ok(digest)
+    }
+}
+
+/// Stateful, fail-closed enforcement used by an authoring harness.
+///
+/// This enforces the envelope before the effect occurs.  It does not infer
+/// semantic correctness; Keel remains responsible for the final assurance case.
+pub struct GovernanceSession {
+    signed: SignedChangeEnvelope,
+    usage: SessionUsage,
+}
+
+impl GovernanceSession {
+    pub fn admit(signed: SignedChangeEnvelope) -> Result<Self, GovernanceError> {
+        signed.verify()?;
+        Ok(Self {
+            signed,
+            usage: SessionUsage::default(),
+        })
+    }
+
+    pub fn envelope(&self) -> &ChangeEnvelope {
+        &self.signed.envelope
+    }
+
+    pub fn usage(&self) -> &SessionUsage {
+        &self.usage
+    }
+
+    pub fn authorize(&mut self, action: GenerationAction<'_>) -> Result<(), GovernanceError> {
+        let envelope = &self.signed.envelope;
+        match action {
+            GenerationAction::WritePath(path) => {
+                if envelope.read_only_evidence_paths.contains(path) {
+                    return Err(GovernanceError::Denied(format!(
+                        "evidence path is read-only: {path}"
+                    )));
+                }
+                if !envelope.allowed_paths.contains(path) {
+                    return Err(GovernanceError::Denied(format!("path not admitted: {path}")));
+                }
+                self.usage.distinct_written_paths.insert(path.to_string());
+                if self.usage.distinct_written_paths.len() as u32
+                    > envelope.budget.max_files_changed
+                {
+                    return Err(GovernanceError::BudgetExceeded("max_files_changed"));
+                }
+            }
+            GenerationAction::TouchSymbol(symbol) => {
+                if !envelope.allowed_symbols.contains(symbol) {
+                    return Err(GovernanceError::Denied(format!(
+                        "symbol not admitted: {symbol}"
+                    )));
+                }
+            }
+            GenerationAction::UseEffect(effect) => {
+                if !envelope.allowed_effects.contains(effect) {
+                    return Err(GovernanceError::Denied(format!(
+                        "effect not admitted: {effect}"
+                    )));
+                }
+            }
+            GenerationAction::UseCapability(capability) => {
+                if !envelope.allowed_capabilities.contains(capability) {
+                    return Err(GovernanceError::Denied(format!(
+                        "capability not admitted: {capability}"
+                    )));
+                }
+            }
+            GenerationAction::AddDependency(name) => {
+                if envelope.forbidden_operations.contains("new-dependency") {
+                    return Err(GovernanceError::Denied(format!(
+                        "new dependencies forbidden: {name}"
+                    )));
+                }
+                self.usage.added_dependencies.insert(name.to_string());
+                if self.usage.added_dependencies.len() as u32
+                    > envelope.budget.max_new_dependencies
+                {
+                    return Err(GovernanceError::BudgetExceeded("max_new_dependencies"));
+                }
+            }
+            GenerationAction::ReadEvidencePath(path) => {
+                if !envelope.read_only_evidence_paths.contains(path) {
+                    return Err(GovernanceError::Denied(format!(
+                        "evidence path not admitted: {path}"
+                    )));
+                }
+            }
+            GenerationAction::ModifyEvidencePath(path) => {
+                return Err(GovernanceError::Denied(format!(
+                    "implementation author may not modify evidence path: {path}"
+                )));
+            }
+            GenerationAction::InvokeTool { name, effectful } => {
+                self.usage.tool_calls = self.usage.tool_calls.saturating_add(1);
+                if self.usage.tool_calls > envelope.budget.max_tool_calls {
+                    return Err(GovernanceError::BudgetExceeded("max_tool_calls"));
+                }
+                if effectful {
+                    self.usage.effectful_tool_calls =
+                        self.usage.effectful_tool_calls.saturating_add(1);
+                    if self.usage.effectful_tool_calls
+                        > envelope.budget.max_effectful_tool_calls
+                    {
+                        return Err(GovernanceError::BudgetExceeded(
+                            "max_effectful_tool_calls",
+                        ));
+                    }
+                }
+                if envelope.forbidden_operations.contains(name) {
+                    return Err(GovernanceError::Denied(format!(
+                        "tool operation forbidden: {name}"
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_sha256(field: &'static str, value: &str) -> Result<(), GovernanceError> {
+    let bytes = hex::decode(value).map_err(|_| GovernanceError::InvalidSha256(field))?;
+    if bytes.len() != 32 || value.len() != 64 || value != value.to_ascii_lowercase() {
+        return Err(GovernanceError::InvalidSha256(field));
+    }
+    Ok(())
+}
+
+fn decode_fixed<const N: usize>(
+    field: &'static str,
+    value: &str,
+) -> Result<[u8; N], GovernanceError> {
+    let bytes = hex::decode(value).map_err(|_| GovernanceError::InvalidHex(field))?;
+    bytes
+        .try_into()
+        .map_err(|_| GovernanceError::InvalidHex(field))
+}
+
+fn require_subset(
+    dimension: &'static str,
+    child: &BTreeSet<String>,
+    parent: &BTreeSet<String>,
+) -> Result<(), GovernanceError> {
+    if child.is_subset(parent) {
+        Ok(())
+    } else {
+        Err(GovernanceError::Denied(format!(
+            "{dimension} exceeds envelope"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn set(values: &[&str]) -> BTreeSet<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    fn signed_envelope() -> SignedChangeEnvelope {
+        let envelope = ChangeEnvelope {
+            version: CHANGE_ENVELOPE_VERSION,
+            change_id: "CHG-1".into(),
+            parent_digest_sha256: None,
+            source_baseline_sha256: "11".repeat(32),
+            policy_sha256: "22".repeat(32),
+            intent: "repair token redemption".into(),
+            non_goals: set(&["change wire format"]),
+            foundation_tier: FoundationTier::T4FoundationalAuthority,
+            allowed_repositories: set(&["example/auth"]),
+            allowed_paths: set(&["src/auth.rs", "tests/auth.rs"]),
+            allowed_symbols: set(&["redeem", "TokenLedger"]),
+            allowed_effects: set(&["ledger.read", "ledger.atomic-write"]),
+            allowed_capabilities: set(&["fs.read", "db.write"]),
+            forbidden_operations: set(&["network", "new-dependency"]),
+            requirement_refs: set(&["REQ-AUTH-17"]),
+            invariant_refs: set(&["INV-SINGLE-USE"]),
+            required_evidence: set(&["property:double-redemption"]),
+            read_only_evidence_paths: set(&["spec/auth.md"]),
+            budget: ResourceBudget {
+                max_files_changed: 2,
+                max_new_dependencies: 0,
+                max_tool_calls: 4,
+                max_effectful_tool_calls: 1,
+            },
+            expires_at: "2026-07-07T00:00:00Z".into(),
+        };
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let digest = envelope.digest_sha256().unwrap();
+        let signature = signing_key.sign(digest.as_bytes());
+        SignedChangeEnvelope {
+            envelope,
+            signer_key_id: "test-key".into(),
+            verifying_key_hex: hex::encode(signing_key.verifying_key().to_bytes()),
+            signature_hex: hex::encode(signature.to_bytes()),
+        }
+    }
+
+    #[test]
+    fn signature_detects_changed_governance() {
+        let mut signed = signed_envelope();
+        assert!(signed.verify().is_ok());
+        signed.envelope.allowed_effects.insert("network.egress".into());
+        assert_eq!(signed.verify(), Err(GovernanceError::InvalidSignature));
+    }
+
+    #[test]
+    fn design_commitment_must_cover_required_evidence() {
+        let signed = signed_envelope();
+        let commitment = DesignCommitment {
+            change_id: "CHG-1".into(),
+            requirement_refs: set(&["REQ-AUTH-17"]),
+            invariant_refs: set(&["INV-SINGLE-USE"]),
+            intended_paths: set(&["src/auth.rs"]),
+            intended_symbols: set(&["redeem"]),
+            intended_effects: set(&["ledger.atomic-write"]),
+            evidence_plan: BTreeSet::new(),
+            unresolved_assumptions: BTreeSet::new(),
+        };
+        assert_eq!(
+            signed.envelope.validate_commitment(&commitment),
+            Err(GovernanceError::InvalidCommitment("evidence plan"))
+        );
+    }
+
+    #[test]
+    fn undeclared_effect_is_blocked_before_execution() {
+        let mut session = GovernanceSession::admit(signed_envelope()).unwrap();
+        assert!(session
+            .authorize(GenerationAction::UseEffect("ledger.atomic-write"))
+            .is_ok());
+        assert_eq!(
+            session.authorize(GenerationAction::UseEffect("network.egress")),
+            Err(GovernanceError::Denied(
+                "effect not admitted: network.egress".into()
+            ))
+        );
+    }
+
+    #[test]
+    fn evidence_is_read_only_to_implementation_author() {
+        let mut session = GovernanceSession::admit(signed_envelope()).unwrap();
+        assert!(session
+            .authorize(GenerationAction::ReadEvidencePath("spec/auth.md"))
+            .is_ok());
+        assert_eq!(
+            session.authorize(GenerationAction::ModifyEvidencePath("spec/auth.md")),
+            Err(GovernanceError::Denied(
+                "implementation author may not modify evidence path: spec/auth.md".into()
+            ))
+        );
+    }
+
+    #[test]
+    fn budgets_are_enforced_incrementally() {
+        let mut session = GovernanceSession::admit(signed_envelope()).unwrap();
+        assert!(session
+            .authorize(GenerationAction::InvokeTool {
+                name: "read",
+                effectful: false,
+            })
+            .is_ok());
+        assert!(session
+            .authorize(GenerationAction::InvokeTool {
+                name: "write",
+                effectful: true,
+            })
+            .is_ok());
+        assert_eq!(
+            session.authorize(GenerationAction::InvokeTool {
+                name: "write",
+                effectful: true,
+            }),
+            Err(GovernanceError::BudgetExceeded(
+                "max_effectful_tool_calls"
+            ))
+        );
+    }
+}


### PR DESCRIPTION
Implements the first bounded slice of #18 and pairs with srinji-kaggss/keel#34 / PR #35.

## What this PR implements

- Adds a separate `braid-governance` adapter crate rather than changing Braid's universal capsule wire format or widening `braid-verify`'s trust base.
- Independently parses and verifies Keel v1 signed `ChangeEnvelope` artifacts.
- Adds structured `DesignCommitment` validation for explain-before-author workflows.
- Adds fail-closed, pre-effect authorization for:
  - file writes and symbol changes;
  - effects and capabilities;
  - dependency additions;
  - evidence reads versus evidence mutation;
  - tool-call and effectful-tool budgets.
- Keeps session usage state so budget enforcement happens incrementally rather than only after generation.
- Adds negative tests for signature mutation, missing evidence plans, undeclared effects, evidence tampering, and effectful-tool budget exhaustion.

## Deliberate boundary

This PR does not modify `braid-ir::Capsule`, bump `IR_VERSION`, or put an LLM into Braid's verifier. Governance is an authoring envelope around Braid, not a new universal-IR semantic. Keel remains responsible for deriving good requirements/invariants, foundational scoring, and final assurance sufficiency.

## Honest limitations

- Trusted signer policy is not yet externalized; signature validity alone is not organizational identity.
- Expiry is carried by the envelope but this adapter does not assume a trusted local wall clock.
- A cross-repository known-answer vector should be added before declaring the wire representation stable across non-Rust implementations.
- The crate exposes enforcement primitives; wiring every existing frontend/SDK/tool call into `GovernanceSession::authorize` is follow-up integration work.

## Validation expected

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

The review should be strict about trust-base growth, serialization equivalence with Keel, fail-closed behavior, and whether any action can occur before authorization.