### PR TITLE
[lgwks_std] Use cross-platform OS entropy backend

### DIFF
--- a/crates/lgwks-std-gate/src/lib.rs
+++ b/crates/lgwks-std-gate/src/lib.rs
@@ -461,7 +461,7 @@ mod tests {
 
         // lgwks-std may only declare deps on this approved list.
         {
-            const APPROVED: &[&str] = &["blake3", "regex", "rkyv", "serde", "serde_json"];
+            const APPROVED: &[&str] = &["blake3", "getrandom", "regex", "rkyv", "serde", "serde_json"];
 
             let manifest = std::fs::read_to_string(workspace.join("crates/lgwks-std/Cargo.toml"))
                 .expect("std manifest missing");

--- a/crates/lgwks-std/Cargo.toml
+++ b/crates/lgwks-std/Cargo.toml
@@ -22,6 +22,7 @@ keywords = ["stdlib", "utilities", "zero-config", "async", "serialization"]
 #   serde         — 1 crate + derive (proc-macro2, quote, syn — same stack)
 #   serde_json    — 2 crates beyond serde (itoa, ryu — both zero-dep leaves)
 #                   reuses memchr from regex tree
+#   getrandom     — 0-dep leaves in std-only mode for supported OSes
 [features]
 default = ["core"]
 core = []
@@ -37,6 +38,7 @@ regex = { version = "1.13", optional = true }
 rkyv = { version = "0.8", default-features = false, features = ["alloc", "bytecheck"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
+getrandom = "0.2"
 
 [dev-dependencies]
 tempfile = "3.20"

--- a/crates/lgwks-std/README.md
+++ b/crates/lgwks-std/README.md
@@ -78,7 +78,7 @@ Legacy module ownership map:
 
 ## INV-STDPLUS-APPROVED-ONLY
 
-The crate declares five external crates, all vetted leaf stacks, enabled by
+The crate declares six external crates, all vetted leaf stacks, enabled by
 features:
 
 - **`blake3`** (feature `hash`; 3 zero-dep leaves: arrayvec, cfg-if,
@@ -89,6 +89,8 @@ features:
 - **`serde_json`** (feature `json`)
 - **`rkyv`** (feature `wire`; 5 djkoloski crates: rend, ptr_meta, rancor,
   munge + derive; zero external deps)
+- **`getrandom`** (default path for `random`; supported on linux/macOS/windows in
+  this crate)
 
 The gate test `deps_are_approved_leaves` in `lgwks-std-gate` mechanically
 verifies no unapproved dependency appears in the manifest.

--- a/crates/lgwks-std/src/random.rs
+++ b/crates/lgwks-std/src/random.rs
@@ -1,7 +1,7 @@
 //! `random` owns every source of randomness in the estate and enforces
-//! INV-RANDOM-ONE-SOURCE: all randomness comes from the operating system's
-//! CSPRNG, and a failure to read it is an error the caller must handle — never
-//! a silent fall back to a clock, a counter, or a userspace PRNG.
+//! INV-RANDOM-ONE-SOURCE: all randomness comes from a single OS CSPRNG backend,
+//! and a failure to read it is an error the caller must handle — never a
+//! silent fallback to a clock, a counter, or userspace PRNG.
 //!
 //! Backs `uuid` v4 generation and is the intended home for the `rand` crate's
 //! work — but `rand` is declared in 4 manifests and reached from **43** call
@@ -12,47 +12,39 @@
 //! source of randomness would be a second source of truth for one concept,
 //! which Law 3 forbids.
 //!
-//! The entropy device is `/dev/urandom`, which is non-blocking and
-//! cryptographically seeded on both platforms the estate targets. A fallback
-//! path is deliberately absent: a hidden downgrade from CSPRNG bytes to
-//! timestamp bytes is the exact failure mode that makes generated identifiers
-//! predictable, so this module surfaces the fault instead.
+//! Supported targets are Linux, macOS, and Windows. For unsupported targets,
+//! the crate fails at compile time so callers do not get a runtime surprise.
 
 use std::error::Error;
 use std::fmt;
-use std::fs::File;
-use std::io::Read;
 
-const ENTROPY_DEVICE: &str = "/dev/urandom";
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+compile_error!("lgwks_std::random supports linux, macOS, and windows only.");
 
 /// The OS entropy source could not be read. There is no second source; a caller
 /// that cannot proceed without randomness must fail, not substitute.
 #[derive(Debug)]
 pub struct EntropyError {
-    device: &'static str,
-    cause: std::io::Error,
+    backend: &'static str,
+    cause: String,
 }
 
 impl EntropyError {
-    /// The device path that could not be read.
-    pub fn device(&self) -> &'static str {
-        self.device
+    /// The backend that could not provide entropy.
+    pub fn backend(&self) -> &'static str {
+        self.backend
     }
 }
 
 impl fmt::Display for EntropyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "could not read OS entropy from {}: {}",
-            self.device, self.cause
-        )
+        write!(f, "could not read OS entropy from {}: {}", self.backend, self.cause)
     }
 }
 
 impl Error for EntropyError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(&self.cause)
+        None
     }
 }
 
@@ -61,13 +53,9 @@ pub fn fill_bytes(buf: &mut [u8]) -> Result<(), EntropyError> {
     if buf.is_empty() {
         return Ok(());
     }
-    let mut device = File::open(ENTROPY_DEVICE).map_err(|cause| EntropyError {
-        device: ENTROPY_DEVICE,
-        cause,
-    })?;
-    device.read_exact(buf).map_err(|cause| EntropyError {
-        device: ENTROPY_DEVICE,
-        cause,
+    getrandom::fill(buf).map_err(|cause| EntropyError {
+        backend: "getrandom",
+        cause: cause.to_string(),
     })
 }
 


### PR DESCRIPTION
Implements issue #41 by replacing hardcoded /dev/urandom in  with , adding compile-time unsupported-target guard, and updating gate/README to include  as an approved dependency.