### PR TITLE
Harden Braid's public lgwks_std consumption contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,6 @@ jobs:
         if: needs.scope.outputs.code_changed != 'yes'
         run: echo "scope docs-only — clippy skipped (explicit N/A)"
 
-%%%%%%% diff from: tssvtslw 1ad28dbb "Merge pull request #47 from srinji-kaggss/feat/lgwks-std-target-random" (parents of rebased revision)
-\\\\\\\        to: nquwoknt 3c867bb4 "Add lgwks-std MSRV + current-stable contracts (#48)" (rebase destination)
   lgwks-std-current-stable:
     name: lgwks-std current-stable Rust 1.98.0
     needs: [scope, stack-position]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,7 @@ jobs:
 
   lgwks-std-consumption-contract:
     name: lgwks-std public consumption contract
+    # Keep this job as an active regression gate for Braid consumption.
     needs: [scope, stack-position]
     runs-on: self-hosted
     if: needs.scope.outputs.code_changed == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,29 @@ jobs:
               )
           PY
 
+  lgwks-std-consumption-contract:
+    name: lgwks-std public consumption contract
+    needs: [scope, stack-position]
+    runs-on: self-hosted
+    if: needs.scope.outputs.code_changed == 'yes'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure no in-repo path fallback for lgwks_std consumers
+        run: |
+          set -eu
+          if rg 'lgwks_std\s*=\s*\{\s*path\s*=\s*"../lgwks-std"\s*\}' -g '*.toml' crates; then
+            echo "Contract breach: path-based lgwks_std dependency remains." >&2
+            exit 1
+          fi
+          if ! rg '^lgwks_std\s*=\s*\{\s*version\s*=\s*"0\.3\.0"\s*\}' -g '*.toml' Cargo.toml crates; then
+            echo "Contract breach: workspace lgwks_std dependency pin missing or malformed." >&2
+            exit 1
+          fi
+          if ! rg '^lgwks_std\s*=\s*\{\s*path\s*=\s*"crates/lgwks-std"\s*\}' -g '*.toml' Cargo.toml; then
+            echo "Contract breach: local patch for in-repo lgwks_std is missing or malformed." >&2
+            exit 1
+          fi
+
   # ── std+ feature matrix ────────────────────────────────────────────────
   lgwks-std-feature-matrix:
     name: lgwks-std feature matrix


### PR DESCRIPTION
This PR adds a CI guardrail to keep Braid consumption of `lgwks_std` on the public package contract.

What it adds:
- GH Actions check that no `lgwks_std` path dependency to `../lgwks-std` remains in crate manifests.
- Verifies workspace contract pin (`lgwks_std = { version = "0.3.0" }`) is present.
- Verifies local patch override points to `crates/lgwks-std`.

This hardens the already-completed migration path from #44.
