### PR TITLE
[lgwks_std] Drift-proof std+ contract docs, repo metadata, and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,8 @@ jobs:
         if: needs.scope.outputs.code_changed != 'yes'
         run: echo "scope docs-only — clippy skipped (explicit N/A)"
 
+%%%%%%% diff from: tssvtslw 1ad28dbb "Merge pull request #47 from srinji-kaggss/feat/lgwks-std-target-random" (parents of rebased revision)
+\\\\\\\        to: nquwoknt 3c867bb4 "Add lgwks-std MSRV + current-stable contracts (#48)" (rebase destination)
   lgwks-std-current-stable:
     name: lgwks-std current-stable Rust 1.98.0
     needs: [scope, stack-position]
@@ -259,6 +261,55 @@ jobs:
 
       - name: Check lgwks-std-gate at MSRV
         run: cargo check --manifest-path crates/lgwks-std-gate/Cargo.toml --all-targets
+
+  lgwks-std-contract-drift:
+    name: lgwks-std contract drift checks
+    needs: [scope, stack-position]
+    runs-on: self-hosted
+    if: needs.scope.outputs.code_changed == 'yes'
+    env:
+      CARGO_TARGET_DIR: /Users/srinji/.braid-ci/targets/${{ github.run_id }}-std-contract
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate std+ contract alignment
+        run: |
+          python - <<'PY'
+          import re
+          import tomllib
+          from pathlib import Path
+
+          manifest = Path("crates/lgwks-std/Cargo.toml")
+          readme = Path("crates/lgwks-std/README.md")
+
+          parsed = tomllib.loads(manifest.read_text(encoding="utf-8"))
+          manifest_deps = set(parsed["dependencies"].keys())
+
+          text = readme.read_text(encoding="utf-8")
+          marker = "The crate declares six external crates, all vetted leaf stacks, enabled by"
+          start = text.find(marker)
+          if start == -1:
+              raise SystemExit("README contract section missing")
+
+          section = text[start:start + 1800]
+          readme_deps = set(re.findall(r"- \\*\\*`([a-zA-Z0-9_]+)`", section))
+
+          missing_from_readme = sorted(manifest_deps - readme_deps)
+          missing_from_manifest = sorted(readme_deps - manifest_deps)
+          if missing_from_readme or missing_from_manifest:
+              raise SystemExit(
+                  f"Dependency contract drift detected. "
+                  f"missing_from_readme={missing_from_readme}, "
+                  f"missing_from_manifest={missing_from_manifest}"
+              )
+
+          package = parsed["package"]
+          if package["repository"] != "https://github.com/srinji-kaggss/Braid":
+              raise SystemExit(
+                  f"Unexpected package repository URL: {package['repository']}"
+              )
+          PY
 
   # ── std+ feature matrix ────────────────────────────────────────────────
   lgwks-std-feature-matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,10 +478,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "lgwks_bot"
+version = "0.1.0"
+dependencies = [
+ "lgwks_std",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lgwks_std"
 version = "0.3.0"
 dependencies = [
  "blake3",
+ "getrandom 0.2.17",
  "regex",
  "rkyv",
  "serde",

--- a/crates/lgwks-std/Cargo.toml
+++ b/crates/lgwks-std/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.3.0"
 edition = "2021"
 rust-version = "1.97"
 license = "MPL-2.0"
-repository = "https://github.com/logicalworks/lgwks-std"
+repository = "https://github.com/srinji-kaggss/Braid"
 categories = ["development-tools", "encoding", "asynchronous"]
 keywords = ["stdlib", "utilities", "zero-config", "async", "serialization"]
 

--- a/crates/lgwks-std/README.md
+++ b/crates/lgwks-std/README.md
@@ -53,7 +53,7 @@ Default feature set: `core` (enabled by default).
 | `core` | `hex` | Hex encode/decode | `hex` |
 | `core` | `id` | UUID v4 generation and parsing | `uuid` |
 | `core` | `leb128` | LEB128 variable-length integer encoding | — |
-| `core` | `random` | OS entropy (`/dev/urandom`) | `getrandom` |
+| `core` | `random` | OS entropy | `getrandom` |
 | `core` | `task` | Minimal single-threaded async executor | — |
 | `core` | `time` | RFC 3339 timestamps, calendar math | `chrono` / `time` |
 | `hash` | `hash` | BLAKE3 content-addressable hashing | `blake3` |
@@ -79,7 +79,7 @@ Legacy module ownership map:
 | `time` | RFC 3339 timestamps, calendar math |
 | `encoding::base64` | Base64 encode/decode (RFC 4648) |
 | `encoding::percent` | Percent-encoding for URI components |
-| `random` | OS entropy (`/dev/urandom`) |
+| `random` | OS entropy |
 | `leb128` | LEB128 variable-length integer encoding |
 | `fs` | Recursive directory walking with sandbox enforcement |
 | `task` | Minimal single-threaded async executor |
@@ -102,6 +102,12 @@ features:
 
 The gate test `deps_are_approved_leaves` in `lgwks-std-gate` mechanically
 verifies no unapproved dependency appears in the manifest.
+
+## Contract source-of-truth
+
+- `crates/lgwks-std/Cargo.toml` is authoritative for dependency declarations.
+- `contract/APPROVED.toml` is authoritative for approved versions.
+- `crates/lgwks-std-gate/src/lib.rs` is authoritative for enforcement behavior.
 
 ## The gate
 


### PR DESCRIPTION
## Summary
- Align `crates/lgwks-std/Cargo.toml` repository metadata to the canonical repo in this workspace.
- Remove stale entropy wording (`/dev/urandom`) and mark contract authority in docs.
- Add a CI drift check that asserts README dependency claims, manifest dependencies, and repository metadata stay in sync for `lgwks_std`.

Closes #43
