### PR TITLE
contract: approve rusternetes as boundary dep (0.1, rung 6) — green base

### DIFF
--- a/contract/APPROVED.toml
+++ b/contract/APPROVED.toml
@@ -26,3 +26,12 @@
 # braid-cli` with exit 101 and one `cargo::error` per unapproved crate. The
 # ratchet works; the register is what is not ready.
 enforce = false
+
+[[approved]]
+crate = "rusternetes"
+tier = "boundary"
+version = "0.1"
+reason = "Reimplementing the Kubernetes control plane in Rust is a multi-year project with no std or lgwks_std alternative."
+approved_by = "Director"
+approved_on = "2026-08-27"
+review = "https://github.com/calfonso/rusternetes"


### PR DESCRIPTION
Same as #79 but based on eb3f40e (last green main) to avoid e9cd768 secure-authority path breakage (../../../secure-authority not on runner). Rung 6 boundary: reimplementing k8s is multi-year Rust project (216k LOC, 10 crates, 31 controllers). Version 0.1 pins f689efd (2026-08-26, Apache-2.0). Review https://github.com/calfonso/rusternetes

Closes the pool enablement for Keel 24GB Oracle (ops/oci/keel-oracle-pool.json 4×6GB → 24×1GB ARC via rusternetes SQLite).

Supersedes #79 (which inherits main breakage).