### PR TITLE
build: bump cc 1.2.64 → 1.3.0 (rustc 1.97 build fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "shlex",


### PR DESCRIPTION
## Why

cc 1.2.64 fails to compile on rustc 1.97 stable — 11 E0599 errors, all in cc's own `lib.rs` calling methods that don't exist on `TargetInfo` in cc's own `target.rs` (broken publish or feature-gate drift):
- `TargetInfo::llvm_target(...)` at cc/src/lib.rs:2311, 2325
- `TargetInfo::apple_version_flag(...)` at cc/src/lib.rs:2887
- `TargetInfo::apple_sdk_name(...)` at cc/src/lib.rs:2895, 4105, 4127
- `TargetInfo::from_rustc_target(...)` at cc/src/lib.rs:3828

Blast radius: any consumer of Braid's `verify-braid` CI job. Currently failing on `srinji-kaggss/forge-harness` PRs #262 (merged) and #263 (open), blocking auto-merge on #263 (dreamer-retention).

## Fix

`cargo update -p cc --precise 1.3.0`. cc 1.3.0 published 2026-07-18 by upstream; internal consistency restored.

## Verification

- `cargo test --workspace` clean locally on `main` + this change (0 failures across ~20 test binaries).
- No source changes; single-line delta in `Cargo.lock`.