### PR TITLE
build: bump cc 1.2.64 → 1.3.0 (rustc 1.97 build fix) + adopt Constellation Charter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md — agent entry point for Braid
+
+## Constellation charter (read first)
+
+This repo operates under the **Constellation Charter**, ratified 2026-07-20 by Director Srinjon Gupta. Canonical: `~/logic-os-kernel/laws/CONSTELLATION-CHARTER.md`. Where a repo-local doc contradicts the charter, the charter wins.
+
+**Role of this repo:** canonical machine-first IR + encoding + verifier.
+**Authority held here:** **`Cid` contract (`pub struct Cid(pub [u8; 32])`, `crates/braid-ir/src/cid.rs`)** — this is the SOLE authority for content identity across the constellation. Canonical term vocabularies. Verifier reference implementation.
+**Authority NOT held here:** Capability envelope (owner: logic-os-kernel), Verdict (owner: logic-os-kernel), Fact envelope (owner: logic-os-kernel), Principal (owner: logic-os-kernel), Receipt schema (owner: forge-harness).
+**Downstream consumers:** kernel path-deps `braid-ir` + `braid-vocab-cms` (correct direction). Browser has a vendored `vendor/braid/` copy — deprecated on next Braid publish. Charter Step 3 gate: browser consumes published Braid crates instead of the snapshot.
+
+Before creating any type named `Capability`, `Verdict`, `Fact envelope`, `Principal`, `Receipt`, or `WorkObject`, STOP — G2 gate blocks new authorities outside the registered owner.
+
+Before creating any new `pub struct Cid` in ANY repo, STOP — this is the sole authority.
+
+---
+
+## What Braid is
+
+Braid holds the canonical machine-first language of the constellation: intermediate representation, canonical encoding, content-identity contract, term registry, verifier. Every other repo that reasons about content identity or canonical terms consumes Braid — they do not fork it.
+
+## Publishing discipline
+
+Braid crates must be publishable so downstream repos can take real versioned dependencies instead of vendored snapshots. Every breaking change to `Cid`, canonical encoding, or vocabulary registry is a G4 concept-authority event and requires charter amendment.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "shlex",

--- a/docs/handoffs/2026-07-20-constellation-charter-adoption.md
+++ b/docs/handoffs/2026-07-20-constellation-charter-adoption.md
@@ -1,0 +1,25 @@
+# Constellation Charter adoption — 2026-07-20
+
+## What changed
+- Adopted the Constellation Charter (canonical at `~/logic-os-kernel/laws/CONSTELLATION-CHARTER.md`, ratified 2026-07-20 by Director).
+- New `AGENTS.md` (didn't exist before) now opens with a charter pointer + this repo's role line.
+
+## This repo's role under the charter
+**Role:** canonical machine-first IR + encoding + verifier.
+**Authority held (SOLE across the constellation):** `Cid` contract (`pub struct Cid(pub [u8; 32])`, `crates/braid-ir/src/cid.rs`), canonical term vocabularies, verifier reference.
+**Authority NOT held:** Capability envelope (kernel), Verdict (kernel), Fact envelope (kernel), Principal (kernel), Receipt schema (forge-harness).
+
+## Local implications
+- **Publishing discipline is now load-bearing.** Downstream repos (browser `vendor/braid/`, kernel path-deps) need Braid crates published so they can consume versioned deps instead of snapshots. Charter Step 3 gate blocks convergence until this is done.
+- Every breaking change to `Cid`, canonical encoding, or vocabulary registry is a G4 concept-authority event — requires charter amendment (`~/.claude/state/charter-unlock` sentinel + Director ADR).
+- Kernel already path-deps `braid-ir` + `braid-vocab-cms` — that edge is CORRECT direction and confirmed working.
+
+## Follow-ups outstanding
+- Publish Braid crates (versioned) so browser can drop `vendor/braid/` and consume the real crate.
+- Any Cid or vocabulary change → surface as an ADR under `logic-os-kernel/laws/governance/` before merge.
+
+## Provenance
+- Commit: `8174963e05ac` (this docs file will be a subsequent commit).
+- Branch: `fix/cc-1.3.0-toolchain-drift`.
+- Not yet pushed.
+- Related memory: `~/.claude/projects/-Users-srinji/memory/project_constellation_charter_2026_07_20.md`.


### PR DESCRIPTION
Two stacked commits:

1. **`build: bump cc 1.2.64 → 1.3.0`** — fixes rustc 1.97 build failure.
2. **`governance: adopt Constellation Charter 2026-07-20`** + handoff doc — Braid holds SOLE Cid contract authority under the charter.

## Test
Local `cargo check` green.

## Follow-up
CI will run on push; merge after green.

🤖 Generated with Claude Opus 4.7