### PR TITLE
fix: calibration.rs clippy::question_mark (toolchain drift, unrelated to keel PR)

### DIFF
--- a/crates/braid-ir/tests/calibration.rs
+++ b/crates/braid-ir/tests/calibration.rs
@@ -31,11 +31,8 @@ fn rfc_json_to_braid(v: &serde_json::Value) -> Option<Value> {
         J::Bool(b) => Value::Bool(*b),
         J::Number(n) => {
             // RFC ints are within i64; floats are out of Braid's universe.
-            if let Some(i) = n.as_i64() {
-                Value::Int(i)
-            } else {
-                return None; // float or out-of-range — outside Braid's subset
-            }
+            let i = n.as_i64()?; // float or out-of-range — outside Braid's subset
+            Value::Int(i)
         }
         J::String(s) => Value::Text(s.clone()),
         J::Array(items) => {


### PR DESCRIPTION
## Summary
- \`build · test · lint\` currently fails on \`main\` at HEAD (\`d703512\`) under today's \`stable\` toolchain with a \`clippy::question_mark\` error in \`crates/braid-ir/tests/calibration.rs:34\` — CI last ran green on this exact commit on 2026-07-06, so this is toolchain drift (a newer stable clippy), not a regression from any feature branch.
- This blocks \`test\`, which blocks \`tier2-semantic\` (\`needs: [test]\`) on every open PR right now, including #20.
- Mechanical fix only: applies clippy's own suggested rewrite (\`if let Some(i) = ... else { return None }\` → \`let i = ...?;\`). No behavior change — verified locally.

## Test plan
- [x] \`cargo clippy -p braid-ir --tests -- -D warnings\` clean locally
- [x] \`cargo test -p braid-ir --test calibration\` — 2 passed
- [ ] CI green