### PR TITLE
Bound JS elaboration input size

### DIFF
--- a/crates/braid-elaborate-js/src/lib.rs
+++ b/crates/braid-elaborate-js/src/lib.rs
@@ -27,6 +27,13 @@ use braid_sdk::{Builder, Strand};
 use braid_verify::{verify, Verdict};
 use braid_vocab_js::registry_v0;
 
+/// Maximum source length accepted by the frontend.
+///
+/// This is a whole-pipeline work ceiling: lexing, parsing, and emission are
+/// linear in the token stream, so refusing oversized input before the lexer
+/// bounds every later stage as well.
+pub const MAX_SOURCE_CHARS: usize = 8192;
+
 /// Maximum recursion depth allowed during parsing and elaboration to prevent stack exhaustion.
 pub const MAX_DEPTH: usize = 128;
 
@@ -60,6 +67,13 @@ impl core::fmt::Display for ValType {
 pub enum ElabError {
     /// No tokens — empty or whitespace-only source.
     Empty,
+    /// Source exceeded the frontend's bounded-work ceiling.
+    SourceTooLong {
+        /// Number of Unicode scalar values supplied.
+        len: usize,
+        /// The [`MAX_SOURCE_CHARS`] limit.
+        limit: usize,
+    },
     /// A character or token the lexer cannot form.
     Lex(String),
     /// A token stream the grammar does not accept.
@@ -94,6 +108,9 @@ impl core::fmt::Display for ElabError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             ElabError::Empty => f.write_str("empty source: nothing to elaborate"),
+            ElabError::SourceTooLong { len, limit } => {
+                write!(f, "source has {len} characters; maximum is {limit}")
+            }
             ElabError::Lex(m) => write!(f, "lex error: {m}"),
             ElabError::Parse(m) => write!(f, "parse error: {m}"),
             ElabError::TypeError { op, operands } => {
@@ -870,6 +887,14 @@ fn intent_for(src: &str) -> String {
 
 /// Elaborates a JS source (expressions, let-statements, returns) into an admittable [`Capsule`].
 pub fn elaborate_js(src: &str) -> Result<Capsule, ElabError> {
+    let source_len = src.chars().count();
+    if source_len > MAX_SOURCE_CHARS {
+        return Err(ElabError::SourceTooLong {
+            len: source_len,
+            limit: MAX_SOURCE_CHARS,
+        });
+    }
+
     let prog = parse_program(src)?;
     let reg = registry_v0();
     let mut b = Builder::new(&reg, intent_for(src));

--- a/crates/braid-elaborate-js/tests/elaborate.rs
+++ b/crates/braid-elaborate-js/tests/elaborate.rs
@@ -6,7 +6,7 @@
 //! - The 10+ refusal corpus (fail-closed rejections)
 //! - The 10+ golden corpus (pinned deterministic capsule CIDs)
 
-use braid_elaborate_js::{elaborate_and_admit, elaborate_js, ElabError};
+use braid_elaborate_js::{elaborate_and_admit, elaborate_js, ElabError, MAX_SOURCE_CHARS};
 use braid_verify::Verdict;
 
 fn terms(capsule: &braid_ir::Capsule) -> Vec<&str> {
@@ -304,6 +304,17 @@ fn golden_10_comparisons() {
     let src = "let a = 10; let b = 20; let is_less = a < b; !is_less || (a < 100);";
     let capsule = elaborate_js(src).expect("elaborates");
     assert!(!capsule.cid().to_hex().is_empty());
+}
+
+#[test]
+fn oversized_source_is_refused_before_lexing() {
+    let half = MAX_SOURCE_CHARS / 2 + 1;
+    let src = "1+".repeat(half);
+    assert!(matches!(
+        elaborate_js(&src),
+        Err(ElabError::SourceTooLong { len, limit })
+            if len == half * 2 && limit == MAX_SOURCE_CHARS
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Part of #28.

Adds an explicit 8,192-character source ceiling before lexing and a typed `SourceTooLong` error. Since the lexer, parser, and emitter are linear in the token stream, this bounds the whole elaboration pipeline, including the bare string-lexing loop. Local workspace fmt/clippy/tests/doc tests are green.