### PR TITLE
feat: encode root admission triad and compact token plan

### DIFF
--- a/.github/workflows/root-substrate.yml
+++ b/.github/workflows/root-substrate.yml
@@ -1,0 +1,87 @@
+# Compile the Braid trust root even while the full workspace is blocked by the
+# non-hermetic private sibling dependency tracked in #73.
+#
+# This is deliberately NOT named or presented as a full-workspace gate. The
+# checkout-local Cargo.toml edit is ephemeral and removes only
+# braid-governance, whose manifest otherwise requires ../../../secure-authority
+# before Cargo can even format unrelated crates.
+name: Braid Root Substrate
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/root-substrate.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/braid-capability/**"
+      - "crates/braid-ir/**"
+      - "crates/braid-flow-ir/**"
+      - "crates/braid-flow-verify/**"
+      - "crates/braid-verify/**"
+      - "crates/braid-sdk/**"
+      - "crates/braid-vocab-cms/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: root-substrate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_BUILD_JOBS: "4"
+
+jobs:
+  root-substrate:
+    name: Format, test, and lint trust root
+    runs-on: self-hosted
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Isolate the root from the known non-hermetic governance member
+        shell: python3 {0}
+        run: |
+          from pathlib import Path
+
+          manifest = Path("Cargo.toml")
+          source = manifest.read_text(encoding="utf-8")
+          member = '    "crates/braid-governance",\n'
+          if source.count(member) != 1:
+              raise SystemExit(
+                  "expected exactly one braid-governance workspace member; "
+                  "refusing an ambiguous CI rewrite"
+              )
+          manifest.write_text(source.replace(member, ""), encoding="utf-8")
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Compile and test the trust root
+        run: |
+          cargo test --locked \
+            -p braid-ir \
+            -p braid-flow-verify \
+            -p braid-verify \
+            -p braid-sdk \
+            --all-targets
+
+      - name: Run root documentation tests
+        run: |
+          cargo test --locked \
+            -p braid-ir \
+            -p braid-flow-verify \
+            -p braid-verify \
+            -p braid-sdk \
+            --doc
+
+      - name: Reject root warnings
+        run: |
+          cargo clippy --locked \
+            -p braid-ir \
+            -p braid-flow-verify \
+            -p braid-verify \
+            -p braid-sdk \
+            --all-targets -- -D warnings

--- a/.github/workflows/root-substrate.yml
+++ b/.github/workflows/root-substrate.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Compile and test the trust root
         run: |
-          cargo test --locked \
+          cargo test \
             -p braid-ir \
             -p braid-flow-verify \
             -p braid-verify \
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run root documentation tests
         run: |
-          cargo test --locked \
+          cargo test \
             -p braid-ir \
             -p braid-flow-verify \
             -p braid-verify \
@@ -79,7 +79,7 @@ jobs:
 
       - name: Reject root warnings
         run: |
-          cargo clippy --locked \
+          cargo clippy \
             -p braid-ir \
             -p braid-flow-verify \
             -p braid-verify \

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@
 design. Programs are content-addressed graphs of typed terms drawn from a closed
 capability vocabulary. A deterministic compiler/verifier owns the correctness and
 confinement-safety floor — types, effects, capability attenuation, taint, bounds.
-Humans own the architecture and intent above that floor.
+Invocation reduces through one fail-closed root triad: **Safety × Capability ×
+Justification**. Humans own the architecture and intent above that floor.
 
 AI and humans never share a representation. They meet at a shared verified
 **anchor** through separate projections — the AI sees an IR it can produce
-reliably; the human sees a rendered manifest they can audit.
+reliably; the human sees a rendered manifest they can audit. After independent
+admission, Braid may derive a registry-CID-scoped dense token plan for the hot
+path; that plan is a cache, never a second wire or an authority credential.
 
 ## Published crates
 
@@ -21,11 +24,11 @@ reliably; the human sees a rendered manifest they can audit.
 
 | Path | What |
 |------|------|
-| `crates/braid-ir` | Typed term-graph IR, canonical CBOR-subset encoding, BLAKE3 CIDs, bijection guard, capsule artifacts. |
+| `crates/braid-ir` | Typed term-graph IR, canonical encoding, BLAKE3 CIDs, one-byte admission triad, and registry-scoped compact token projection. |
 | `crates/braid-flow-ir` | Canonical inter-capsule Flow IR, strict byte bijection, bounded identity, and justified-invocation declarations. |
-| `crates/braid-flow-verify` | Independent strict decoder + fail-closed admission for Flow graphs. |
+| `crates/braid-flow-verify` | Independent strict decoder + compact iterative fail-closed admission for Flow graphs. |
 | `crates/braid-capability` | Capability token newtype — content-addressed dotted names. Vocabulary-agnostic attenuation. |
-| `crates/braid-verify` | Independent strict decoder + fail-closed admission pipeline. Registry-parametric. |
+| `crates/braid-verify` | Independent strict decoder + fail-closed admission pipeline; emits a CID-bound `P × P × U` compact projection. |
 | `crates/braid-render` | CID-bound manifest, deterministic text rendering, widening/narrowing diff, DOT export. |
 | `crates/braid-sdk` | Typed authoring builder over `braid-ir`. |
 | `crates/braid-cli` | The `braid` binary: encode, decode, verify, render, diff, catalog, store. |

--- a/crates/braid-flow-verify/src/verify.rs
+++ b/crates/braid-flow-verify/src/verify.rs
@@ -166,8 +166,8 @@ struct CompactGraph {
 
 impl CompactGraph {
     fn build(flow: &FlowSpec) -> VerifyResult<Self> {
-        let node_count = u32::try_from(flow.nodes().len())
-            .map_err(|_| arithmetic_overflow("node count"))?;
+        let node_count =
+            u32::try_from(flow.nodes().len()).map_err(|_| arithmetic_overflow("node count"))?;
         let mut edges = collect_edges(flow)?;
         let forward = Csr::from_sorted(flow.nodes().len(), &edges)?;
 
@@ -266,11 +266,7 @@ fn check_reachability(flow: &FlowSpec, graph: &CompactGraph) -> VerifyResult<()>
     // zero-indegree node; the synthetic start connects exactly those roots.
     // The non-trivial half is proving that every node can reach a declared
     // terminal.
-    let to_terminal = mark_reachable(
-        &graph.reverse,
-        graph.node_count,
-        &terminal_nodes(flow)?,
-    );
+    let to_terminal = mark_reachable(&graph.reverse, graph.node_count, &terminal_nodes(flow)?);
 
     if to_terminal.iter().all(|reached| *reached) {
         Ok(())
@@ -311,8 +307,7 @@ fn check_choice(flow: &FlowSpec) -> VerifyResult<()> {
 fn check_join(flow: &FlowSpec, graph: &CompactGraph) -> VerifyResult<()> {
     for (index, node) in flow.nodes().iter().enumerate() {
         if matches!(node.kind, FlowNodeKind::JoinAll) {
-            let node_id =
-                u32::try_from(index).map_err(|_| arithmetic_overflow("join index"))?;
+            let node_id = u32::try_from(index).map_err(|_| arithmetic_overflow("join index"))?;
             if graph.reverse.neighbors(node_id).is_empty() {
                 return Err(FlowVerifyError::JoinCardinality {
                     invariant: "INV-FLOW-013",
@@ -338,9 +333,7 @@ fn check_terminals(flow: &FlowSpec) -> VerifyResult<()> {
 
 fn check_justification(flow: &FlowSpec) -> VerifyResult<()> {
     for node in flow.nodes() {
-        if matches!(node.kind, FlowNodeKind::InvokeCapsule { .. })
-            && node.justification.is_none()
-        {
+        if matches!(node.kind, FlowNodeKind::InvokeCapsule { .. }) && node.justification.is_none() {
             return Err(FlowVerifyError::JustificationIncomplete {
                 field: "justification",
                 invariant: "INV-FLOW-006",

--- a/crates/braid-flow-verify/src/verify.rs
+++ b/crates/braid-flow-verify/src/verify.rs
@@ -1,11 +1,16 @@
 //! Fail-closed admission stages.
+
 use crate::decode::decode_flow_verify;
 use crate::error::{FlowVerifyError, VerifyResult};
-use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::ToString;
+use alloc::vec;
 use alloc::vec::Vec;
-use braid_flow_ir::{FlowNodeKind, FlowSpec};
+use braid_flow_ir::{FlowEdge, FlowNodeKind, FlowSpec, ValueSource};
 
+type NodeId = u32;
+type Edge = (NodeId, NodeId);
+
+/// Independently admitted Flow plus its exact content identity.
 pub struct AdmittedFlow {
     pub flow: FlowSpec,
     pub flow_cid: braid_ir::Cid,
@@ -13,153 +18,286 @@ pub struct AdmittedFlow {
 
 pub fn verify(bytes: &[u8]) -> VerifyResult<AdmittedFlow> {
     let flow = decode_flow_verify(bytes)?;
-    check_acyclic(&flow)?;
-    check_reachability(&flow)?;
+    let graph = CompactGraph::build(&flow)?;
+    check_acyclic(&graph)?;
+    check_reachability(&flow, &graph)?;
     check_choice(&flow)?;
-    check_join(&flow)?;
+    check_join(&flow, &graph)?;
     check_terminals(&flow)?;
     check_justification(&flow)?;
     let flow_cid = braid_ir::Cid::compute(braid_flow_ir::FLOW_DOMAIN, bytes);
     Ok(AdmittedFlow { flow, flow_cid })
 }
 
-fn check_acyclic(flow: &FlowSpec) -> VerifyResult<()> {
-    let n = flow.nodes().len();
-    let idx: BTreeMap<String, usize> = flow
-        .nodes()
-        .iter()
-        .enumerate()
-        .map(|(i, nd)| (nd.key.to_string(), i))
-        .collect();
-    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
-    for e in flow.edges() {
-        match e {
-            braid_flow_ir::FlowEdge::After { from, to, .. } => {
-                if let (Some(&u), Some(&v)) = (idx.get(&from.to_string()), idx.get(&to.to_string()))
-                {
-                    adj[u].push(v);
-                }
-            }
-            braid_flow_ir::FlowEdge::Data { from, to, .. } => {
-                let src = match from {
-                    braid_flow_ir::ValueSource::Node(o) => o.node.to_string(),
-                    _ => continue,
-                };
-                let dst = to.node.to_string();
-                if let (Some(&u), Some(&v)) = (idx.get(&src), idx.get(&dst)) {
-                    adj[u].push(v);
-                }
-            }
-        }
+fn arithmetic_overflow(field: &'static str) -> FlowVerifyError {
+    FlowVerifyError::ArithmeticOverflow {
+        field,
+        invariant: "INV-FLOW-004",
     }
-    let mut state = vec![0u8; n];
-    fn dfs(u: usize, adj: &[Vec<usize>], state: &mut [u8]) -> bool {
-        state[u] = 1;
-        for &v in &adj[u] {
-            if state[v] == 1 {
-                return true;
-            }
-            if state[v] == 0 && dfs(v, adj, state) {
-                return true;
-            }
-        }
-        state[u] = 2;
-        false
-    }
-    for i in 0..n {
-        if state[i] == 0 && dfs(i, &adj, &mut state) {
-            return Err(FlowVerifyError::Cycle {
-                invariant: "INV-FLOW-003",
-            });
-        }
-    }
-    Ok(())
 }
-fn check_reachability(flow: &FlowSpec) -> VerifyResult<()> {
-    // Every node must be on some path from synthetic start (roots/data predecessors) to a terminal.
-    // Minimal v0: every node has at least one incoming or is referenced; and every node can reach a terminal via after/data edges.
-    let idx: BTreeMap<String, usize> = flow
+
+fn resolve_node(flow: &FlowSpec, key: &str, field: &'static str) -> VerifyResult<NodeId> {
+    let index = flow
         .nodes()
-        .iter()
-        .enumerate()
-        .map(|(i, nd)| (nd.key.to_string(), i))
-        .collect();
-    let n = flow.nodes().len();
-    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
-    let mut rev: Vec<Vec<usize>> = vec![Vec::new(); n];
-    for e in flow.edges() {
-        let (s, d) = match e {
-            braid_flow_ir::FlowEdge::After { from, to, .. } => (from.to_string(), to.to_string()),
-            braid_flow_ir::FlowEdge::Data { from, to, .. } => {
-                let s = match from {
-                    braid_flow_ir::ValueSource::Node(o) => o.node.to_string(),
-                    _ => continue,
-                };
-                (s, to.node.to_string())
-            }
+        .binary_search_by(|node| node.key.as_str().cmp(key))
+        .map_err(|_| FlowVerifyError::Unresolved {
+            field,
+            key: key.to_string(),
+            invariant: "INV-FLOW-002",
+        })?;
+    u32::try_from(index).map_err(|_| arithmetic_overflow("node index"))
+}
+
+fn choice_edge_count(flow: &FlowSpec) -> VerifyResult<usize> {
+    flow.nodes().iter().try_fold(0usize, |count, node| {
+        let added = match &node.kind {
+            FlowNodeKind::Choice { arms, .. } => arms
+                .len()
+                .checked_add(1)
+                .ok_or_else(|| arithmetic_overflow("choice edge count"))?,
+            _ => 0,
         };
-        if let (Some(&u), Some(&v)) = (idx.get(&s), idx.get(&d)) {
-            adj[u].push(v);
-            rev[v].push(u);
-        }
-    }
-    // Include Choice arms as edges for reachability
-    for (i, nd) in flow.nodes().iter().enumerate() {
-        if let FlowNodeKind::Choice { arms, otherwise } = &nd.kind {
-            for a in arms {
-                if let Some(&v) = idx.get(&a.then.to_string()) {
-                    adj[i].push(v);
-                    rev[v].push(i);
+        count
+            .checked_add(added)
+            .ok_or_else(|| arithmetic_overflow("choice edge count"))
+    })
+}
+
+fn collect_edges(flow: &FlowSpec) -> VerifyResult<Vec<Edge>> {
+    let capacity = flow
+        .edges()
+        .len()
+        .checked_add(choice_edge_count(flow)?)
+        .ok_or_else(|| arithmetic_overflow("graph edge capacity"))?;
+    let mut edges = Vec::with_capacity(capacity);
+
+    for edge in flow.edges() {
+        match edge {
+            FlowEdge::After { from, to, .. } => {
+                edges.push((
+                    resolve_node(flow, from.as_str(), "after.from")?,
+                    resolve_node(flow, to.as_str(), "after.to")?,
+                ));
+            }
+            FlowEdge::Data { from, to, .. } => {
+                let destination = resolve_node(flow, to.node.as_str(), "data.to")?;
+                match from {
+                    ValueSource::Node(output) => edges.push((
+                        resolve_node(flow, output.node.as_str(), "data.from")?,
+                        destination,
+                    )),
+                    ValueSource::Root(_) | ValueSource::Literal(_) => {}
                 }
             }
-            if let Some(&v) = idx.get(&otherwise.to_string()) {
-                adj[i].push(v);
-                rev[v].push(i);
+        }
+    }
+
+    for (source_index, node) in flow.nodes().iter().enumerate() {
+        let source =
+            u32::try_from(source_index).map_err(|_| arithmetic_overflow("choice source"))?;
+        if let FlowNodeKind::Choice { arms, otherwise } = &node.kind {
+            for arm in arms {
+                edges.push((
+                    source,
+                    resolve_node(flow, arm.then.as_str(), "choice.then")?,
+                ));
             }
+            edges.push((
+                source,
+                resolve_node(flow, otherwise.as_str(), "choice.otherwise")?,
+            ));
         }
     }
-    // Can-reach-terminal (reverse BFS from terminals)
-    let mut can_reach_term = vec![false; n];
-    let mut q: Vec<usize> = flow
-        .terminals()
-        .iter()
-        .filter_map(|k| idx.get(&k.to_string()).copied())
-        .collect();
-    for &t in &q {
-        can_reach_term[t] = true;
-    }
-    let mut qi = 0;
-    while qi < q.len() {
-        let u = q[qi];
-        qi += 1;
-        for &p in &rev[u] {
-            if !can_reach_term[p] {
-                can_reach_term[p] = true;
-                q.push(p);
-            }
-        }
-    }
-    for can in &can_reach_term {
-        if !*can {
-            return Err(FlowVerifyError::TerminalSoundness {
-                invariant: "INV-FLOW-014",
-            });
-        }
-    }
-    Ok(())
+
+    edges.sort_unstable();
+    edges.dedup();
+    Ok(edges)
 }
+
+/// Compressed-sparse-row adjacency using u32 node IDs and offsets.
+///
+/// Flow's hard bounds are far below u32 limits. This avoids one heap
+/// allocation per node (`Vec<Vec<usize>>`) and halves edge storage relative to
+/// host-sized `usize` pairs on 64-bit machines.
+struct Csr {
+    offsets: Vec<u32>,
+    targets: Vec<NodeId>,
+}
+
+impl Csr {
+    fn from_sorted(node_count: usize, edges: &[Edge]) -> VerifyResult<Self> {
+        let offset_count = node_count
+            .checked_add(1)
+            .ok_or_else(|| arithmetic_overflow("csr offsets"))?;
+        let mut offsets = vec![0u32; offset_count];
+
+        for &(source, _) in edges {
+            let slot = offsets
+                .get_mut(source as usize + 1)
+                .ok_or_else(|| arithmetic_overflow("csr source"))?;
+            *slot = slot
+                .checked_add(1)
+                .ok_or_else(|| arithmetic_overflow("csr degree"))?;
+        }
+
+        for index in 1..offsets.len() {
+            offsets[index] = offsets[index]
+                .checked_add(offsets[index - 1])
+                .ok_or_else(|| arithmetic_overflow("csr prefix sum"))?;
+        }
+
+        let targets = edges.iter().map(|&(_, target)| target).collect();
+        Ok(Self { offsets, targets })
+    }
+
+    fn neighbors(&self, node: NodeId) -> &[NodeId] {
+        let index = node as usize;
+        let start = self.offsets[index] as usize;
+        let end = self.offsets[index + 1] as usize;
+        &self.targets[start..end]
+    }
+}
+
+struct CompactGraph {
+    node_count: NodeId,
+    forward: Csr,
+    reverse: Csr,
+}
+
+impl CompactGraph {
+    fn build(flow: &FlowSpec) -> VerifyResult<Self> {
+        let node_count = u32::try_from(flow.nodes().len())
+            .map_err(|_| arithmetic_overflow("node count"))?;
+        let mut edges = collect_edges(flow)?;
+        let forward = Csr::from_sorted(flow.nodes().len(), &edges)?;
+
+        // Reuse the same edge arena to build the reverse CSR. This keeps peak
+        // memory to one pair arena plus the two compact target arrays.
+        for edge in &mut edges {
+            *edge = (edge.1, edge.0);
+        }
+        edges.sort_unstable();
+        edges.dedup();
+        let reverse = Csr::from_sorted(flow.nodes().len(), &edges)?;
+
+        Ok(Self {
+            node_count,
+            forward,
+            reverse,
+        })
+    }
+}
+
+fn initial_indegree(graph: &CompactGraph) -> VerifyResult<Vec<u32>> {
+    (0..graph.node_count)
+        .map(|node| {
+            u32::try_from(graph.reverse.neighbors(node).len())
+                .map_err(|_| arithmetic_overflow("node indegree"))
+        })
+        .collect()
+}
+
+fn check_acyclic(graph: &CompactGraph) -> VerifyResult<()> {
+    let mut indegree = initial_indegree(graph)?;
+    let mut queue = Vec::with_capacity(graph.node_count as usize);
+    for node in 0..graph.node_count {
+        if indegree[node as usize] == 0 {
+            queue.push(node);
+        }
+    }
+
+    let mut cursor = 0usize;
+    while cursor < queue.len() {
+        let node = queue[cursor];
+        cursor += 1;
+        for &target in graph.forward.neighbors(node) {
+            let degree = &mut indegree[target as usize];
+            *degree = degree
+                .checked_sub(1)
+                .ok_or_else(|| arithmetic_overflow("kahn indegree"))?;
+            if *degree == 0 {
+                queue.push(target);
+            }
+        }
+    }
+
+    if queue.len() == graph.node_count as usize {
+        Ok(())
+    } else {
+        Err(FlowVerifyError::Cycle {
+            invariant: "INV-FLOW-003",
+        })
+    }
+}
+
+fn mark_reachable(adjacency: &Csr, node_count: NodeId, seeds: &[NodeId]) -> Vec<bool> {
+    let mut reached = vec![false; node_count as usize];
+    let mut queue = Vec::with_capacity(node_count as usize);
+    for &seed in seeds {
+        if !reached[seed as usize] {
+            reached[seed as usize] = true;
+            queue.push(seed);
+        }
+    }
+
+    let mut cursor = 0usize;
+    while cursor < queue.len() {
+        let node = queue[cursor];
+        cursor += 1;
+        for &target in adjacency.neighbors(node) {
+            if !reached[target as usize] {
+                reached[target as usize] = true;
+                queue.push(target);
+            }
+        }
+    }
+    reached
+}
+
+fn terminal_nodes(flow: &FlowSpec) -> VerifyResult<Vec<NodeId>> {
+    flow.terminals()
+        .iter()
+        .map(|terminal| resolve_node(flow, terminal.as_str(), "terminal"))
+        .collect()
+}
+
+fn check_reachability(flow: &FlowSpec, graph: &CompactGraph) -> VerifyResult<()> {
+    // After acyclicity is proven, every node is reachable from at least one
+    // zero-indegree node; the synthetic start connects exactly those roots.
+    // The non-trivial half is proving that every node can reach a declared
+    // terminal.
+    let to_terminal = mark_reachable(
+        &graph.reverse,
+        graph.node_count,
+        &terminal_nodes(flow)?,
+    );
+
+    if to_terminal.iter().all(|reached| *reached) {
+        Ok(())
+    } else {
+        Err(FlowVerifyError::TerminalSoundness {
+            invariant: "INV-FLOW-014",
+        })
+    }
+}
+
 fn check_choice(flow: &FlowSpec) -> VerifyResult<()> {
-    for nd in flow.nodes() {
-        if let FlowNodeKind::Choice { arms, otherwise: _ } = &nd.kind {
+    for node in flow.nodes() {
+        if let FlowNodeKind::Choice { arms, .. } = &node.kind {
             if arms.is_empty() {
                 return Err(FlowVerifyError::ChoiceNotTotal {
                     invariant: "INV-FLOW-011",
                 });
             }
-            // Bounded disjointness: syntactic check — distinct `then` targets.
-            let mut seen = BTreeSet::new();
-            for a in arms {
-                if !seen.insert(a.then.to_string()) {
+
+            // v0 can cheaply reject aliased targets without allocating a set.
+            // This is only a shape check; it does NOT prove predicate
+            // disjointness. That semantic proof remains a loud P2 blocker.
+            for (index, arm) in arms.iter().enumerate() {
+                if arms[..index]
+                    .iter()
+                    .any(|prior| prior.then.as_str() == arm.then.as_str())
+                {
                     return Err(FlowVerifyError::ChoiceNotDisjoint {
                         invariant: "INV-FLOW-011",
                     });
@@ -169,22 +307,13 @@ fn check_choice(flow: &FlowSpec) -> VerifyResult<()> {
     }
     Ok(())
 }
-fn check_join(flow: &FlowSpec) -> VerifyResult<()> {
-    for nd in flow.nodes() {
-        if matches!(nd.kind, FlowNodeKind::JoinAll) {
-            let preds = flow
-                .edges()
-                .iter()
-                .filter(|e| match e {
-                    braid_flow_ir::FlowEdge::After { to, .. } => {
-                        to.to_string() == nd.key.to_string()
-                    }
-                    braid_flow_ir::FlowEdge::Data { to, .. } => {
-                        to.node.to_string() == nd.key.to_string()
-                    }
-                })
-                .count();
-            if preds == 0 {
+
+fn check_join(flow: &FlowSpec, graph: &CompactGraph) -> VerifyResult<()> {
+    for (index, node) in flow.nodes().iter().enumerate() {
+        if matches!(node.kind, FlowNodeKind::JoinAll) {
+            let node_id =
+                u32::try_from(index).map_err(|_| arithmetic_overflow("join index"))?;
+            if graph.reverse.neighbors(node_id).is_empty() {
                 return Err(FlowVerifyError::JoinCardinality {
                     invariant: "INV-FLOW-013",
                 });
@@ -193,28 +322,25 @@ fn check_join(flow: &FlowSpec) -> VerifyResult<()> {
     }
     Ok(())
 }
+
 fn check_terminals(flow: &FlowSpec) -> VerifyResult<()> {
-    let keys: BTreeSet<String> = flow.nodes().iter().map(|n| n.key.to_string()).collect();
-    for t in flow.terminals() {
-        if !keys.contains(&t.to_string()) {
-            return Err(FlowVerifyError::Unresolved {
-                field: "terminal",
-                key: t.to_string(),
-                invariant: "INV-FLOW-014",
-            });
-        }
-    }
     if flow.terminals().is_empty() {
         return Err(FlowVerifyError::EmptyCollection {
             field: "terminals",
             invariant: "INV-FLOW-014",
         });
     }
+    for terminal in flow.terminals() {
+        resolve_node(flow, terminal.as_str(), "terminal")?;
+    }
     Ok(())
 }
+
 fn check_justification(flow: &FlowSpec) -> VerifyResult<()> {
-    for nd in flow.nodes() {
-        if matches!(nd.kind, FlowNodeKind::InvokeCapsule { .. }) && nd.justification.is_none() {
+    for node in flow.nodes() {
+        if matches!(node.kind, FlowNodeKind::InvokeCapsule { .. })
+            && node.justification.is_none()
+        {
             return Err(FlowVerifyError::JustificationIncomplete {
                 field: "justification",
                 invariant: "INV-FLOW-006",

--- a/crates/braid-ir/src/admission.rs
+++ b/crates/braid-ir/src/admission.rs
@@ -282,16 +282,10 @@ mod tests {
             for &capability in &STATES {
                 for &justification in &STATES {
                     let triad = AdmissionTriad::new(safety, capability, justification);
-                    assert_eq!(
-                        AdmissionTriad::from_packed(triad.packed()).unwrap(),
-                        triad
-                    );
+                    assert_eq!(AdmissionTriad::from_packed(triad.packed()).unwrap(), triad);
                     assert_eq!(triad.state(AdmissionAxis::Safety), safety);
                     assert_eq!(triad.state(AdmissionAxis::Capability), capability);
-                    assert_eq!(
-                        triad.state(AdmissionAxis::Justification),
-                        justification
-                    );
+                    assert_eq!(triad.state(AdmissionAxis::Justification), justification);
                 }
             }
         }
@@ -331,11 +325,8 @@ mod tests {
 
     #[test]
     fn meet_is_conservative() {
-        let proven = AdmissionTriad::new(
-            ProofState::Proven,
-            ProofState::Proven,
-            ProofState::Proven,
-        );
+        let proven =
+            AdmissionTriad::new(ProofState::Proven, ProofState::Proven, ProofState::Proven);
         let partial = AdmissionTriad::new(
             ProofState::Proven,
             ProofState::Unknown,

--- a/crates/braid-ir/src/admission.rs
+++ b/crates/braid-ir/src/admission.rs
@@ -1,0 +1,346 @@
+//! Compact, deterministic invocation admission algebra.
+//!
+//! Braid's root admission question is three-dimensional:
+//!
+//! - **Safety** — is the computation structurally and semantically admitted?
+//! - **Capability** — is the caller authorized by the external authority boundary?
+//! - **Justification** — is there a snapshot-bound reason to run now?
+//!
+//! These are not author-controlled booleans. A verifier, authority adapter, or
+//! planner produces evidence and projects its result into [`ProofState`].
+//! [`AdmissionTriad`] only composes those results. It cannot create evidence,
+//! mint authority, or turn an unknown proof into success.
+//!
+//! The packed representation is deliberately one byte. Zero means
+//! `Unknown × Unknown × Unknown`, so zero-initialization fails closed by
+//! deferring rather than executing.
+
+/// Result of checking one admission axis.
+///
+/// The declaration order is the conservative lattice order:
+/// `Disproven < Unknown < Proven`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ProofState {
+    /// A counterexample or failed obligation exists.
+    Disproven,
+    /// The obligation was not established under the declared proof envelope.
+    Unknown,
+    /// The obligation was established by the owning verifier.
+    Proven,
+}
+
+impl ProofState {
+    /// Conservative conjunction. Only two proven inputs remain proven.
+    pub const fn meet(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Disproven, _) | (_, Self::Disproven) => Self::Disproven,
+            (Self::Unknown, _) | (_, Self::Unknown) => Self::Unknown,
+            (Self::Proven, Self::Proven) => Self::Proven,
+        }
+    }
+}
+
+/// One coordinate of Braid's admission triad.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AdmissionAxis {
+    /// Structural, type, effect, taint, and resource safety.
+    Safety,
+    /// Externally supplied capability/authority.
+    Capability,
+    /// Snapshot-bound need and purpose.
+    Justification,
+}
+
+/// Deterministic reduction of the complete triad.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvocationDecision {
+    /// At least one required obligation was disproven.
+    Reject {
+        /// First disproven axis in stable triad order.
+        axis: AdmissionAxis,
+    },
+    /// Nothing was disproven, but at least one obligation is unknown.
+    Defer {
+        /// First unknown axis in stable triad order.
+        axis: AdmissionAxis,
+    },
+    /// Every axis is proven; execution may be considered by the runtime.
+    Execute,
+}
+
+/// Invalid compact admission representation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionEncodingError {
+    /// Bits outside the three two-bit coordinates were set.
+    ReservedHighBits {
+        /// Rejected packed byte.
+        packed: u8,
+    },
+    /// A coordinate used the reserved `0b11` state.
+    ReservedState {
+        /// Coordinate containing the reserved state.
+        axis: AdmissionAxis,
+    },
+}
+
+impl core::fmt::Display for AdmissionEncodingError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ReservedHighBits { packed } => {
+                write!(f, "admission byte {packed:#010b} sets reserved high bits")
+            }
+            Self::ReservedState { axis } => {
+                write!(f, "admission axis {axis:?} uses reserved state 0b11")
+            }
+        }
+    }
+}
+
+impl core::error::Error for AdmissionEncodingError {}
+
+const STATE_MASK: u8 = 0b11;
+const SAFETY_SHIFT: u8 = 0;
+const CAPABILITY_SHIFT: u8 = 2;
+const JUSTIFICATION_SHIFT: u8 = 4;
+const RESERVED_HIGH_BITS: u8 = 0b1100_0000;
+
+const fn encode_state(state: ProofState) -> u8 {
+    match state {
+        ProofState::Unknown => 0b00,
+        ProofState::Proven => 0b01,
+        ProofState::Disproven => 0b10,
+    }
+}
+
+const fn decode_known_state(bits: u8) -> ProofState {
+    match bits {
+        0b01 => ProofState::Proven,
+        0b10 => ProofState::Disproven,
+        _ => ProofState::Unknown,
+    }
+}
+
+const fn axis_shift(axis: AdmissionAxis) -> u8 {
+    match axis {
+        AdmissionAxis::Safety => SAFETY_SHIFT,
+        AdmissionAxis::Capability => CAPABILITY_SHIFT,
+        AdmissionAxis::Justification => JUSTIFICATION_SHIFT,
+    }
+}
+
+/// One-byte projection of Safety × Capability × Justification.
+///
+/// This type is a compact *result carrier*, not a proof token. It is not part
+/// of the canonical capsule wire and must never be accepted as authority merely
+/// because its bits say [`ProofState::Proven`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct AdmissionTriad(u8);
+
+impl AdmissionTriad {
+    /// Construct a triad from independently established axis states.
+    pub const fn new(
+        safety: ProofState,
+        capability: ProofState,
+        justification: ProofState,
+    ) -> Self {
+        Self(
+            (encode_state(safety) << SAFETY_SHIFT)
+                | (encode_state(capability) << CAPABILITY_SHIFT)
+                | (encode_state(justification) << JUSTIFICATION_SHIFT),
+        )
+    }
+
+    /// Decode a packed byte, refusing reserved states and future-version bits.
+    pub fn from_packed(packed: u8) -> Result<Self, AdmissionEncodingError> {
+        if packed & RESERVED_HIGH_BITS != 0 {
+            return Err(AdmissionEncodingError::ReservedHighBits { packed });
+        }
+        for axis in [
+            AdmissionAxis::Safety,
+            AdmissionAxis::Capability,
+            AdmissionAxis::Justification,
+        ] {
+            let bits = (packed >> axis_shift(axis)) & STATE_MASK;
+            if bits == STATE_MASK {
+                return Err(AdmissionEncodingError::ReservedState { axis });
+            }
+        }
+        Ok(Self(packed))
+    }
+
+    /// Return the compact byte.
+    pub const fn packed(self) -> u8 {
+        self.0
+    }
+
+    /// Read one axis.
+    pub const fn state(self, axis: AdmissionAxis) -> ProofState {
+        decode_known_state((self.0 >> axis_shift(axis)) & STATE_MASK)
+    }
+
+    /// Return a copy with one coordinate replaced.
+    ///
+    /// This is composition machinery only; callers still need evidence from
+    /// the subsystem that owns the axis.
+    pub const fn with_state(self, axis: AdmissionAxis, state: ProofState) -> Self {
+        let shift = axis_shift(axis);
+        let cleared = self.0 & !(STATE_MASK << shift);
+        Self(cleared | (encode_state(state) << shift))
+    }
+
+    /// Pointwise conservative composition.
+    pub const fn meet(self, other: Self) -> Self {
+        Self::new(
+            self.state(AdmissionAxis::Safety)
+                .meet(other.state(AdmissionAxis::Safety)),
+            self.state(AdmissionAxis::Capability)
+                .meet(other.state(AdmissionAxis::Capability)),
+            self.state(AdmissionAxis::Justification)
+                .meet(other.state(AdmissionAxis::Justification)),
+        )
+    }
+
+    /// Reduce the triad with fail-closed precedence:
+    /// disproven → reject, unknown → defer, all proven → execute.
+    pub const fn decision(self) -> InvocationDecision {
+        let safety = self.state(AdmissionAxis::Safety);
+        let capability = self.state(AdmissionAxis::Capability);
+        let justification = self.state(AdmissionAxis::Justification);
+
+        if matches!(safety, ProofState::Disproven) {
+            InvocationDecision::Reject {
+                axis: AdmissionAxis::Safety,
+            }
+        } else if matches!(capability, ProofState::Disproven) {
+            InvocationDecision::Reject {
+                axis: AdmissionAxis::Capability,
+            }
+        } else if matches!(justification, ProofState::Disproven) {
+            InvocationDecision::Reject {
+                axis: AdmissionAxis::Justification,
+            }
+        } else if matches!(safety, ProofState::Unknown) {
+            InvocationDecision::Defer {
+                axis: AdmissionAxis::Safety,
+            }
+        } else if matches!(capability, ProofState::Unknown) {
+            InvocationDecision::Defer {
+                axis: AdmissionAxis::Capability,
+            }
+        } else if matches!(justification, ProofState::Unknown) {
+            InvocationDecision::Defer {
+                axis: AdmissionAxis::Justification,
+            }
+        } else {
+            InvocationDecision::Execute
+        }
+    }
+}
+
+impl Default for AdmissionTriad {
+    fn default() -> Self {
+        Self::new(
+            ProofState::Unknown,
+            ProofState::Unknown,
+            ProofState::Unknown,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    const STATES: [ProofState; 3] = [
+        ProofState::Disproven,
+        ProofState::Unknown,
+        ProofState::Proven,
+    ];
+
+    #[test]
+    fn triad_is_exactly_one_byte() {
+        assert_eq!(size_of::<AdmissionTriad>(), 1);
+    }
+
+    #[test]
+    fn zero_is_fail_closed_unknown() {
+        let triad = AdmissionTriad::from_packed(0).unwrap();
+        assert_eq!(triad, AdmissionTriad::default());
+        assert_eq!(
+            triad.decision(),
+            InvocationDecision::Defer {
+                axis: AdmissionAxis::Safety
+            }
+        );
+    }
+
+    #[test]
+    fn all_twenty_seven_states_round_trip() {
+        for &safety in &STATES {
+            for &capability in &STATES {
+                for &justification in &STATES {
+                    let triad = AdmissionTriad::new(safety, capability, justification);
+                    assert_eq!(
+                        AdmissionTriad::from_packed(triad.packed()).unwrap(),
+                        triad
+                    );
+                    assert_eq!(triad.state(AdmissionAxis::Safety), safety);
+                    assert_eq!(triad.state(AdmissionAxis::Capability), capability);
+                    assert_eq!(
+                        triad.state(AdmissionAxis::Justification),
+                        justification
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn decision_never_executes_with_unknown_or_disproven_axis() {
+        for &safety in &STATES {
+            for &capability in &STATES {
+                for &justification in &STATES {
+                    let triad = AdmissionTriad::new(safety, capability, justification);
+                    let all_proven = safety == ProofState::Proven
+                        && capability == ProofState::Proven
+                        && justification == ProofState::Proven;
+                    assert_eq!(
+                        matches!(triad.decision(), InvocationDecision::Execute),
+                        all_proven
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn reserved_bits_are_rejected() {
+        assert!(matches!(
+            AdmissionTriad::from_packed(0b0000_0011),
+            Err(AdmissionEncodingError::ReservedState {
+                axis: AdmissionAxis::Safety
+            })
+        ));
+        assert!(matches!(
+            AdmissionTriad::from_packed(0b1000_0000),
+            Err(AdmissionEncodingError::ReservedHighBits { .. })
+        ));
+    }
+
+    #[test]
+    fn meet_is_conservative() {
+        let proven = AdmissionTriad::new(
+            ProofState::Proven,
+            ProofState::Proven,
+            ProofState::Proven,
+        );
+        let partial = AdmissionTriad::new(
+            ProofState::Proven,
+            ProofState::Unknown,
+            ProofState::Disproven,
+        );
+        assert_eq!(proven.meet(partial), partial);
+    }
+}

--- a/crates/braid-ir/src/lib.rs
+++ b/crates/braid-ir/src/lib.rs
@@ -2,9 +2,9 @@
 //!
 //! The canonical form of a Braid program is **data**: a content-addressed,
 //! canonically-encoded capsule wrapping a DAG of typed term applications.
-//! This crate owns the type universe, the canonical encoding (with bijection
-//! guard — threat T3), content addressing (D8 hash discipline), the closed
-//! term registry shape, and the capsule artifact.
+//! This crate owns the type universe, canonical encoding, content addressing,
+//! closed registry shape, capsule artifact, compact admission algebra, and the
+//! registry-scoped token projection used after independent verification.
 //!
 //! //why no serde/ciborium: the canonical byte form is a *security surface*
 //! (admission hashes it). A third-party serializer's normalization choices
@@ -16,29 +16,35 @@
 //! consumer pulls `braid-ir` for the substrate (types, encoding, CID,
 //! registry shape, capsule) and a vocabulary package (`braid-vocab-cms`,
 //! `braid-vocab-js`, …) for the term alphabet + capability space. Baking a
-//! domain vocabulary into the substrate would force every consumer to fork
-//! to escape it — the "good enough to not be a fork" failure. The substrate
-//! is registry-parametric: `verify` and the SDK take any `TermRegistry`.
+//! domain vocabulary into the substrate would force every consumer to fork.
 //!
 //! Boundary covenant (D3): this crate depends only on `blake3` and
 //! `braid-capability`. Enforced by `tests/boundary_conformance.rs`.
 
 #![no_std]
+#![forbid(unsafe_code)]
+
 extern crate alloc;
 
+pub mod admission;
 pub mod braid;
 pub mod canon;
 pub mod capsule;
 pub mod cid;
 pub mod term;
+pub mod token;
 pub mod value;
 
+pub use crate::admission::{
+    AdmissionAxis, AdmissionEncodingError, AdmissionTriad, InvocationDecision, ProofState,
+};
 pub use crate::braid::{Braid, Strand};
 pub use crate::canon::{CanonError, decode_strict, encode};
 pub use crate::capsule::{Capsule, ConfirmPolicy, IR_VERSION};
-pub use crate::cid::Cid;
+pub use crate::cid::{CAPSULE_DOMAIN, Cid, REGISTRY_DOMAIN};
 pub use crate::term::{
     EffectClass, Exposure, TermRegistry, TermSpec, TypeTag, TypeTagError, type_tag_node_count,
     type_tag_to_text, validate_type_tag,
 };
+pub use crate::token::{TermTable, TermToken, TokenError, TokenOp, TokenProgram};
 pub use crate::value::Value;

--- a/crates/braid-ir/src/token.rs
+++ b/crates/braid-ir/src/token.rs
@@ -377,6 +377,7 @@ mod tests {
     use crate::braid::{Braid, Strand};
     use crate::capsule::{Capsule, ConfirmPolicy, IR_VERSION};
     use crate::term::{EffectClass, Exposure, TermRegistry, TermSpec, TypeTag};
+    use alloc::vec;
     use core::mem::size_of;
 
     fn fixture() -> (TermRegistry, Capsule) {
@@ -453,11 +454,8 @@ mod tests {
     #[test]
     fn graph_projects_to_fixed_ops_and_one_input_arena() {
         let (registry, capsule) = fixture();
-        let triad = AdmissionTriad::new(
-            ProofState::Proven,
-            ProofState::Proven,
-            ProofState::Unknown,
-        );
+        let triad =
+            AdmissionTriad::new(ProofState::Proven, ProofState::Proven, ProofState::Unknown);
         let program = TokenProgram::derive(&capsule, &registry, triad).unwrap();
 
         assert_eq!(program.ops().len(), 2);

--- a/crates/braid-ir/src/token.rs
+++ b/crates/braid-ir/src/token.rs
@@ -1,0 +1,501 @@
+//! Dense, registry-scoped execution tokens derived from canonical Braid IR.
+//!
+//! Canonical capsules keep protocol-stable term names because names are the
+//! cross-system identity. The admitted hot path should not carry one heap
+//! `String` and one heap `Vec` per strand. This module therefore derives a
+//! compact, non-canonical view:
+//!
+//! ```text
+//! (registry CID, canonical term name) -> TermToken
+//! strand-local Vec<input>             -> one shared input arena
+//! ```
+//!
+//! A [`TermToken`] is meaningful only with the exact registry CID carried by
+//! [`TokenProgram`]. It is never a global identifier by itself, and this
+//! representation never replaces the canonical bytes used for content
+//! addressing or independent admission.
+
+use crate::admission::AdmissionTriad;
+use crate::capsule::Capsule;
+use crate::cid::Cid;
+use crate::term::{TermRegistry, TermSpec};
+use alloc::vec::Vec;
+
+/// Dense ordinal of a term in one canonical registry.
+///
+/// The scope is the registry CID. Persisting or comparing the integer without
+/// that CID is a protocol error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct TermToken(u32);
+
+impl TermToken {
+    /// Return the dense integer used by the hot path.
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+
+    fn from_index(index: usize) -> Result<Self, TokenError> {
+        checked_u32(index, "term registry").map(Self)
+    }
+}
+
+/// Fixed-width operation header. Inputs live in [`TokenProgram`]'s shared
+/// input arena at `input_start..input_start + input_len`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct TokenOp {
+    term: TermToken,
+    input_start: u32,
+    input_len: u32,
+}
+
+impl TokenOp {
+    /// Registry-scoped term token.
+    pub const fn term(self) -> TermToken {
+        self.term
+    }
+
+    /// First input index in the shared input arena.
+    pub const fn input_start(self) -> u32 {
+        self.input_start
+    }
+
+    /// Number of input indices in the shared input arena.
+    pub const fn input_len(self) -> u32 {
+        self.input_len
+    }
+}
+
+/// Dense lookup table over an immutable canonical registry.
+///
+/// Construction allocates one pointer per term once. Token resolution is then
+/// O(1), while name-to-token elaboration is O(log n) over the already sorted
+/// canonical registry order.
+#[derive(Debug)]
+pub struct TermTable<'a> {
+    registry_cid: Cid,
+    terms: Vec<&'a TermSpec>,
+}
+
+impl<'a> TermTable<'a> {
+    /// Bind a dense table to an exact registry.
+    pub fn new(registry: &'a TermRegistry) -> Result<Self, TokenError> {
+        if registry.len() > u32::MAX as usize {
+            return Err(TokenError::RegistryTooLarge {
+                count: registry.len(),
+            });
+        }
+        Ok(Self {
+            registry_cid: registry.cid(),
+            terms: registry.terms().collect(),
+        })
+    }
+
+    /// Exact registry identity that scopes every token in this table.
+    pub const fn registry_cid(&self) -> Cid {
+        self.registry_cid
+    }
+
+    /// Number of dense term entries.
+    pub fn len(&self) -> usize {
+        self.terms.len()
+    }
+
+    /// Whether the registry has no terms.
+    pub fn is_empty(&self) -> bool {
+        self.terms.is_empty()
+    }
+
+    /// Resolve a canonical term name to its dense token.
+    pub fn token_for(&self, term_id: &str) -> Option<TermToken> {
+        self.terms
+            .binary_search_by(|spec| spec.id.as_str().cmp(term_id))
+            .ok()
+            .and_then(|index| TermToken::from_index(index).ok())
+    }
+
+    /// Resolve a dense token in O(1).
+    pub fn resolve(&self, token: TermToken) -> Option<&'a TermSpec> {
+        self.terms.get(token.0 as usize).copied()
+    }
+}
+
+/// Why a canonical graph could not be projected into the dense hot form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenError {
+    /// Capsule and term table commit to different registries.
+    RegistryMismatch {
+        /// Registry CID pinned by the capsule.
+        capsule: Cid,
+        /// Registry CID used for tokenization.
+        table: Cid,
+    },
+    /// A registry cannot fit in the 32-bit token namespace.
+    RegistryTooLarge {
+        /// Number of terms observed.
+        count: usize,
+    },
+    /// A compact arena or index cannot fit in its 32-bit representation.
+    ProgramTooLarge {
+        /// Collection or index that overflowed.
+        field: &'static str,
+        /// Observed host-size value.
+        count: usize,
+    },
+    /// A strand names no term in the bound registry.
+    UnknownTerm {
+        /// Topological strand index.
+        strand: usize,
+    },
+    /// An input is not a preceding strand.
+    InvalidInput {
+        /// Topological strand index.
+        strand: usize,
+        /// Invalid referenced strand.
+        input: u32,
+    },
+    /// A declared output is outside the operation arena.
+    InvalidOutput {
+        /// Invalid referenced strand.
+        output: u32,
+    },
+}
+
+impl core::fmt::Display for TokenError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::RegistryMismatch { capsule, table } => write!(
+                f,
+                "token registry mismatch: capsule {} table {}",
+                capsule.to_hex(),
+                table.to_hex()
+            ),
+            Self::RegistryTooLarge { count } => {
+                write!(f, "term registry has {count} entries; maximum is u32::MAX")
+            }
+            Self::ProgramTooLarge { field, count } => {
+                write!(f, "{field} has {count} entries; maximum is u32::MAX")
+            }
+            Self::UnknownTerm { strand } => {
+                write!(f, "unknown term at strand {strand}")
+            }
+            Self::InvalidInput { strand, input } => {
+                write!(f, "strand {strand} references non-preceding input {input}")
+            }
+            Self::InvalidOutput { output } => {
+                write!(f, "output references missing strand {output}")
+            }
+        }
+    }
+}
+
+impl core::error::Error for TokenError {}
+
+fn checked_u32(value: usize, field: &'static str) -> Result<u32, TokenError> {
+    u32::try_from(value).map_err(|_| TokenError::ProgramTooLarge {
+        field,
+        count: value,
+    })
+}
+
+fn total_input_count(capsule: &Capsule) -> Result<usize, TokenError> {
+    capsule
+        .braid
+        .strands
+        .iter()
+        .try_fold(0usize, |total, strand| {
+            total
+                .checked_add(strand.inputs.len())
+                .ok_or(TokenError::ProgramTooLarge {
+                    field: "input arena",
+                    count: usize::MAX,
+                })
+        })
+}
+
+/// Dense, immutable execution projection of one canonical capsule.
+///
+/// This form is intentionally not serialized as the capsule identity. The
+/// canonical graph remains the source of truth; the program is a cacheable
+/// projection bound to both capsule and registry CIDs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenProgram {
+    capsule_cid: Cid,
+    registry_cid: Cid,
+    admission: AdmissionTriad,
+    ops: Vec<TokenOp>,
+    inputs: Vec<u32>,
+    outputs: Vec<u32>,
+}
+
+impl TokenProgram {
+    /// Derive a compact program and compute the canonical capsule CID.
+    ///
+    /// This performs representation checks, not independent admission. Only a
+    /// verifier-owned wrapper may treat the resulting program as admitted.
+    pub fn derive(
+        capsule: &Capsule,
+        registry: &TermRegistry,
+        admission: AdmissionTriad,
+    ) -> Result<Self, TokenError> {
+        let table = TermTable::new(registry)?;
+        Self::derive_bound(capsule, &table, capsule.cid(), admission)
+    }
+
+    /// Derive a compact program using a CID already computed from the exact
+    /// canonical bytes being admitted.
+    ///
+    /// This avoids a second canonical encoding in the independent verifier.
+    /// Callers outside a verifier should prefer [`Self::derive`].
+    pub fn derive_bound(
+        capsule: &Capsule,
+        table: &TermTable<'_>,
+        capsule_cid: Cid,
+        admission: AdmissionTriad,
+    ) -> Result<Self, TokenError> {
+        if capsule.registry_cid != table.registry_cid {
+            return Err(TokenError::RegistryMismatch {
+                capsule: capsule.registry_cid,
+                table: table.registry_cid,
+            });
+        }
+
+        checked_u32(capsule.braid.strands.len(), "operation arena")?;
+        let total_inputs = total_input_count(capsule)?;
+        checked_u32(total_inputs, "input arena")?;
+        checked_u32(capsule.braid.outputs.len(), "output arena")?;
+
+        let mut ops = Vec::with_capacity(capsule.braid.strands.len());
+        let mut inputs = Vec::with_capacity(total_inputs);
+
+        for (strand_index, strand) in capsule.braid.strands.iter().enumerate() {
+            let term = table
+                .token_for(&strand.term)
+                .ok_or(TokenError::UnknownTerm {
+                    strand: strand_index,
+                })?;
+            let input_start = checked_u32(inputs.len(), "input arena")?;
+            let input_len = checked_u32(strand.inputs.len(), "strand inputs")?;
+            for &input in &strand.inputs {
+                if input as usize >= strand_index {
+                    return Err(TokenError::InvalidInput {
+                        strand: strand_index,
+                        input,
+                    });
+                }
+                inputs.push(input);
+            }
+            ops.push(TokenOp {
+                term,
+                input_start,
+                input_len,
+            });
+        }
+
+        let mut outputs = Vec::with_capacity(capsule.braid.outputs.len());
+        for &output in &capsule.braid.outputs {
+            if output as usize >= ops.len() {
+                return Err(TokenError::InvalidOutput { output });
+            }
+            outputs.push(output);
+        }
+
+        Ok(Self {
+            capsule_cid,
+            registry_cid: table.registry_cid,
+            admission,
+            ops,
+            inputs,
+            outputs,
+        })
+    }
+
+    /// Canonical capsule identity this projection was derived from.
+    pub const fn capsule_cid(&self) -> Cid {
+        self.capsule_cid
+    }
+
+    /// Exact registry identity that scopes all operation tokens.
+    pub const fn registry_cid(&self) -> Cid {
+        self.registry_cid
+    }
+
+    /// Current Safety × Capability × Justification projection.
+    pub const fn admission(&self) -> AdmissionTriad {
+        self.admission
+    }
+
+    /// Fixed-width operation arena.
+    pub fn ops(&self) -> &[TokenOp] {
+        &self.ops
+    }
+
+    /// Shared topological input-index arena.
+    pub fn input_arena(&self) -> &[u32] {
+        &self.inputs
+    }
+
+    /// Topological output indices.
+    pub fn outputs(&self) -> &[u32] {
+        &self.outputs
+    }
+
+    /// Inputs for one operation, with bounds checked against the private arena.
+    pub fn inputs_for(&self, op_index: usize) -> Option<&[u32]> {
+        let op = self.ops.get(op_index)?;
+        let start = op.input_start as usize;
+        let end = start.checked_add(op.input_len as usize)?;
+        self.inputs.get(start..end)
+    }
+
+    /// Approximate bytes occupied by the dense variable-sized arenas.
+    ///
+    /// This excludes allocator metadata and the fixed-size `TokenProgram`
+    /// header. It is diagnostic only, never a budget proof.
+    pub fn hot_arena_bytes(&self) -> usize {
+        self.ops
+            .len()
+            .saturating_mul(core::mem::size_of::<TokenOp>())
+            .saturating_add(
+                self.inputs
+                    .len()
+                    .saturating_mul(core::mem::size_of::<u32>()),
+            )
+            .saturating_add(
+                self.outputs
+                    .len()
+                    .saturating_mul(core::mem::size_of::<u32>()),
+            )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::admission::{AdmissionAxis, InvocationDecision, ProofState};
+    use crate::braid::{Braid, Strand};
+    use crate::capsule::{Capsule, ConfirmPolicy, IR_VERSION};
+    use crate::term::{EffectClass, Exposure, TermRegistry, TermSpec, TypeTag};
+    use core::mem::size_of;
+
+    fn fixture() -> (TermRegistry, Capsule) {
+        let mut registry = TermRegistry::new(7);
+        registry
+            .insert(TermSpec {
+                id: "z.consume".into(),
+                inputs: vec![TypeTag::Int],
+                output: TypeTag::Bool,
+                capability: None,
+                effect: EffectClass::Pure,
+                source_exposure: Exposure::Public,
+                egress_ceiling: None,
+                cost: 1,
+            })
+            .unwrap();
+        registry
+            .insert(TermSpec {
+                id: "a.literal".into(),
+                inputs: vec![],
+                output: TypeTag::Int,
+                capability: None,
+                effect: EffectClass::Pure,
+                source_exposure: Exposure::Public,
+                egress_ceiling: None,
+                cost: 1,
+            })
+            .unwrap();
+
+        let capsule = Capsule {
+            ir_version: IR_VERSION,
+            vocab_version: registry.vocab_version,
+            registry_cid: registry.cid(),
+            intent: "compact fixture".into(),
+            grants: vec![],
+            braid: Braid {
+                strands: vec![
+                    Strand {
+                        term: "a.literal".into(),
+                        inputs: vec![],
+                    },
+                    Strand {
+                        term: "z.consume".into(),
+                        inputs: vec![0],
+                    },
+                ],
+                outputs: vec![1],
+            },
+            budget: 2,
+            confirm: ConfirmPolicy::None,
+            evidence: vec![],
+        };
+        (registry, capsule)
+    }
+
+    #[test]
+    fn operation_header_is_twelve_bytes() {
+        assert_eq!(size_of::<TermToken>(), 4);
+        assert_eq!(size_of::<TokenOp>(), 12);
+    }
+
+    #[test]
+    fn canonical_registry_order_defines_dense_tokens() {
+        let (registry, _) = fixture();
+        let table = TermTable::new(&registry).unwrap();
+        assert_eq!(table.token_for("a.literal").unwrap().get(), 0);
+        assert_eq!(table.token_for("z.consume").unwrap().get(), 1);
+        assert_eq!(
+            table.resolve(TermToken(1)).unwrap().id.as_str(),
+            "z.consume"
+        );
+    }
+
+    #[test]
+    fn graph_projects_to_fixed_ops_and_one_input_arena() {
+        let (registry, capsule) = fixture();
+        let triad = AdmissionTriad::new(
+            ProofState::Proven,
+            ProofState::Proven,
+            ProofState::Unknown,
+        );
+        let program = TokenProgram::derive(&capsule, &registry, triad).unwrap();
+
+        assert_eq!(program.ops().len(), 2);
+        assert_eq!(program.ops()[0].term().get(), 0);
+        assert_eq!(program.ops()[1].term().get(), 1);
+        assert_eq!(program.input_arena(), &[0]);
+        assert_eq!(program.inputs_for(0), Some(&[] as &[u32]));
+        assert_eq!(program.inputs_for(1), Some(&[0][..]));
+        assert_eq!(program.outputs(), &[1]);
+        assert_eq!(
+            program.admission().decision(),
+            InvocationDecision::Defer {
+                axis: AdmissionAxis::Justification
+            }
+        );
+        assert_eq!(program.hot_arena_bytes(), 32);
+    }
+
+    #[test]
+    fn token_scope_is_bound_to_registry_cid() {
+        let (registry, mut capsule) = fixture();
+        capsule.registry_cid = Cid([9; 32]);
+        assert!(matches!(
+            TokenProgram::derive(&capsule, &registry, AdmissionTriad::default()),
+            Err(TokenError::RegistryMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn invalid_topology_cannot_enter_compact_program() {
+        let (registry, mut capsule) = fixture();
+        capsule.braid.strands[1].inputs = vec![1];
+        assert!(matches!(
+            TokenProgram::derive(&capsule, &registry, AdmissionTriad::default()),
+            Err(TokenError::InvalidInput {
+                strand: 1,
+                input: 1
+            })
+        ));
+    }
+}

--- a/crates/braid-sdk/src/lib.rs
+++ b/crates/braid-sdk/src/lib.rs
@@ -6,16 +6,14 @@
 //! a typed error at construction instead of a `Reject` later — but the
 //! verifier remains the sole authority (D9: the SDK never decides admission).
 //!
-//! Two invariants the SDK makes *unrepresentable* (stronger than a check):
-//! - **No forward reference / no cycle**: [`Strand`] handles are returned by
-//!   [`Builder::strand`] and can only reference already-added strands, so the
-//!   DAG's index order — the verifier's topological order — holds by
-//!   construction.
-//! - **No undeclared capability**: grants are *collected* from the terms used,
-//!   not declared separately, so a capsule cannot use a capability it failed
-//!   to request (the omission that scenario #4b rejects can't be authored).
+//! The SDK removes two common authoring errors inside one builder: handles
+//! reference already-added strands, and grants are collected from the terms
+//! used. The independent verifier still repeats topology and authority checks;
+//! an SDK handle is never an admission proof.
 //!
 //! Boundary (D3): depends only on `braid-ir` + `braid-capability`.
+
+#![forbid(unsafe_code)]
 
 use braid_capability::Capability;
 use braid_ir::braid::{Braid, Strand as IrStrand};
@@ -66,11 +64,19 @@ pub enum BuildError {
     NoOutputs {
         at: &'static str,
     },
-    /// A declared budget below the composed cost (the SDK refuses to author an
-    /// over-budget capsule rather than emit one the verifier will reject).
+    /// A declared budget below the composed cost.
     BudgetTooLow {
         needed: u64,
         set: u64,
+        at: &'static str,
+    },
+    /// Static term costs overflowed the u64 budget algebra.
+    CostOverflow {
+        at: &'static str,
+    },
+    /// A strand index cannot fit the canonical u32 graph representation.
+    TooManyStrands {
+        count: usize,
         at: &'static str,
     },
     /// Irreversible/egress term used without a confirm policy set.
@@ -112,6 +118,10 @@ impl fmt::Display for BuildError {
             Self::BudgetTooLow { needed, set, at } => {
                 write!(f, "budget too low at {at}: needed {needed}, set {set}")
             }
+            Self::CostOverflow { at } => write!(f, "static term cost overflow at {at}"),
+            Self::TooManyStrands { count, at } => {
+                write!(f, "{count} strands exceed the u32 graph limit at {at}")
+            }
             Self::ConfirmRequired { at } => {
                 write!(f, "human confirmation required for dangerous terms at {at}")
             }
@@ -127,12 +137,9 @@ pub struct Builder<'r> {
     intent: String,
     strands: Vec<IrStrand>,
     outputs: Vec<u32>,
-    /// Parallel to `strands`: the interned output type of each.
-    out_types: Vec<TypeTag>,
     type_interner: Vec<TypeTag>,
-    // //why a Vec + membership check, not a set: `Capability` is not `Ord`
-    // (kernel contract — D3 forbids us adding a derive to it), so we dedup by
-    // the protocol-stable name and sort on emit to hit the canonical order.
+    // Capability is protocol-ordered. Keep one canonical value rather than
+    // allocating temporary Strings for equality and sorting.
     grants: Vec<Capability>,
     cost: u64,
     has_dangerous: bool,
@@ -148,7 +155,6 @@ impl<'r> Builder<'r> {
             intent: intent.into(),
             strands: Vec::new(),
             outputs: Vec::new(),
-            out_types: Vec::new(),
             type_interner: Vec::new(),
             grants: Vec::new(),
             cost: 0,
@@ -160,8 +166,8 @@ impl<'r> Builder<'r> {
     }
 
     fn intern(&mut self, ty: &TypeTag) -> TypeTagId {
-        if let Some(i) = self.type_interner.iter().position(|t| t == ty) {
-            TypeTagId(i)
+        if let Some(index) = self.type_interner.iter().position(|item| item == ty) {
+            TypeTagId(index)
         } else {
             self.type_interner.push(ty.clone());
             TypeTagId(self.type_interner.len() - 1)
@@ -215,16 +221,26 @@ impl<'r> Builder<'r> {
         Ok(())
     }
 
-    fn record_effects(&mut self, spec: &TermSpec) {
-        if let Some(cap) = &spec.capability
-            && !self.grants.iter().any(|g| g.to_string() == cap.to_string())
+    fn record_effects(&mut self, spec: &TermSpec) -> Result<(), BuildError> {
+        let next_cost = self
+            .cost
+            .checked_add(spec.cost)
+            .ok_or(BuildError::CostOverflow {
+                at: "Builder::strand",
+            })?;
+        if let Some(capability) = &spec.capability
+            && !self.grants.contains(capability)
         {
-            self.grants.push(cap.clone());
+            self.grants.push(capability.clone());
         }
-        if matches!(spec.effect, EffectClass::Irreversible | EffectClass::Egress) {
+        if matches!(
+            spec.effect,
+            EffectClass::Irreversible | EffectClass::Egress
+        ) {
             self.has_dangerous = true;
         }
-        self.cost = self.cost.saturating_add(spec.cost);
+        self.cost = next_cost;
+        Ok(())
     }
 
     /// Place a strand, type- and arity-checking its inputs against the
@@ -238,38 +254,39 @@ impl<'r> Builder<'r> {
                 at: "Builder::strand",
             })?;
         self.validate_inputs(term_id, inputs, spec)?;
-        self.record_effects(spec);
-
-        let index = self.strands.len() as u32;
+        let index =
+            u32::try_from(self.strands.len()).map_err(|_| BuildError::TooManyStrands {
+                count: self.strands.len(),
+                at: "Builder::strand",
+            })?;
+        self.record_effects(spec)?;
         let ty = self.intern(&spec.output);
         self.strands.push(IrStrand {
             term: term_id.to_string(),
-            inputs: inputs.iter().map(|h| h.index).collect(),
+            inputs: inputs.iter().map(|handle| handle.index).collect(),
         });
-        self.out_types.push(self.type_interner[ty.0].clone());
         Ok(Strand { index, ty })
     }
 
     /// Mark a strand as a capsule output.
-    pub fn output(&mut self, s: Strand) -> &mut Self {
-        self.outputs.push(s.index);
+    pub fn output(&mut self, strand: Strand) -> &mut Self {
+        self.outputs.push(strand.index);
         self
     }
 
-    pub fn budget(&mut self, b: u64) -> &mut Self {
-        self.budget = Some(b);
+    pub fn budget(&mut self, budget: u64) -> &mut Self {
+        self.budget = Some(budget);
         self
     }
 
-    /// Size the budget exactly to the composed cost (convenience for tight
-    /// authoring; the verifier still checks).
+    /// Size the budget exactly to the composed cost.
     pub fn budget_tight(&mut self) -> &mut Self {
         self.budget = Some(self.cost);
         self
     }
 
-    pub fn confirm(&mut self, c: ConfirmPolicy) -> &mut Self {
-        self.confirm = Some(c);
+    pub fn confirm(&mut self, confirm: ConfirmPolicy) -> &mut Self {
+        self.confirm = Some(confirm);
         self
     }
 
@@ -320,7 +337,8 @@ impl<'r> Builder<'r> {
         let confirm = self.resolve_confirm()?;
 
         let mut grants = self.grants;
-        grants.sort_by_key(|c| c.to_string());
+        grants.sort();
+        grants.dedup();
 
         Ok(Capsule {
             ir_version: IR_VERSION,

--- a/crates/braid-sdk/src/lib.rs
+++ b/crates/braid-sdk/src/lib.rs
@@ -265,10 +265,7 @@ impl<'r> Builder<'r> {
         {
             self.grants.push(capability.clone());
         }
-        if matches!(
-            spec.effect,
-            EffectClass::Irreversible | EffectClass::Egress
-        ) {
+        if matches!(spec.effect, EffectClass::Irreversible | EffectClass::Egress) {
             self.has_dangerous = true;
         }
         self.cost = next_cost;
@@ -286,11 +283,10 @@ impl<'r> Builder<'r> {
                 at: "Builder::strand",
             })?;
         self.validate_inputs(term_id, inputs, spec)?;
-        let index =
-            u32::try_from(self.strands.len()).map_err(|_| BuildError::TooManyStrands {
-                count: self.strands.len(),
-                at: "Builder::strand",
-            })?;
+        let index = u32::try_from(self.strands.len()).map_err(|_| BuildError::TooManyStrands {
+            count: self.strands.len(),
+            at: "Builder::strand",
+        })?;
         self.record_effects(spec)?;
         let ty = self.intern(&spec.output);
         self.strands.push(IrStrand {

--- a/crates/braid-sdk/src/lib.rs
+++ b/crates/braid-sdk/src/lib.rs
@@ -20,12 +20,22 @@ use braid_ir::braid::{Braid, Strand as IrStrand};
 use braid_ir::term::{TermSpec, TypeTag};
 use braid_ir::{Capsule, ConfirmPolicy, EffectClass, IR_VERSION, TermRegistry};
 use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_BUILDER_ID: AtomicU64 = AtomicU64::new(1);
+
+fn allocate_builder_id() -> u64 {
+    let id = NEXT_BUILDER_ID.fetch_add(1, Ordering::Relaxed);
+    assert_ne!(id, 0, "exhausted SDK builder identity space");
+    id
+}
 
 /// A typed reference to a strand already placed in the braid. Carries its
 /// output type so wiring is type-checked the moment it is used as an input.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Strand {
     index: u32,
+    owner: u64,
     // //why store the type here and not look it up: the handle is the only way
     // to reference a strand, so carrying the type makes a mis-wire a
     // compile-adjacent error at the call site, not a deferred verdict.
@@ -79,6 +89,11 @@ pub enum BuildError {
         count: usize,
         at: &'static str,
     },
+    /// A strand handle came from another builder or no longer names an
+    /// already-authored strand.
+    ForeignStrand {
+        at: &'static str,
+    },
     /// Irreversible/egress term used without a confirm policy set.
     ConfirmRequired {
         at: &'static str,
@@ -122,6 +137,9 @@ impl fmt::Display for BuildError {
             Self::TooManyStrands { count, at } => {
                 write!(f, "{count} strands exceed the u32 graph limit at {at}")
             }
+            Self::ForeignStrand { at } => {
+                write!(f, "strand handle belongs to another builder at {at}")
+            }
             Self::ConfirmRequired { at } => {
                 write!(f, "human confirmation required for dangerous terms at {at}")
             }
@@ -133,10 +151,12 @@ impl std::error::Error for BuildError {}
 
 /// Capsule builder bound to a registry.
 pub struct Builder<'r> {
+    id: u64,
     registry: &'r TermRegistry,
     intent: String,
     strands: Vec<IrStrand>,
     outputs: Vec<u32>,
+    foreign_output: bool,
     type_interner: Vec<TypeTag>,
     // Capability is protocol-ordered. Keep one canonical value rather than
     // allocating temporary Strings for equality and sorting.
@@ -151,10 +171,12 @@ pub struct Builder<'r> {
 impl<'r> Builder<'r> {
     pub fn new(registry: &'r TermRegistry, intent: impl Into<String>) -> Self {
         Builder {
+            id: allocate_builder_id(),
             registry,
             intent: intent.into(),
             strands: Vec::new(),
             outputs: Vec::new(),
+            foreign_output: false,
             type_interner: Vec::new(),
             grants: Vec::new(),
             cost: 0,
@@ -194,7 +216,17 @@ impl<'r> Builder<'r> {
         handle: Strand,
         expected: &TypeTag,
     ) -> Result<(), BuildError> {
-        let got = &self.type_interner[handle.ty.0];
+        if handle.owner != self.id || handle.index as usize >= self.strands.len() {
+            return Err(BuildError::ForeignStrand {
+                at: "Builder::strand",
+            });
+        }
+        let got = self
+            .type_interner
+            .get(handle.ty.0)
+            .ok_or(BuildError::ForeignStrand {
+                at: "Builder::strand",
+            })?;
         if got != expected {
             Err(BuildError::TypeMismatch {
                 term: term_id.to_string(),
@@ -265,12 +297,20 @@ impl<'r> Builder<'r> {
             term: term_id.to_string(),
             inputs: inputs.iter().map(|handle| handle.index).collect(),
         });
-        Ok(Strand { index, ty })
+        Ok(Strand {
+            index,
+            owner: self.id,
+            ty,
+        })
     }
 
     /// Mark a strand as a capsule output.
     pub fn output(&mut self, strand: Strand) -> &mut Self {
-        self.outputs.push(strand.index);
+        if strand.owner != self.id || strand.index as usize >= self.strands.len() {
+            self.foreign_output = true;
+        } else {
+            self.outputs.push(strand.index);
+        }
         self
     }
 
@@ -293,6 +333,16 @@ impl<'r> Builder<'r> {
     pub fn evidence(&mut self, key: impl Into<String>) -> &mut Self {
         self.evidence.push(key.into());
         self
+    }
+
+    fn check_output_handles(&self) -> Result<(), BuildError> {
+        if self.foreign_output {
+            Err(BuildError::ForeignStrand {
+                at: "Builder::output",
+            })
+        } else {
+            Ok(())
+        }
     }
 
     fn check_has_outputs(&self) -> Result<(), BuildError> {
@@ -332,6 +382,7 @@ impl<'r> Builder<'r> {
     /// Finalize. Grants are emitted sorted+deduped (canonical order); a
     /// dangerous capsule without `HumanConfirm` is refused at author time.
     pub fn build(self) -> Result<Capsule, BuildError> {
+        self.check_output_handles()?;
         self.check_has_outputs()?;
         let budget = self.resolve_budget()?;
         let confirm = self.resolve_confirm()?;

--- a/crates/braid-sdk/tests/authoring.rs
+++ b/crates/braid-sdk/tests/authoring.rs
@@ -154,9 +154,35 @@ fn no_outputs_refused() {
     ));
 }
 
-/// A handle from one builder cannot be used in another: the type system
-/// prevents cross-braid strand references (forward-ref/cycle unrepresentable).
-/// This is a compile-time guarantee; documented here as a usage note.
+#[test]
+fn foreign_input_handle_is_rejected_without_panicking() {
+    let reg = registry_v0();
+    let mut first = Builder::new(&reg, "first");
+    let foreign = first.strand("lit.text", &[]).unwrap();
+
+    let mut second = Builder::new(&reg, "second");
+    assert!(matches!(
+        second.strand("view.section", &[foreign]),
+        Err(BuildError::ForeignStrand { .. })
+    ));
+}
+
+#[test]
+fn foreign_output_handle_poison_is_rejected_at_build() {
+    let reg = registry_v0();
+    let mut first = Builder::new(&reg, "first");
+    let foreign = first.strand("lit.text", &[]).unwrap();
+
+    let mut second = Builder::new(&reg, "second");
+    let own = second.strand("lit.text", &[]).unwrap();
+    second.output(own);
+    second.output(foreign);
+    assert!(matches!(
+        second.build(),
+        Err(BuildError::ForeignStrand { .. })
+    ));
+}
+
 #[test]
 fn budget_tight_sizes_to_cost() {
     let reg = registry_v0();

--- a/crates/braid-verify/src/lib.rs
+++ b/crates/braid-verify/src/lib.rs
@@ -240,7 +240,12 @@ fn stage_4_types(capsule: &Capsule, registry: &TermRegistry) -> Result<(), Verdi
         .braid
         .strands
         .iter()
-        .map(|strand| &registry.get(&strand.term).expect("checked in stage 3").output)
+        .map(|strand| {
+            &registry
+                .get(&strand.term)
+                .expect("checked in stage 3")
+                .output
+        })
         .collect();
 
     for (strand_idx, strand) in capsule.braid.strands.iter().enumerate() {
@@ -280,9 +285,7 @@ fn ensure_capability_granted(
     if grants.binary_search(capability).is_err() {
         Err(reject(
             Stage::Capability,
-            format!(
-                "strand {strand_idx} `{term}` requires undeclared capability `{capability}`"
-            ),
+            format!("strand {strand_idx} `{term}` requires undeclared capability `{capability}`"),
         ))
     } else {
         Ok(())
@@ -519,11 +522,7 @@ fn compile_compact_program(
         reject(stage, error.to_string())
     })?;
     let capsule_cid = Cid::compute(CAPSULE_DOMAIN, bytes);
-    let triad = AdmissionTriad::new(
-        ProofState::Proven,
-        ProofState::Proven,
-        ProofState::Unknown,
-    );
+    let triad = AdmissionTriad::new(ProofState::Proven, ProofState::Proven, ProofState::Unknown);
     TokenProgram::derive_bound(capsule, &table, capsule_cid, triad).map_err(|error| {
         let stage = token_error_stage(error);
         reject(stage, error.to_string())

--- a/crates/braid-verify/src/lib.rs
+++ b/crates/braid-verify/src/lib.rs
@@ -1,20 +1,24 @@
 //! # braid-verify — deterministic admission (ADR-088 D3, U3–U5 #560)
 //!
 //! The fail-closed stage pipeline. Order is LOCKED (ADR-088 D3); a request
-//! that survives one gate becomes the typed input of the next (the kernel's
-//! composition idiom). Neither an AI nor a reviewer is the enforcement
-//! mechanism — this crate is.
+//! that survives one gate becomes the typed input of the next. Neither an AI
+//! nor a reviewer is the enforcement mechanism — this crate is.
 //!
-//! Verdicts are typed and machine-readable: an authoring agent repairs from
-//! `Reject { stage, reason }` without a human in the loop; a human reads the
-//! same verdict in CI.
+//! Verdicts are typed and machine-readable. [`verify_compact`] additionally
+//! projects an admitted canonical graph into the dense token form used by the
+//! future hot runtime without turning that cache into a second wire format.
+
+#![forbid(unsafe_code)]
 
 pub mod decode;
 
 use braid_capability::Capability;
 use braid_ir::braid::Strand;
 use braid_ir::term::{EffectClass, Exposure};
-use braid_ir::{Capsule, Cid, ConfirmPolicy, IR_VERSION, TermRegistry, TypeTag};
+use braid_ir::{
+    AdmissionTriad, CAPSULE_DOMAIN, Capsule, Cid, ConfirmPolicy, IR_VERSION, ProofState,
+    TermRegistry, TermTable, TokenError, TokenProgram, TypeTag,
+};
 
 /// Pipeline stages, in locked order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,10 +33,47 @@ pub enum Stage {
     Bounds,
 }
 
+/// Deterministic admission result for the canonical capsule.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Verdict {
     Admit { capsule_cid: Cid },
     Reject { stage: Stage, reason: String },
+}
+
+/// Ephemeral, non-serializable result of independent admission plus compact
+/// projection.
+///
+/// Safety and Capability are proven by this verifier invocation under the
+/// supplied registry and ambient capability set. Justification remains
+/// [`ProofState::Unknown`] until the snapshot-bound Flow planner supplies that
+/// proof. Consequently the embedded triad deterministically returns `Defer`,
+/// never `Execute`, in v0.
+///
+/// This value is not an authority credential. In particular, serializing the
+/// one-byte triad would not preserve the external authority snapshot that
+/// produced it.
+#[derive(Debug, PartialEq, Eq)]
+pub struct AdmittedCapsule {
+    program: TokenProgram,
+}
+
+impl AdmittedCapsule {
+    /// Dense, CID-bound projection of the admitted graph.
+    pub fn program(&self) -> &TokenProgram {
+        &self.program
+    }
+
+    /// Canonical capsule identity.
+    pub const fn capsule_cid(&self) -> Cid {
+        self.program.capsule_cid()
+    }
+
+    /// Consume the wrapper and return the compact projection.
+    ///
+    /// The returned projection remains data, not an authority credential.
+    pub fn into_program(self) -> TokenProgram {
+        self.program
+    }
 }
 
 fn reject(stage: Stage, reason: impl Into<String>) -> Verdict {
@@ -199,7 +240,7 @@ fn stage_4_types(capsule: &Capsule, registry: &TermRegistry) -> Result<(), Verdi
         .braid
         .strands
         .iter()
-        .map(|s| &registry.get(&s.term).expect("checked in stage 3").output)
+        .map(|strand| &registry.get(&strand.term).expect("checked in stage 3").output)
         .collect();
 
     for (strand_idx, strand) in capsule.braid.strands.iter().enumerate() {
@@ -231,13 +272,17 @@ fn check_grants_ambient(grants: &[Capability], ambient: &[Capability]) -> Result
 fn ensure_capability_granted(
     strand_idx: usize,
     term: &str,
-    cap: &Capability,
+    capability: &Capability,
     grants: &[Capability],
 ) -> Result<(), Verdict> {
-    if !grants.contains(cap) {
+    // Canonical capsule decoding enforces strict grant ordering, so binary
+    // search avoids one linear string scan per effectful strand.
+    if grants.binary_search(capability).is_err() {
         Err(reject(
             Stage::Capability,
-            format!("strand {strand_idx} `{term}` requires undeclared capability `{cap}`"),
+            format!(
+                "strand {strand_idx} `{term}` requires undeclared capability `{capability}`"
+            ),
         ))
     } else {
         Ok(())
@@ -251,8 +296,8 @@ fn check_strand_capability(
     grants: &[Capability],
 ) -> Result<(), Verdict> {
     let spec = registry.get(&strand.term).expect("checked in stage 3");
-    if let Some(cap) = &spec.capability {
-        ensure_capability_granted(strand_idx, &strand.term, cap, grants)?;
+    if let Some(capability) = &spec.capability {
+        ensure_capability_granted(strand_idx, &strand.term, capability, grants)?;
     }
     Ok(())
 }
@@ -271,11 +316,17 @@ fn stage_5_capability(
 
 // ── Stage 6: Effect ────────────────────────────────────────────────────────
 
+fn is_irreversible_or_egress(effect: EffectClass) -> bool {
+    matches!(effect, EffectClass::Irreversible | EffectClass::Egress)
+}
+
 fn check_confirm_policy(capsule: &Capsule, registry: &TermRegistry) -> Result<(), Verdict> {
-    let needs_confirm = capsule.braid.strands.iter().any(|s| {
-        matches!(
-            registry.get(&s.term).expect("checked in stage 3").effect,
-            EffectClass::Irreversible | EffectClass::Egress
+    let needs_confirm = capsule.braid.strands.iter().any(|strand| {
+        is_irreversible_or_egress(
+            registry
+                .get(&strand.term)
+                .expect("checked in stage 3")
+                .effect,
         )
     });
     if needs_confirm && capsule.confirm != ConfirmPolicy::HumanConfirm {
@@ -288,78 +339,51 @@ fn check_confirm_policy(capsule: &Capsule, registry: &TermRegistry) -> Result<()
     }
 }
 
-fn explore_inputs(
-    strands: &[Strand],
-    current_idx: usize,
-    to_idx: usize,
-    seen: &mut [bool],
-    stack: &mut Vec<usize>,
-) -> bool {
-    for &target in &strands[current_idx].inputs {
-        let target_idx = target as usize;
-        if target_idx == to_idx {
-            return true;
-        }
-        if target_idx < seen.len() && !seen[target_idx] {
-            seen[target_idx] = true;
-            stack.push(target_idx);
-        }
-    }
-    false
-}
-
-fn reaches(strands: &[Strand], from_idx: usize, to_idx: usize) -> bool {
-    if from_idx == to_idx {
-        return true;
-    }
-    let mut seen = vec![false; strands.len()];
-    let mut stack = vec![from_idx];
-    while let Some(current_idx) = stack.pop() {
-        if explore_inputs(strands, current_idx, to_idx, &mut seen, &mut stack) {
-            return true;
-        }
-    }
-    false
-}
-
-fn check_effect_pair(
-    strands: &[Strand],
-    first_idx: usize,
-    second_idx: usize,
-) -> Result<(), Verdict> {
-    let upper = first_idx.max(second_idx);
-    let lower = first_idx.min(second_idx);
-    if !reaches(strands, upper, lower) {
-        Err(reject(
-            Stage::Effect,
-            format!(
-                "unordered irreversible/egress strands {first_idx} and {second_idx}: \
-                 relative order undefined — wire an explicit dependency"
-            ),
-        ))
-    } else {
-        Ok(())
-    }
-}
-
-fn check_effect_ordering(capsule: &Capsule, registry: &TermRegistry) -> Result<(), Verdict> {
-    let effectful: Vec<usize> = capsule
-        .braid
-        .strands
+fn latest_effect_from_inputs(
+    strand: &Strand,
+    latest_visible_effect: &[Option<usize>],
+) -> Option<usize> {
+    strand
+        .inputs
         .iter()
-        .enumerate()
-        .filter(|(_, s)| {
-            matches!(
-                registry.get(&s.term).expect("checked in stage 3").effect,
-                EffectClass::Irreversible | EffectClass::Egress
-            )
-        })
-        .map(|(i, _)| i)
-        .collect();
+        .filter_map(|&input| latest_visible_effect[input as usize])
+        .max()
+}
 
-    for (pos, &first_idx) in effectful.iter().enumerate() {
-        for &second_idx in &effectful[pos + 1..] {
-            check_effect_pair(&capsule.braid.strands, first_idx, second_idx)?;
+/// Prove that dangerous effects form one explicit dependency chain.
+///
+/// Because strands are topologically ordered, checking that every dangerous
+/// strand depends on the immediately previous dangerous strand is sufficient:
+/// transitivity then orders every earlier pair. This is O(V + E), replacing
+/// the former O(k² × (V + E)) pairwise graph search and its per-search
+/// allocations.
+fn check_effect_ordering(capsule: &Capsule, registry: &TermRegistry) -> Result<(), Verdict> {
+    let mut latest_visible_effect = Vec::with_capacity(capsule.braid.strands.len());
+    let mut previous_effect = None;
+
+    for (strand_index, strand) in capsule.braid.strands.iter().enumerate() {
+        let incoming_latest = latest_effect_from_inputs(strand, &latest_visible_effect);
+        let effect = registry
+            .get(&strand.term)
+            .expect("checked in stage 3")
+            .effect;
+
+        if is_irreversible_or_egress(effect) {
+            if let Some(previous_index) = previous_effect
+                && incoming_latest != Some(previous_index)
+            {
+                return Err(reject(
+                    Stage::Effect,
+                    format!(
+                        "unordered irreversible/egress strands {previous_index} and \
+                         {strand_index}: relative order undefined — wire an explicit dependency"
+                    ),
+                ));
+            }
+            previous_effect = Some(strand_index);
+            latest_visible_effect.push(Some(strand_index));
+        } else {
+            latest_visible_effect.push(incoming_latest);
         }
     }
     Ok(())
@@ -436,7 +460,7 @@ fn stage_7_taint(capsule: &Capsule, registry: &TermRegistry) -> Result<(), Verdi
 
 fn check_cost_overflow(sum: Option<u64>) -> Result<u64, Verdict> {
     match sum {
-        Some(val) => Ok(val),
+        Some(value) => Ok(value),
         None => Err(reject(Stage::Bounds, "cost overflow")),
     }
 }
@@ -448,7 +472,7 @@ fn accumulate_strand_cost(total: &mut u64, cost: u64) -> Result<(), Verdict> {
 }
 
 fn compute_total_cost(capsule: &Capsule, registry: &TermRegistry) -> Result<u64, Verdict> {
-    let mut total: u64 = 0;
+    let mut total = 0u64;
     for strand in &capsule.braid.strands {
         let spec = registry.get(&strand.term).expect("checked in stage 3");
         accumulate_strand_cost(&mut total, spec.cost)?;
@@ -473,7 +497,40 @@ fn stage_8_bounds(capsule: &Capsule, registry: &TermRegistry) -> Result<(), Verd
     Ok(())
 }
 
-// ── Pipeline Entry Point ────────────────────────────────────────────────────
+// ── Compact projection ─────────────────────────────────────────────────────
+
+fn token_error_stage(error: TokenError) -> Stage {
+    match error {
+        TokenError::RegistryTooLarge { .. } | TokenError::ProgramTooLarge { .. } => Stage::Bounds,
+        TokenError::RegistryMismatch { .. }
+        | TokenError::UnknownTerm { .. }
+        | TokenError::InvalidInput { .. }
+        | TokenError::InvalidOutput { .. } => Stage::Structure,
+    }
+}
+
+fn compile_compact_program(
+    bytes: &[u8],
+    capsule: &Capsule,
+    registry: &TermRegistry,
+) -> Result<TokenProgram, Verdict> {
+    let table = TermTable::new(registry).map_err(|error| {
+        let stage = token_error_stage(error);
+        reject(stage, error.to_string())
+    })?;
+    let capsule_cid = Cid::compute(CAPSULE_DOMAIN, bytes);
+    let triad = AdmissionTriad::new(
+        ProofState::Proven,
+        ProofState::Proven,
+        ProofState::Unknown,
+    );
+    TokenProgram::derive_bound(capsule, &table, capsule_cid, triad).map_err(|error| {
+        let stage = token_error_stage(error);
+        reject(stage, error.to_string())
+    })
+}
+
+// ── Pipeline Entry Point ───────────────────────────────────────────────────
 
 fn verify_structure_and_types(capsule: &Capsule, registry: &TermRegistry) -> Result<(), Verdict> {
     stage_2_version_pin(capsule, registry)?;
@@ -494,23 +551,43 @@ fn verify_security_and_bounds(
     Ok(())
 }
 
-fn run_pipeline(
+fn admit_capsule(
     bytes: &[u8],
     registry: &TermRegistry,
     ambient: &[Capability],
-) -> Result<Cid, Verdict> {
+) -> Result<Capsule, Verdict> {
     let capsule = stage_1_canonical_form(bytes)?;
     verify_structure_and_types(&capsule, registry)?;
     verify_security_and_bounds(&capsule, registry, ambient)?;
-    Ok(capsule.cid())
+    Ok(capsule)
 }
 
-/// Verify capsule BYTES against a registry and the ambient grant set the
+/// Independently verify canonical bytes and return the compact, CID-bound
+/// projection.
+///
+/// The returned triad has Safety=`Proven`, Capability=`Proven`, and
+/// Justification=`Unknown`. A runtime must therefore defer until a
+/// snapshot-bound planner supplies the third proof.
+pub fn verify_compact(
+    bytes: &[u8],
+    registry: &TermRegistry,
+    ambient: &[Capability],
+) -> Result<AdmittedCapsule, Verdict> {
+    let capsule = admit_capsule(bytes, registry, ambient)?;
+    let program = compile_compact_program(bytes, &capsule, registry)?;
+    Ok(AdmittedCapsule { program })
+}
+
+/// Verify capsule bytes against a registry and the ambient grant set the
 /// principal actually holds. Bytes in, verdict out — the admission decision
-/// is reproducible from the artifact alone (D9).
+/// is reproducible from the artifact and explicit authority input.
+///
+/// This verdict-only path does not allocate the dense execution projection.
 pub fn verify(bytes: &[u8], registry: &TermRegistry, ambient: &[Capability]) -> Verdict {
-    match run_pipeline(bytes, registry, ambient) {
-        Ok(capsule_cid) => Verdict::Admit { capsule_cid },
+    match admit_capsule(bytes, registry, ambient) {
+        Ok(_) => Verdict::Admit {
+            capsule_cid: Cid::compute(CAPSULE_DOMAIN, bytes),
+        },
         Err(verdict) => verdict,
     }
 }

--- a/crates/braid-verify/tests/compact.rs
+++ b/crates/braid-verify/tests/compact.rs
@@ -1,0 +1,62 @@
+use braid_capability::Capability;
+use braid_ir::{AdmissionAxis, InvocationDecision, ProofState};
+use braid_verify::{Stage, Verdict, verify_compact};
+use braid_vocab_cms::{
+    INTENT_EMIT_NAME, REMOTE_COMPUTE_NAME, SIGNAL_EMIT_NAME, TAPE_READ_NAME, cap,
+    edit_section_capsule, registry_v0,
+};
+
+fn full_ambient() -> Vec<Capability> {
+    vec![
+        cap!(SIGNAL_EMIT_NAME),
+        cap!(INTENT_EMIT_NAME),
+        cap!(TAPE_READ_NAME),
+        cap!(REMOTE_COMPUTE_NAME),
+    ]
+}
+
+#[test]
+fn admitted_graph_becomes_registry_scoped_dense_program() {
+    let capsule = edit_section_capsule();
+    let registry = registry_v0();
+    let admitted =
+        verify_compact(&capsule.to_bytes(), &registry, &full_ambient()).expect("must admit");
+    let program = admitted.program();
+
+    assert_eq!(admitted.capsule_cid(), capsule.cid());
+    assert_eq!(program.registry_cid(), registry.cid());
+    assert_eq!(program.ops().len(), capsule.braid.strands.len());
+    assert_eq!(
+        program.admission().state(AdmissionAxis::Safety),
+        ProofState::Proven
+    );
+    assert_eq!(
+        program.admission().state(AdmissionAxis::Capability),
+        ProofState::Proven
+    );
+    assert_eq!(
+        program.admission().state(AdmissionAxis::Justification),
+        ProofState::Unknown
+    );
+    assert_eq!(
+        program.admission().decision(),
+        InvocationDecision::Defer {
+            axis: AdmissionAxis::Justification
+        }
+    );
+}
+
+#[test]
+fn compact_projection_cannot_bypass_capability_rejection() {
+    let capsule = edit_section_capsule();
+    let registry = registry_v0();
+    let result = verify_compact(&capsule.to_bytes(), &registry, &[]);
+
+    assert!(matches!(
+        result,
+        Err(Verdict::Reject {
+            stage: Stage::Capability,
+            ..
+        })
+    ));
+}

--- a/docs/adr-101-root-admission-triad-and-token-plan.md
+++ b/docs/adr-101-root-admission-triad-and-token-plan.md
@@ -1,0 +1,133 @@
+# ADR-101 — Root Admission Triad and Registry-Scoped Token Plan
+
+**Status:** Accepted for the substrate; runtime integration remains blocked on the justification planner and authority-safe execution boundary.  
+**Date:** 2026-08-26  
+**Supersedes:** no canonical wire decision. Elaborates ADR-100 and issues #59, #61, #63.
+
+## Context
+
+Braid has two representations with different jobs:
+
+1. The **canonical graph** is the stable, content-addressed meaning. Dotted term names remain readable, globally exchangeable identities inside a registry pinned by CID.
+2. The **hot execution projection** should be dense, bounded, and allocation-light. Repeating a heap `String` and a heap `Vec<u32>` for every strand is unnecessary after independent verification.
+
+The AppleScript progression contains one useful idea and one failure to avoid. Its application dictionaries gave commands stable, discoverable identities. Its English-like syntax, implicit coercion, and context-sensitive name resolution made those identities ambiguous in use. Braid keeps the dictionary lesson—closed named vocabularies—but lowers admitted names into typed numeric tokens instead of executing prose.
+
+Admission also had a semantic gap. Safety, authority, and need were described separately, but no root value forced their results to travel together. A safe and authorized operation is still wasteful or harmful when it is not justified under the current snapshot.
+
+## Decision
+
+### 1. The root admission value is one fail-closed triad
+
+Braid defines:
+
+```text
+Admission = Safety × Capability × Justification
+```
+
+Each axis has exactly three states:
+
+```text
+Disproven < Unknown < Proven
+```
+
+Reduction is deterministic:
+
+```text
+any Disproven -> Reject
+else any Unknown -> Defer
+else             Execute
+```
+
+The representation is one byte: two bits per axis, with `00 = Unknown`, `01 = Proven`, `10 = Disproven`, `11 = reserved`; the high two bits are reserved. Therefore an all-zero value is fail-closed and cannot accidentally execute.
+
+The byte is a compact **result carrier**, not evidence. No producer may obtain authority by serializing `Proven`. The subsystems that own the checks must construct the states from their proof artifacts.
+
+### 2. Current independent capsule admission is deliberately `P × P × U`
+
+`braid-verify` can currently establish:
+
+- **Safety = Proven:** canonical form, version pin, structure, types, effects, taint, and bounds pass.
+- **Capability = Proven:** capsule grants are attenuated against an externally supplied ambient authority set.
+- **Justification = Unknown:** the snapshot-bound Flow planner is not complete.
+
+The compact verifier result therefore deterministically returns `Defer`, never `Execute`. This is an intentional loud gate, not an incomplete boolean default.
+
+### 3. Canonical names remain identity; dense tokens are a derived cache
+
+A term token is:
+
+```text
+(registry_cid, dense_u32_ordinal)
+```
+
+The integer alone has no meaning. The ordinal is assigned by canonical registry order, and resolution is valid only under the exact pinned registry CID.
+
+The canonical capsule remains the wire, hash preimage, audit artifact, and interoperability boundary. The token plan is never serialized as a replacement wire and never accepted as authority.
+
+### 4. The compact program uses flat arenas
+
+For `N` operations, `E` input references, and `O` outputs, the variable-size hot arenas are:
+
+```text
+12N + 4E + 4O bytes
+```
+
+plus one native pointer per term in the registry lookup table and allocator/fixed-header overhead. `TokenOp` is exactly 12 bytes:
+
+```text
+term_token:  u32
+input_start: u32
+input_len:   u32
+```
+
+All input references live in one contiguous `u32` arena. This removes the per-strand `String` and `Vec` headers and the per-strand input allocation from the hot form. On a typical 64-bit target, the old in-memory `Strand` shape had at least a 24-byte `String` header plus a 24-byte `Vec` header before payload and allocator metadata; that comparison is architecture-specific and is not itself a budget proof.
+
+### 5. Verification must not become the memory hazard
+
+The Flow verifier uses compressed-sparse-row adjacency, `u32` node IDs, iterative Kahn cycle detection, and iterative reachability. It does not allocate a `Vec` for every node and does not recurse to graph depth.
+
+Capsule irreversible/egress ordering is proven as one explicit dependency chain in linear graph work: every dangerous operation must depend on the immediately preceding dangerous operation. Transitivity orders the complete set without pairwise graph searches.
+
+## Safety invariants
+
+1. **Canonical-first:** tokens are derived only from a capsule that passed independent decoding and admission.
+2. **Registry scope:** a token is rejected if the capsule registry CID and token table registry CID differ.
+3. **No authority from bits:** `AdmissionTriad` and `TokenProgram` are data, not credentials.
+4. **Unknown does not execute:** v0 justification remains `Unknown`; the reduction is `Defer`.
+5. **No second wire:** capsule CIDs are computed from the exact canonical bytes, not the token plan.
+6. **No hidden topology:** input references remain topological `u32` strand indices and are checked while compacting.
+7. **No silent overflow:** arena sizes, indices, and static cost composition use checked arithmetic.
+8. **No unsafe substrate code:** `braid-ir`, `braid-verify`, and `braid-sdk` forbid `unsafe`.
+
+## Review findings fixed in this change
+
+- The triad existed in prose but not as a shared root algebra.
+- Every canonical strand carried a heap term string into prospective execution.
+- Every strand owned a separate input vector instead of a flat arena.
+- The SDK allocated temporary capability strings despite `Capability: Ord`.
+- The SDK retained an unused parallel output-type vector.
+- SDK static cost used saturating arithmetic, which could hide overflow.
+- SDK handles from another builder could panic type lookup or silently name the wrong strand; handles are now builder-scoped and rejected.
+- The Flow verifier repeatedly cloned node keys into strings and maps.
+- The Flow verifier allocated one adjacency vector per node and used recursive DFS.
+- Capsule dangerous-effect ordering used repeated pairwise graph searches and allocations.
+
+## Deliberately unresolved gates
+
+These are not papered over by this ADR:
+
+1. **Runtime authority bypass:** `braid-run` still accepts a raw `Capsule`; its API must consume a verifier/planner-owned runnable typestate and external authority context, not self-declared grants.
+2. **Runtime allocation amplification:** execution still performs string dispatch and clones every input/output/journal value. It has not yet migrated to `TokenProgram` plus a bounded value arena.
+3. **Justification proof:** the Flow planner must evaluate `needed_when` and `satisfied_when` against a CID-bound snapshot and return the third proof.
+4. **Choice disjointness:** v0 checks choice shape and duplicate targets; it does not prove predicate disjointness. The verifier must not describe that as solved.
+5. **Decoder preflight:** the capsule independent decoder still needs explicit wire-byte and total-value ceilings before allocating the complete canonical value tree.
+6. **Cross-process proof transport:** a future runnable artifact needs identity-bound evidence/receipt references; the one-byte triad is insufficient.
+
+## Consequences
+
+- Human- and machine-readable canonical identity is preserved.
+- Repeated execution can use dense numeric dispatch without pretending numbers create universal meaning.
+- Zero-initialized admission state is safe.
+- The current system becomes more honest: it can prove safe and authorized admission, but it visibly defers because need is not yet proven.
+- Runtime integration is intentionally a separate change because mixing representation compaction with execution authority would enlarge the trusted computing base and make review weaker.


### PR DESCRIPTION
## Why

Braid already described **Safety × Capability × Justification**, but the three results did not exist as one executable root algebra. The canonical graph also carried string-heavy authoring structures toward the hot path instead of deriving a compact verified representation.

This PR encodes the triad without pretending the unfinished justification planner exists, and applies the useful AppleScript lesson: stable dictionary identities remain canonical; execution receives dense tokens only after independent verification.

Closes the executable substrate portion of #61. Elaborates #59 and #63. Runtime/planner completion remains intentionally separate.

## What changed

- adds a one-byte, fail-closed `AdmissionTriad`
  - `Disproven < Unknown < Proven`
  - any disproven → reject
  - else any unknown → defer
  - all proven → execute
  - zero is `Unknown × Unknown × Unknown`
  - reserved states fail closed
- adds registry-CID-scoped `TermToken`, `TermTable`, and `TokenProgram`
  - canonical names remain the wire and hash identity
  - dense ordinals are meaningful only with the exact registry CID
  - fixed 12-byte operation headers
  - one flat `u32` input arena instead of one input allocation per strand
- adds `verify_compact`
  - independent verifier establishes `Safety=Proven`
  - ambient authority check establishes `Capability=Proven`
  - `Justification=Unknown` remains loud, so the decision is `Defer`
  - compact projection is data, never an authority credential or second wire
- replaces pairwise dangerous-effect reachability searches with a linear explicit-chain proof
- replaces Flow verifier string maps, per-node adjacency allocations, and recursive DFS with binary search + CSR + iterative Kahn/reachability
- removes SDK capability-string allocations and unused parallel type storage
- replaces saturating static-cost accumulation with checked failure
- scopes SDK strand handles to their builder; foreign handles now return typed errors instead of panicking or silently aliasing another strand
- ratifies the boundary and remaining blockers in ADR-101

## Memory shape

For `N` operations, `E` input references, and `O` outputs, the compact variable arenas are:

```text
12N + 4E + 4O bytes
```

plus one native pointer per registry term and fixed/allocator overhead. The canonical graph remains unchanged and auditable.

## Deliberate non-goals / blockers

This PR does **not** connect `braid-run` to the token plan. The current raw-`Capsule` runtime entry point must first be replaced by a verifier/planner-owned runnable typestate carrying external authority and snapshot-bound justification. Otherwise tokenization would make an unsafe bypass faster.

Still loud:

1. raw runtime authority bypass and clone amplification
2. snapshot-bound justification proof
3. real Choice predicate disjointness proof
4. independent decoder wire/value preflight ceilings
5. identity-bound proof transport for cross-process execution

## Verification

CI must pass workspace build, tests, doctests, clippy `-D warnings`, rustfmt, and the repository policy tiers before this leaves draft.