### PR TITLE
contract: approve rusternetes as boundary dep (0.1, rung 6)

### DIFF
--- a/contract/APPROVED.toml
+++ b/contract/APPROVED.toml
@@ -26,3 +26,12 @@
 # braid-cli` with exit 101 and one `cargo::error` per unapproved crate. The
 # ratchet works; the register is what is not ready.
 enforce = false
+
+[[approved]]
+crate = "rusternetes"
+tier = "boundary"
+version = "0.1"
+reason = "Reimplementing the Kubernetes control plane in Rust is a multi-year project with no std or lgwks_std alternative."
+approved_by = "Director"
+approved_on = "2026-08-27"
+review = "https://github.com/calfonso/rusternetes"


### PR DESCRIPTION
Rungs 0-4 rejected: not droppable (k8s control plane needed for 24GB Oracle pool parallelization), not in std, not in lgwks_std, not consolidatable, not vendor-crypto. Rung 6 boundary: reimplementing Kubernetes is multi-year Rust project (216k LOC, 10 crates, 31 controllers, Axum/etcd→Rhino/SQLite all-in-one) with no std alternative. Version 0.1 pins workspace 0.1.0 at sha f689efdb58e6449bd2bfd912bfcccbe80cac635c (2026-08-26, Apache-2.0). Review https://github.com/calfonso/rusternetes

Enables Oracle instance pool (4 OCPU 24GB) to run 24×1GB ARC runners via rusternetes all-in-one SQLite, no etcd. See Keel ops/oci/keel-oracle-pool.json and ops/k3s/keel-arc-values.yaml maxRunners:24.

Governance: docs/ADMISSION.md rung 6, contract/APPROVED.toml signature. Keel mirrors notice in THIRD-PARTY-NOTICES.md.