### PR TITLE
Migrate Braid to public lgwks_std dependency surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,6 @@ jobs:
         if: needs.scope.outputs.code_changed != 'yes'
         run: echo "scope docs-only — clippy skipped (explicit N/A)"
 
-%%%%%%% diff from: tssvtslw 1ad28dbb "Merge pull request #47 from srinji-kaggss/feat/lgwks-std-target-random" (parents of rebased revision)
-\\\\\\\        to: nquwoknt 3c867bb4 "Add lgwks-std MSRV + current-stable contracts (#48)" (rebase destination)
   lgwks-std-current-stable:
     name: lgwks-std current-stable Rust 1.98.0
     needs: [scope, stack-position]
@@ -262,6 +260,7 @@ jobs:
       - name: Check lgwks-std-gate at MSRV
         run: cargo check --manifest-path crates/lgwks-std-gate/Cargo.toml --all-targets
 
+
   lgwks-std-contract-drift:
     name: lgwks-std contract drift checks
     needs: [scope, stack-position]
@@ -310,6 +309,20 @@ jobs:
                   f"Unexpected package repository URL: {package['repository']}"
               )
           PY
+
+  lgwks-std-package-smoke:
+    name: lgwks-std package smoke-test
+    needs: [scope, stack-position]
+    runs-on: self-hosted
+    if: needs.scope.outputs.code_changed == 'yes'
+    env:
+      CARGO_TARGET_DIR: /Users/srinji/.braid-ci/targets/${{ github.run_id }}-std-package
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run package smoke test
+        run: ./scripts/lgwks-std-package-smoke.sh
 
   # ── std+ feature matrix ────────────────────────────────────────────────
   lgwks-std-feature-matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ resolver = "2"
 # `{ workspace = true }`.
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.dependencies]
+# Shared workspace crate pins.
+lgwks_std = { version = "0.3.0" }
 # Content-addressed hash chain (BLAKE3 CIDs under lw.braid.*).
 blake3 = { version = "1.8.5", default-features = false }
 
@@ -56,6 +58,11 @@ braid-render = { path = "crates/braid-render" }
 braid-sdk = { path = "crates/braid-sdk" }
 braid-manifest = { path = "crates/braid-manifest" }
 braid-runtime = { path = "crates/braid-runtime" }
+
+[patch.crates-io]
+# While developing against the in-repo implementation, keep the public contract
+# path (`lgwks_std = "0.3.0"`) while resolving to local source.
+lgwks_std = { path = "crates/lgwks-std" }
 
 [profile.release]
 opt-level = 3

--- a/crates/braid-governance/Cargo.toml
+++ b/crates/braid-governance/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Fail-closed generation-time enforcement of Keel ChangeEnvelopes"
 
 [dependencies]
-lgwks_std = { path = "../lgwks-std" }
+lgwks_std = { workspace = true }
 serde = { workspace = true }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/crates/braid-ir/Cargo.toml
+++ b/crates/braid-ir/Cargo.toml
@@ -14,7 +14,7 @@ blake3 = { workspace = true }
 braid-capability = { workspace = true }
 
 [dev-dependencies]
-lgwks_std = { path = "../lgwks-std" }
+lgwks_std = { workspace = true }
 proptest = { workspace = true }
 serde_json = { workspace = true }
 braid-vocab-cms = { workspace = true }

--- a/crates/braid-run/Cargo.toml
+++ b/crates/braid-run/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 braid-capability = { path = "../braid-capability" }
 braid-ir = { path = "../braid-ir" }
-lgwks_std = { path = "../lgwks-std" }
+lgwks_std = { workspace = true }
 
 [dev-dependencies]
 braid-verify = { path = "../braid-verify" }

--- a/crates/braid-verify/Cargo.toml
+++ b/crates/braid-verify/Cargo.toml
@@ -13,5 +13,5 @@ braid-ir = { workspace = true }
 braid-capability = { workspace = true }
 
 [dev-dependencies]
-lgwks_std = { path = "../lgwks-std" }
+lgwks_std = { workspace = true }
 braid-vocab-cms = { workspace = true }

--- a/crates/lgwks-bot/Cargo.toml
+++ b/crates/lgwks-bot/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 repository = "https://github.com/srinji-kaggss/afternow"
 
 [dependencies]
-lgwks_std = { path = "../lgwks-std" }
+lgwks_std = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/lgwks-std/Cargo.toml
+++ b/crates/lgwks-std/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 rust-version = "1.97"
 license = "MPL-2.0"
 repository = "https://github.com/srinji-kaggss/Braid"
+readme = "README.md"
+homepage = "https://github.com/srinji-kaggss/Braid/tree/main/crates/lgwks-std"
 categories = ["development-tools", "encoding", "asynchronous"]
 keywords = ["stdlib", "utilities", "zero-config", "async", "serialization"]
 

--- a/crates/lgwks-std/README.md
+++ b/crates/lgwks-std/README.md
@@ -109,6 +109,25 @@ verifies no unapproved dependency appears in the manifest.
 - `contract/APPROVED.toml` is authoritative for approved versions.
 - `crates/lgwks-std-gate/src/lib.rs` is authoritative for enforcement behavior.
 
+## Distribution lane
+
+`lgwks_std` is prepared as a normal Cargo package artifact:
+
+- distribution lane: **crates.io (public package) / manifest-only dependency**.
+- package entrypoint: `crates/lgwks-std/Cargo.toml`.
+- release check: `cargo package --manifest-path crates/lgwks-std/Cargo.toml`.
+
+### Smoke-test fixture
+
+Run the package smoke test from this repo root:
+
+```bash
+./scripts/lgwks-std-package-smoke.sh
+```
+
+The script packages the crate, unpacks the produced `.crate`, and consumes it as a
+standalone dependency from outside the Braid workspace dependency graph.
+
 ## The gate
 
 Three lines in a consumer's `build.rs` turn INV-DEP-REGISTERED into a compile

--- a/scripts/lgwks-std-package-smoke.sh
+++ b/scripts/lgwks-std-package-smoke.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Verify lgwks_std stays independently packageable and consumable as an artifact.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+(cd "$ROOT" && cargo package --manifest-path crates/lgwks-std/Cargo.toml --allow-dirty)
+
+PKG_FILE="$(find "$ROOT/target/package" -maxdepth 1 -name 'lgwks_std-*.crate' -print | sort | tail -n 1)"
+if [ -z "$PKG_FILE" ]; then
+  echo "missing package artifact" >&2
+  exit 1
+fi
+
+tar -xzf "$PKG_FILE" -C "$WORK"
+PACKAGE_DIR="$(find "$WORK" -maxdepth 1 -mindepth 1 -type d -name 'lgwks_std-*' -print | sort | head -n 1)"
+if [ -z "$PACKAGE_DIR" ]; then
+  echo "missing extracted package directory" >&2
+  exit 1
+fi
+PKG_BASENAME="${PACKAGE_DIR##*/}"
+
+SMOKE="$WORK/consumer-smoke"
+mkdir -p "$SMOKE/src"
+cat >"$SMOKE/Cargo.toml" <<EOF2
+[package]
+name = "lgwks-std-consumer-smoke"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+lgwks_std = { path = "../${PKG_BASENAME}" }
+EOF2
+
+cat >"$SMOKE/src/main.rs" <<'EOF3'
+fn main() {
+    let _ = lgwks_std::id::Uuid::new_v4().expect("randomness available");
+    let encoded = lgwks_std::hex::encode(&[1u8, 2, 3, 4]);
+    assert_eq!(encoded, "01020304");
+    println!("lgwks_std package smoke passed");
+}
+EOF3
+
+(cd "$SMOKE" && RUSTFLAGS='-D warnings' cargo run)


### PR DESCRIPTION
Closes #44.

This change switches Braid crates from workspace path dependencies on  to a package-level dependency () via  plus a local  for in-repo development.

Braid crates updated:
- crates/braid-governance
- crates/braid-ir
- crates/braid-verify
- crates/braid-run
- crates/lgwks-bot

This moves Braid toward consuming the same public interface that external consumers receive.
