### PR TITLE
[lgwks_std] Add MSRV + current-stable Rust CI contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,64 @@ jobs:
         if: needs.scope.outputs.code_changed != 'yes'
         run: echo "scope docs-only — clippy skipped (explicit N/A)"
 
+  lgwks-std-current-stable:
+    name: lgwks-std current-stable Rust 1.98.0
+    needs: [scope, stack-position]
+    runs-on: self-hosted
+    if: needs.scope.outputs.code_changed == 'yes'
+    env:
+      CARGO_TARGET_DIR: /Users/srinji/.braid-ci/targets/${{ github.run_id }}-std-stable
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pin Rust 1.98.0
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.98.0"
+          components: clippy
+
+      - name: Workspace test on current stable
+        run: cargo test --workspace --all-targets
+
+      - name: Workspace clippy on current stable
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+  lgwks-std-msrv:
+    name: lgwks-std MSRV
+    needs: [scope, stack-position]
+    runs-on: self-hosted
+    if: needs.scope.outputs.code_changed == 'yes'
+    env:
+      CARGO_TARGET_DIR: /Users/srinji/.braid-ci/targets/${{ github.run_id }}-msrv
+    strategy:
+      fail-fast: false
+      matrix:
+        msrv: ["1.97.0"]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pin MSRV
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "${{ matrix.msrv }}"
+          components: ""
+
+      - name: Check lgwks-std feature matrix at MSRV
+        run: |
+          set -eu
+          cargo check --manifest-path crates/lgwks-std/Cargo.toml --all-targets --no-default-features
+          cargo check --manifest-path crates/lgwks-std/Cargo.toml --all-targets
+          cargo check --manifest-path crates/lgwks-std/Cargo.toml --all-targets --features hash --no-default-features
+          cargo check --manifest-path crates/lgwks-std/Cargo.toml --all-targets --features pattern --no-default-features
+          cargo check --manifest-path crates/lgwks-std/Cargo.toml --all-targets --features json --no-default-features
+          cargo check --manifest-path crates/lgwks-std/Cargo.toml --all-targets --features wire --no-default-features
+          cargo check --manifest-path crates/lgwks-std/Cargo.toml --all-targets --all-features
+
+      - name: Check lgwks-std-gate at MSRV
+        run: cargo check --manifest-path crates/lgwks-std-gate/Cargo.toml --all-targets
+
   # ── std+ feature matrix ────────────────────────────────────────────────
   lgwks-std-feature-matrix:
     name: lgwks-std feature matrix

--- a/crates/lgwks-std/README.md
+++ b/crates/lgwks-std/README.md
@@ -6,6 +6,14 @@ has registered it in the semantic contract.
 
 This crate is the `+`. `lgwks-std-gate` is the "does not compile."
 
+## Supported Rust policy
+
+`lgwks_std` and `lgwks_std_gate` are governed by two Rust contracts:
+
+- **Current stable contract:** workspace and CI run against Rust 1.98.0.
+- **MSRV contract:** `Cargo.toml` `rust-version` fields are the minimum supported compiler, not the
+  active CI compiler. They move forward only when code or dependency requirements require it.
+
 ## What it provides
 
 Every module is a declarative primitive — one import, one function call, done.

--- a/crates/lgwks-std/src/random.rs
+++ b/crates/lgwks-std/src/random.rs
@@ -53,7 +53,7 @@ pub fn fill_bytes(buf: &mut [u8]) -> Result<(), EntropyError> {
     if buf.is_empty() {
         return Ok(());
     }
-    getrandom::fill(buf).map_err(|cause| EntropyError {
+    getrandom::getrandom(buf).map_err(|cause| EntropyError {
         backend: "getrandom",
         cause: cause.to_string(),
     })

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.98.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary
- Add repository rust-toolchain policy for current stable .
- Add CI jobs for:
  - full workspace test/clippy on Rust , and
  - lgwks-std/msrv checks across default + feature matrix and gate crate.
- Update  entropy backend call to  for compatibility.
- Add Rust policy note in .

Closes #38