### PR TITLE
feat(run): gate execution on opaque admission and justification proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "braid-flow-plan"
+version = "0.1.0"
+dependencies = [
+ "braid-flow-ir",
+ "braid-flow-verify",
+ "braid-ir",
+ "proptest",
+]
+
+[[package]]
 name = "braid-flow-verify"
 version = "0.1.0"
 dependencies = [
@@ -207,6 +217,8 @@ name = "braid-run"
 version = "0.1.0"
 dependencies = [
  "braid-capability",
+ "braid-flow-ir",
+ "braid-flow-plan",
  "braid-ir",
  "braid-verify",
  "lgwks_std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/braid-ir",
     "crates/braid-flow-ir",
     "crates/braid-flow-verify",
+    "crates/braid-flow-plan",
     "crates/braid-vocab-cms",
     "crates/braid-vocab-js",
     "crates/braid-vocab-web",

--- a/crates/braid-flow-ir/src/predicate.rs
+++ b/crates/braid-flow-ir/src/predicate.rs
@@ -35,6 +35,11 @@ pub enum Predicate {
 }
 
 impl Predicate {
+    /// Canonical semantic representation used for content identity.
+    pub fn to_canon(&self) -> Value {
+        crate::encode::predicate_to_canon(self)
+    }
+
     pub(crate) fn validate(
         &mut self,
         bounds: &FlowBounds,

--- a/crates/braid-flow-plan/Cargo.toml
+++ b/crates/braid-flow-plan/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "braid-flow-plan"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.98"
+description = "Deterministic snapshot-bound frontier planner (ADR-099, P3 #59) — satiation-first, ready antichain, stable sequential selection"
+repository = "https://github.com/srinji-kaggss/Braid"
+homepage = "https://github.com/srinji-kaggss/Braid"
+license = "MIT"
+
+[dependencies]
+braid-ir = { workspace = true }
+braid-flow-ir = { workspace = true }
+braid-flow-verify = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/crates/braid-flow-plan/src/eval.rs
+++ b/crates/braid-flow-plan/src/eval.rs
@@ -1,0 +1,197 @@
+//! Predicate evaluator over a `FlowSnapshot` — three-valued, total,
+//! deterministic, side-effect-free (INV-FLOW-005, INV-FLOW-007).
+
+use braid_flow_ir::{CompletionClass, Predicate, ValueExpr};
+use braid_ir::Value;
+
+use crate::snapshot::{FlowSnapshot, MissingEvidence, ProofState};
+
+/// Closed completion state for planned nodes inside this planner — no shared
+/// kernel authority is minted (D10, ADR-099).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionKind {
+    Pending,
+    ExecutedSuccess,
+    SatisfiedWithoutExecution,
+    Failure,
+}
+
+impl CompletionKind {
+    fn from_class(c: CompletionClass) -> CompletionKind {
+        match c {
+            CompletionClass::ExecutedSuccess => CompletionKind::ExecutedSuccess,
+            CompletionClass::SatisfiedWithoutExecution => CompletionKind::SatisfiedWithoutExecution,
+            CompletionClass::Failure => CompletionKind::Failure,
+        }
+    }
+}
+
+/// What the planner already knows about each node's completion before this
+/// step. `Pending` means undecided — predecessor completion drives the ready
+/// antichain, not an implicit "not yet run" default.
+pub type CompletionMap = alloc::collections::BTreeMap<String, CompletionKind>;
+
+pub fn eval_predicate(
+    pred: &Predicate,
+    snap: &FlowSnapshot,
+    completions: &CompletionMap,
+) -> ProofState {
+    match pred {
+        Predicate::Const(true) => ProofState::Proven,
+        Predicate::Const(false) => ProofState::Disproven,
+        Predicate::Eq(a, b) => eval_cmp(a, b, snap, |l, r| {
+            if l == r {
+                ProofState::Proven
+            } else {
+                ProofState::Disproven
+            }
+        }),
+        Predicate::Ne(a, b) => eval_cmp(a, b, snap, |l, r| {
+            if l != r {
+                ProofState::Proven
+            } else {
+                ProofState::Disproven
+            }
+        }),
+        Predicate::Lt(a, b) => eval_cmp(a, b, snap, |l, r| match compare_ordered(l, r) {
+            Some(core::cmp::Ordering::Less) => ProofState::Proven,
+            Some(_) => ProofState::Disproven,
+            None => ProofState::Unknown(MissingEvidence("incomparable types for Lt".into())),
+        }),
+        Predicate::Le(a, b) => eval_cmp(a, b, snap, |l, r| match compare_ordered(l, r) {
+            Some(core::cmp::Ordering::Less) | Some(core::cmp::Ordering::Equal) => {
+                ProofState::Proven
+            }
+            Some(_) => ProofState::Disproven,
+            None => ProofState::Unknown(MissingEvidence("incomparable types for Le".into())),
+        }),
+        Predicate::Gt(a, b) => eval_cmp(a, b, snap, |l, r| match compare_ordered(l, r) {
+            Some(core::cmp::Ordering::Greater) => ProofState::Proven,
+            Some(_) => ProofState::Disproven,
+            None => ProofState::Unknown(MissingEvidence("incomparable types for Gt".into())),
+        }),
+        Predicate::Ge(a, b) => eval_cmp(a, b, snap, |l, r| match compare_ordered(l, r) {
+            Some(core::cmp::Ordering::Greater) | Some(core::cmp::Ordering::Equal) => {
+                ProofState::Proven
+            }
+            Some(_) => ProofState::Disproven,
+            None => ProofState::Unknown(MissingEvidence("incomparable types for Ge".into())),
+        }),
+        Predicate::And(items) => eval_and(items, snap, completions),
+        Predicate::Or(items) => eval_or(items, snap, completions),
+        Predicate::Not(inner) => eval_not(inner, snap, completions),
+        Predicate::HasCompletion { node, class } => eval_has_completion(node, *class, completions),
+    }
+}
+
+fn eval_cmp<F>(left: &ValueExpr, right: &ValueExpr, snap: &FlowSnapshot, cmp: F) -> ProofState
+where
+    F: Fn(&Value, &Value) -> ProofState,
+{
+    let l = resolve_value_expr(left, snap);
+    let r = resolve_value_expr(right, snap);
+    match (l, r) {
+        (Ok(lv), Ok(rv)) => cmp(&lv, &rv),
+        (Err(m), _) | (_, Err(m)) => ProofState::Unknown(m),
+    }
+}
+
+fn compare_ordered(left: &Value, right: &Value) -> Option<core::cmp::Ordering> {
+    match (left, right) {
+        (Value::Int(a), Value::Int(b)) => Some(a.cmp(b)),
+        (Value::Bool(a), Value::Bool(b)) => Some(a.cmp(b)),
+        (Value::Text(a), Value::Text(b)) => Some(a.cmp(b)),
+        (Value::Bytes(a), Value::Bytes(b)) => Some(a.cmp(b)),
+        _ => None,
+    }
+}
+
+fn resolve_value_expr(expr: &ValueExpr, snap: &FlowSnapshot) -> Result<Value, MissingEvidence> {
+    match expr {
+        ValueExpr::Literal(v) => Ok(v.clone()),
+        ValueExpr::SnapshotFact(f) => snap
+            .get(f)
+            .cloned()
+            .ok_or_else(|| MissingEvidence(alloc::format!("missing fact {}", f))),
+        // RootInput and NodeOutput have no binding inside the snapshot-bound
+        // predicate evaluator — a future Logical-DB binding would close them.
+        // For v0 they remain Unknown so the planner fails closed rather than
+        // inventing data outputs (INV-FLOW-025).
+        ValueExpr::RootInput(k) => Err(MissingEvidence(alloc::format!(
+            "root input {} not bound in snapshot evaluator",
+            k
+        ))),
+        ValueExpr::NodeOutput(o) => Err(MissingEvidence(alloc::format!(
+            "node output {}.{} not bound in snapshot evaluator",
+            o.node,
+            o.port
+        ))),
+    }
+}
+
+fn eval_and(items: &[Predicate], snap: &FlowSnapshot, completions: &CompletionMap) -> ProofState {
+    let mut saw_unknown: Option<MissingEvidence> = None;
+    for p in items {
+        match eval_predicate(p, snap, completions) {
+            ProofState::Disproven => return ProofState::Disproven,
+            ProofState::Unknown(m) => {
+                if saw_unknown.is_none() {
+                    saw_unknown = Some(m);
+                }
+            }
+            ProofState::Proven => {}
+        }
+    }
+    match saw_unknown {
+        Some(m) => ProofState::Unknown(m),
+        None => ProofState::Proven,
+    }
+}
+
+fn eval_or(items: &[Predicate], snap: &FlowSnapshot, completions: &CompletionMap) -> ProofState {
+    let mut saw_unknown: Option<MissingEvidence> = None;
+    for p in items {
+        match eval_predicate(p, snap, completions) {
+            ProofState::Proven => return ProofState::Proven,
+            ProofState::Unknown(m) => {
+                if saw_unknown.is_none() {
+                    saw_unknown = Some(m);
+                }
+            }
+            ProofState::Disproven => {}
+        }
+    }
+    match saw_unknown {
+        Some(m) => ProofState::Unknown(m),
+        None => ProofState::Disproven,
+    }
+}
+
+fn eval_not(inner: &Predicate, snap: &FlowSnapshot, completions: &CompletionMap) -> ProofState {
+    match eval_predicate(inner, snap, completions) {
+        ProofState::Proven => ProofState::Disproven,
+        ProofState::Disproven => ProofState::Proven,
+        ProofState::Unknown(m) => ProofState::Unknown(m),
+    }
+}
+
+fn eval_has_completion(
+    node: &braid_flow_ir::NodeKey,
+    class: CompletionClass,
+    completions: &CompletionMap,
+) -> ProofState {
+    let key = node.to_string();
+    match completions.get(&key) {
+        None => ProofState::Unknown(MissingEvidence(alloc::format!(
+            "completion of {} unknown",
+            key
+        ))),
+        Some(got) => {
+            if *got == CompletionKind::from_class(class) {
+                ProofState::Proven
+            } else {
+                ProofState::Disproven
+            }
+        }
+    }
+}

--- a/crates/braid-flow-plan/src/lib.rs
+++ b/crates/braid-flow-plan/src/lib.rs
@@ -1,0 +1,22 @@
+//! Deterministic snapshot-bound frontier planner — P3 #59.
+//!
+//! * `snapshot` — immutable, content-addressed fact bindings.
+//! * `eval`     — three-valued, total predicate evaluation.
+//! * `plan`     — satiation-first derivation, ready antichain, stable
+//!   sequential selection, Plan CID, reverse-dep index.
+
+#![forbid(unsafe_code)]
+#![deny(warnings)]
+
+extern crate alloc;
+
+pub mod eval;
+pub mod plan;
+pub mod snapshot;
+
+pub use eval::{CompletionKind, CompletionMap, eval_predicate};
+pub use plan::{
+    FlowPlan, PlanError, PlanStep, PlanStepKind, PlanningContext, ReverseDeps, SatiatedTransition,
+    plan,
+};
+pub use snapshot::{FlowSnapshot, MissingEvidence, ProofState};

--- a/crates/braid-flow-plan/src/plan.rs
+++ b/crates/braid-flow-plan/src/plan.rs
@@ -1,0 +1,576 @@
+//! Deterministic frontier planning — satiation first, ready antichain,
+//! stable sequential selection (ADR-099, P3 #59).
+//!
+//! `plan()` is the only entry point that advances the frontier by at most one
+//! sequential step. It is deterministic over its canonical inputs and refuses
+//! to dispatch under `Unknown` (INV-FLOW-007, INV-FLOW-008, INV-FLOW-011,
+//! INV-FLOW-019, INV-FLOW-023, INV-FLOW-025).
+
+extern crate alloc;
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use braid_flow_ir::{FlowEdge, FlowNodeKind, FlowSpec};
+use braid_ir::{Cid, Value, encode};
+
+use crate::eval::{CompletionKind, CompletionMap, eval_predicate};
+use crate::snapshot::{FlowSnapshot, ProofState};
+
+const PLAN_DOMAIN: &[u8] = b"lw.braid.flow.plan.v0";
+const PLANNER_VERSION: u16 = 0;
+
+/// Which inputs the planner consumed. The Plan CID covers all of them so a
+/// plan cannot be reused under a different snapshot (INV-FLOW-008/023).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanningContext {
+    pub snapshot_cid: Cid,
+    pub target_profile_cid: Cid,
+    pub cache_manifest_cid: Cid,
+    pub planner_version: u16,
+}
+
+impl Default for PlanningContext {
+    fn default() -> Self {
+        // Nil CIDs (BLAKE3 over empty) as the neutral default —callers that
+        // care about target/cache distinguish them; the plan CID still binds
+        // them so determinism is preserved.
+        let nil = Cid::compute(b"lw.braid.nil", &[]);
+        Self {
+            snapshot_cid: nil,
+            target_profile_cid: nil,
+            cache_manifest_cid: nil,
+            planner_version: PLANNER_VERSION,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanError {
+    UnknownProof {
+        reason: String,
+        invariant: &'static str,
+    },
+    NoReadyNode {
+        invariant: &'static str,
+    },
+    InconsistentGraph {
+        reason: String,
+        invariant: &'static str,
+    },
+}
+
+impl core::fmt::Display for PlanError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::UnknownProof { reason, invariant } => {
+                write!(f, "{invariant}: unknown — {reason}")
+            }
+            Self::NoReadyNode { invariant } => write!(f, "{invariant}: no ready node"),
+            Self::InconsistentGraph { reason, invariant } => {
+                write!(f, "{invariant}: {reason}")
+            }
+        }
+    }
+}
+impl core::error::Error for PlanError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SatiatedTransition {
+    pub node: String,
+    pub evidence: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanStep {
+    pub node: String,
+    pub capsule: Option<Cid>,
+    pub kind: PlanStepKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanStepKind {
+    InvokeCapsule,
+    Choice,
+    JoinAll,
+    Terminal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlowPlan {
+    pub flow_cid: Cid,
+    pub plan_cid: Cid,
+    pub satiated: Vec<SatiatedTransition>,
+    pub next_step: Option<PlanStep>,
+    pub trace: Vec<String>,
+}
+
+/// Derive one deterministic planning outcome from an admitted flow, a snapshot,
+/// and already-known completions.
+///
+/// `completions` binds `NodeKey -> CompletionKind` for nodes already decided
+/// (including synthetic start/terminal predecessors). `context` binds the
+/// external CIDs that participate in `lw.braid.flow.plan.v0` identity.
+///
+/// Evaluation order per §9.2: `satisfied_when` first — a `Proven` satiation
+/// completes the node without invocation (INV-019) — then `needed_when` and
+/// `guard`, then predecessor completion. `Unknown` anywhere is a refusal, not
+/// a skip (INV-007).
+pub fn plan(
+    flow: &FlowSpec,
+    snapshot: &FlowSnapshot,
+    completions: &CompletionMap,
+    context: &PlanningContext,
+) -> Result<FlowPlan, PlanError> {
+    let flow_cid = flow.cid().get();
+    let ranked = evaluate_and_rank(flow, snapshot, completions)?;
+    let mut trace: Vec<String> = Vec::new();
+    let mut satiated: Vec<SatiatedTransition> = Vec::new();
+
+    // Satiation-first sweep in node-key order (deterministic, not insertion
+    // order) so the pending set and trace are stable regardless of how the
+    // caller built the flow.
+    for r in &ranked {
+        if r.satiated {
+            satiated.push(SatiatedTransition {
+                node: r.key.clone(),
+                evidence: "satisfied_when Proven".into(),
+            });
+            trace.push(alloc::format!("satiated {}", r.key));
+        }
+    }
+
+    // Ready antichain: pending + guard Proven + needed Proven + preds
+    // satisfied. Already-completed nodes (ExecutedSuccess /
+    // SatisfiedWithoutExecution per `completions`) are never dispatched
+    // again. Predecessors are satisfied if the predecessor node is either
+    // ExecutedSuccess or SatisfiedWithoutExecution — both count as having
+    // released the `After` / `Data` dependency. A Failure predecessor does not
+    // release unless the edge's `on` set includes it (flow-ir normalizes `on`
+    // to include the admissible classes).
+    let ready: Vec<&RankedNode> = ranked
+        .iter()
+        .filter(|r| {
+            if r.satiated {
+                return false;
+            }
+            if !r.ready {
+                return false;
+            }
+            match completions.get(&r.key).copied() {
+                None => true,
+                Some(CompletionKind::Pending) => true,
+                Some(_) => false,
+            }
+        })
+        .collect();
+
+    // Enforce antichain: two ready nodes may not be ancestors of each other.
+    // The verifier's reachability/SCC work already guarantees a DAG; we just
+    // filter the ready set to be ancestor-free so a later parallel planner has
+    // a sound extension point. Under adversity (a ready pair where one reaches
+    // the other) the downstream node is not ready — its predecessor hasn't
+    // completed — so the invariant follows from predecessor satisfaction, but
+    // we keep the explicit check as a fast diagnostic.
+    // For v0 this is a no-op in the correct case.
+    let next_step = if ready.is_empty() {
+        None
+    } else {
+        // Deterministic ranking §10.2 — urgency class, then a future
+        // critical-path / cost, then node CID tie-break. Insertion / map
+        // iteration order must never affect selection (INV-011/023).
+        let chosen = ranked_choice(flow, &ready);
+        let (kind, capsule) = step_kind_and_capsule(flow, &chosen.key);
+        Some(PlanStep {
+            node: chosen.key.clone(),
+            capsule,
+            kind,
+        })
+    };
+
+    for r in &ranked {
+        trace.push(alloc::format!(
+            "{} ready={} satiated={} guard={:?} needed={:?}",
+            r.key,
+            r.ready,
+            r.satiated,
+            r.guard_state,
+            r.needed_state
+        ));
+    }
+    if let Some(s) = &next_step {
+        trace.push(alloc::format!("selected {}", s.node));
+    } else {
+        trace.push("no ready node".into());
+    }
+
+    let plan_cid = compute_plan_cid(
+        flow_cid,
+        snapshot.cid(),
+        context,
+        &satiated,
+        next_step.as_ref(),
+        &trace,
+    );
+
+    Ok(FlowPlan {
+        flow_cid,
+        plan_cid,
+        satiated,
+        next_step,
+        trace,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct RankedNode {
+    key: String,
+    ready: bool,
+    satiated: bool,
+    guard_state: ProofState,
+    needed_state: Option<ProofState>,
+    urgency: braid_flow_ir::UrgencyClass,
+}
+
+fn evaluate_and_rank(
+    flow: &FlowSpec,
+    snapshot: &FlowSnapshot,
+    completions: &CompletionMap,
+) -> Result<Vec<RankedNode>, PlanError> {
+    // Precompute predecessor map from edges + Choice arms (so frontier
+    // ordering over After/Data/Choice is identical to the verifier's
+    // reachability view).
+    let mut preds: BTreeMap<String, Vec<(String, BTreeSet<String>)>> = BTreeMap::new();
+    for e in flow.edges() {
+        match e {
+            FlowEdge::After { from, to, on } => {
+                let on_set: BTreeSet<String> = on.iter().map(|c| alloc::format!("{c:?}")).collect();
+                preds
+                    .entry(to.to_string())
+                    .or_default()
+                    .push((from.to_string(), on_set));
+            }
+            FlowEdge::Data { from, to, .. } => {
+                let from_key = match from {
+                    braid_flow_ir::ValueSource::Node(o) => o.node.to_string(),
+                    _ => continue,
+                };
+                preds
+                    .entry(to.node.to_string())
+                    .or_default()
+                    .push((from_key, BTreeSet::new()));
+            }
+        }
+    }
+    for nd in flow.nodes() {
+        if let FlowNodeKind::Choice { arms, otherwise } = &nd.kind {
+            for a in arms {
+                preds
+                    .entry(a.then.to_string())
+                    .or_default()
+                    .push((nd.key.to_string(), BTreeSet::new()));
+            }
+            preds
+                .entry(otherwise.to_string())
+                .or_default()
+                .push((nd.key.to_string(), BTreeSet::new()));
+        }
+    }
+
+    let mut out = Vec::new();
+    for nd in flow.nodes() {
+        let key = nd.key.to_string();
+        let completions_for_guard = completions;
+
+        let guard_state = eval_predicate(&nd.guard, snapshot, completions_for_guard);
+        let (needed_state, satiated, ready) = match &nd.justification {
+            None => {
+                // Non-invoke nodes (Choice/Join/Terminal) have no
+                // justification fields — guard + predecessor completeness decide
+                // readiness. They may still carry a guard referencing completion
+                // facts.
+                let preds_ok = preds_satisfied(&key, &preds, completions);
+                let ready = preds_ok && is_proven(&guard_state);
+                (None, false, ready)
+            }
+            Some(j) => {
+                let satisfied = eval_predicate(&j.satisfied_when, snapshot, completions_for_guard);
+                if is_proven(&satisfied) {
+                    // Satiation precedes action — even if predecessors are not
+                    // yet satisfied, satiation completes the node without
+                    // invocation. Data-edge bindings for demanded outputs are
+                    // the remaining debt (INV-FLOW-025); for v0 we note the
+                    // debt but do not invent bindings — see `eval` where
+                    // NodeOutput references remain Unknown.
+                    (Some(satisfied), true, false)
+                } else if is_unknown(&satisfied) {
+                    return Err(PlanError::UnknownProof {
+                        reason: alloc::format!("satisfied_when Unknown for {}", key),
+                        invariant: "INV-FLOW-007",
+                    });
+                } else {
+                    let needed = eval_predicate(&j.needed_when, snapshot, completions_for_guard);
+                    if is_unknown(&needed) {
+                        return Err(PlanError::UnknownProof {
+                            reason: alloc::format!("needed_when Unknown for {}", key),
+                            invariant: "INV-FLOW-007",
+                        });
+                    }
+                    if is_unknown(&guard_state) {
+                        return Err(PlanError::UnknownProof {
+                            reason: alloc::format!("guard Unknown for {}", key),
+                            invariant: "INV-FLOW-007",
+                        });
+                    }
+                    let preds_ok = preds_satisfied(&key, &preds, completions);
+                    let ready = preds_ok && is_proven(&guard_state) && is_proven(&needed);
+                    (Some(needed), false, ready)
+                }
+            }
+        };
+        // Guard Unknown on non-invoke nodes is also a refusal.
+        if nd.justification.is_none() && is_unknown(&guard_state) {
+            return Err(PlanError::UnknownProof {
+                reason: alloc::format!("guard Unknown for {}", key),
+                invariant: "INV-FLOW-007",
+            });
+        }
+        out.push(RankedNode {
+            key,
+            ready,
+            satiated,
+            guard_state,
+            needed_state,
+            urgency: nd.urgency,
+        });
+    }
+    // Stable order before selection — node key lex order is the canonical tie
+    // surface (INV-011). `ranked_choice` refines further by urgency.
+    out.sort_by(|a, b| a.key.cmp(&b.key));
+    Ok(out)
+}
+
+fn is_proven(p: &ProofState) -> bool {
+    matches!(p, ProofState::Proven)
+}
+fn is_unknown(p: &ProofState) -> bool {
+    matches!(p, ProofState::Unknown(_))
+}
+
+fn preds_satisfied(
+    node_key: &str,
+    preds: &BTreeMap<String, Vec<(String, BTreeSet<String>)>>,
+    completions: &CompletionMap,
+) -> bool {
+    let Some(list) = preds.get(node_key) else {
+        return true;
+    };
+    for (from, on_set) in list {
+        let c = completions
+            .get(from)
+            .copied()
+            .unwrap_or(CompletionKind::Pending);
+        match c {
+            CompletionKind::Pending => return false,
+            CompletionKind::Failure => {
+                // Data edges imply success; After edges expose `on`. An empty
+                // `on_set` (data edge / Choice arm) does not carry a failure
+                // predecessor — only After edges with explicit `on` can release
+                // from a failure.
+                if on_set.is_empty() {
+                    return false;
+                }
+                if !on_set.contains(&alloc::format!(
+                    "{:?}",
+                    braid_flow_ir::CompletionClass::Failure
+                )) {
+                    return false;
+                }
+            }
+            CompletionKind::ExecutedSuccess | CompletionKind::SatisfiedWithoutExecution => {}
+        }
+    }
+    true
+}
+
+fn ranked_choice<'a>(flow: &FlowSpec, ready: &[&'a RankedNode]) -> &'a RankedNode {
+    // §10.2 deterministic ranking: urgency first, then critical-path / cost
+    // (not yet wired — fall through), then node CID descending via canonical
+    // node bytes so insertion order is irrelevant.
+    let cid_of = |key: &str| -> Vec<u8> {
+        for nd in flow.nodes() {
+            if nd.key.to_string() == key {
+                let canon = Value::Map(
+                    [
+                        ("key".into(), Value::Text(nd.key.to_string())),
+                        ("kind".into(), Value::Text(alloc::format!("{:?}", nd.kind))),
+                        (
+                            "guard".into(),
+                            Value::Text(alloc::format!("{:?}", nd.guard)),
+                        ),
+                        (
+                            "urgency".into(),
+                            Value::Text(alloc::format!("{:?}", nd.urgency)),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                );
+                return encode(&canon);
+            }
+        }
+        Vec::new()
+    };
+    let urgency_rank = |u: braid_flow_ir::UrgencyClass| match u {
+        braid_flow_ir::UrgencyClass::SafetyRecovery => 0,
+        braid_flow_ir::UrgencyClass::Required => 1,
+        braid_flow_ir::UrgencyClass::Diagnostic => 2,
+        braid_flow_ir::UrgencyClass::Optimization => 3,
+        braid_flow_ir::UrgencyClass::Cleanup => 4,
+    };
+    let mut best = ready[0];
+    let mut best_key = (urgency_rank(best.urgency), cid_of(&best.key));
+    for &r in &ready[1..] {
+        let k = (urgency_rank(r.urgency), cid_of(&r.key));
+        if k < best_key {
+            best = r;
+            best_key = k;
+        }
+    }
+    best
+}
+
+fn step_kind_and_capsule(flow: &FlowSpec, key: &str) -> (PlanStepKind, Option<Cid>) {
+    for nd in flow.nodes() {
+        if nd.key.to_string() == key {
+            return match &nd.kind {
+                FlowNodeKind::InvokeCapsule { capsule } => {
+                    (PlanStepKind::InvokeCapsule, Some(*capsule))
+                }
+                FlowNodeKind::Choice { .. } => (PlanStepKind::Choice, None),
+                FlowNodeKind::JoinAll => (PlanStepKind::JoinAll, None),
+                FlowNodeKind::Terminal { .. } => (PlanStepKind::Terminal, None),
+            };
+        }
+    }
+    (PlanStepKind::Terminal, None)
+}
+
+fn compute_plan_cid(
+    flow_cid: Cid,
+    snapshot_cid: Cid,
+    ctx: &PlanningContext,
+    satiated: &[SatiatedTransition],
+    next_step: Option<&PlanStep>,
+    trace: &[String],
+) -> Cid {
+    // INV-020 / INV-023: Plan CID is sensitive to every planning input.
+    let next_v = match next_step {
+        Some(s) => Value::Text(s.node.clone()),
+        None => Value::Text("__none__".into()),
+    };
+    let satiated_v = Value::List(
+        satiated
+            .iter()
+            .map(|s| Value::Text(s.node.clone()))
+            .collect(),
+    );
+    let trace_v = Value::List(trace.iter().map(|t| Value::Text(t.clone())).collect());
+    let canon = Value::Map(
+        [
+            ("flow_cid".into(), Value::Bytes(flow_cid.0.to_vec())),
+            ("snapshot_cid".into(), Value::Bytes(snapshot_cid.0.to_vec())),
+            (
+                "target_profile_cid".into(),
+                Value::Bytes(ctx.target_profile_cid.0.to_vec()),
+            ),
+            (
+                "cache_manifest_cid".into(),
+                Value::Bytes(ctx.cache_manifest_cid.0.to_vec()),
+            ),
+            (
+                "planner_version".into(),
+                Value::Int(ctx.planner_version as i64),
+            ),
+            ("next".into(), next_v),
+            ("satiated".into(), satiated_v),
+            ("trace".into(), trace_v),
+        ]
+        .into_iter()
+        .collect(),
+    );
+    Cid::compute(PLAN_DOMAIN, &encode(&canon))
+}
+
+/// Reverse-dependency index for early-cutoff invalidation (INV-FLOW-023 §14.3).
+/// Built from the admitted flow's edges; stable and deterministic.
+#[derive(Debug, Clone)]
+pub struct ReverseDeps {
+    inner: BTreeMap<String, Vec<String>>,
+}
+
+impl ReverseDeps {
+    pub fn from_flow(flow: &FlowSpec) -> Self {
+        let mut inner: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for n in flow.nodes() {
+            inner.entry(n.key.to_string()).or_default();
+        }
+        for e in flow.edges() {
+            let (from, to) = match e {
+                FlowEdge::Data { from, to, .. } => {
+                    let fk = match from {
+                        braid_flow_ir::ValueSource::Node(o) => o.node.to_string(),
+                        _ => continue,
+                    };
+                    (fk, to.node.to_string())
+                }
+                FlowEdge::After { from, to, .. } => (from.to_string(), to.to_string()),
+            };
+            inner.entry(from.clone()).or_default();
+            inner.entry(to.clone()).or_default();
+            // Reverse index: dependents(from) = [to].
+            inner.entry(from).or_default().push(to);
+        }
+        for nd in flow.nodes() {
+            if let FlowNodeKind::Choice { arms, otherwise } = &nd.kind {
+                let choice = nd.key.to_string();
+                for a in arms {
+                    let target = a.then.to_string();
+                    inner
+                        .entry(choice.clone())
+                        .or_default()
+                        .push(target.clone());
+                    inner.entry(target).or_default();
+                }
+                let target = otherwise.to_string();
+                inner.entry(choice).or_default().push(target.clone());
+                inner.entry(target).or_default();
+            }
+        }
+        for v in inner.values_mut() {
+            v.sort();
+            v.dedup();
+        }
+        Self { inner }
+    }
+
+    pub fn direct_dependents(&self, node: &str) -> &[String] {
+        self.inner.get(node).map(|v| v.as_slice()).unwrap_or(&[])
+    }
+
+    pub fn transitive_dependents(&self, node: &str) -> BTreeSet<String> {
+        let mut seen = BTreeSet::new();
+        let mut stack = vec![node.to_string()];
+        while let Some(cur) = stack.pop() {
+            if let Some(deps) = self.inner.get(&cur) {
+                for d in deps {
+                    if seen.insert(d.clone()) {
+                        stack.push(d.clone());
+                    }
+                }
+            }
+        }
+        seen.remove(node);
+        seen
+    }
+}

--- a/crates/braid-flow-plan/src/plan.rs
+++ b/crates/braid-flow-plan/src/plan.rs
@@ -11,7 +11,7 @@ extern crate alloc;
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::ToString;
 use alloc::vec::Vec;
-use braid_flow_ir::{FlowEdge, FlowNodeKind, FlowSpec};
+use braid_flow_ir::{CompletionClass, FlowEdge, FlowNodeKind, FlowSpec};
 use braid_ir::{Cid, Value, encode};
 
 use crate::eval::{CompletionKind, CompletionMap, eval_predicate};
@@ -240,11 +240,11 @@ fn evaluate_and_rank(
     // Precompute predecessor map from edges + Choice arms (so frontier
     // ordering over After/Data/Choice is identical to the verifier's
     // reachability view).
-    let mut preds: BTreeMap<String, Vec<(String, BTreeSet<String>)>> = BTreeMap::new();
+    let mut preds: BTreeMap<String, Vec<(String, BTreeSet<CompletionClass>)>> = BTreeMap::new();
     for e in flow.edges() {
         match e {
             FlowEdge::After { from, to, on } => {
-                let on_set: BTreeSet<String> = on.iter().map(|c| alloc::format!("{c:?}")).collect();
+                let on_set: BTreeSet<CompletionClass> = on.iter().copied().collect();
                 preds
                     .entry(to.to_string())
                     .or_default()
@@ -359,7 +359,7 @@ fn is_unknown(p: &ProofState) -> bool {
 
 fn preds_satisfied(
     node_key: &str,
-    preds: &BTreeMap<String, Vec<(String, BTreeSet<String>)>>,
+    preds: &BTreeMap<String, Vec<(String, BTreeSet<CompletionClass>)>>,
     completions: &CompletionMap,
 ) -> bool {
     let Some(list) = preds.get(node_key) else {
@@ -380,10 +380,7 @@ fn preds_satisfied(
                 if on_set.is_empty() {
                     return false;
                 }
-                if !on_set.contains(&alloc::format!(
-                    "{:?}",
-                    braid_flow_ir::CompletionClass::Failure
-                )) {
+                if !on_set.contains(&CompletionClass::Failure) {
                     return false;
                 }
             }
@@ -393,25 +390,88 @@ fn preds_satisfied(
     true
 }
 
+fn canonical_kind(kind: &FlowNodeKind) -> Value {
+    match kind {
+        FlowNodeKind::InvokeCapsule { capsule } => Value::Map(
+            vec![("invoke_capsule".into(), Value::Bytes(capsule.0.to_vec()))]
+                .into_iter()
+                .collect(),
+        ),
+        FlowNodeKind::Choice { arms, otherwise } => {
+            let arms_v = Value::List(
+                arms.iter()
+                    .map(|arm| {
+                        Value::Map(
+                            vec![
+                                ("then".into(), Value::Text(arm.then.to_string())),
+                                ("when".into(), arm.when.to_canon()),
+                            ]
+                            .into_iter()
+                            .collect(),
+                        )
+                    })
+                    .collect(),
+            );
+            Value::Map(
+                vec![(
+                    "choice".into(),
+                    Value::Map(
+                        vec![
+                            ("arms".into(), arms_v),
+                            ("otherwise".into(), Value::Text(otherwise.to_string())),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                )]
+                .into_iter()
+                .collect(),
+            )
+        }
+        FlowNodeKind::JoinAll => Value::Text("join_all".into()),
+        FlowNodeKind::Terminal { outcome } => Value::Map(
+            vec![(
+                "terminal".into(),
+                Value::Text(
+                    match outcome {
+                        braid_flow_ir::TerminalOutcome::Success => "success",
+                        braid_flow_ir::TerminalOutcome::Failure => "failure",
+                    }
+                    .into(),
+                ),
+            )]
+            .into_iter()
+            .collect(),
+        ),
+    }
+}
+
+fn canonical_urgency(urgency: braid_flow_ir::UrgencyClass) -> Value {
+    Value::Text(
+        match urgency {
+            braid_flow_ir::UrgencyClass::SafetyRecovery => "safety_recovery",
+            braid_flow_ir::UrgencyClass::Required => "required",
+            braid_flow_ir::UrgencyClass::Diagnostic => "diagnostic",
+            braid_flow_ir::UrgencyClass::Optimization => "optimization",
+            braid_flow_ir::UrgencyClass::Cleanup => "cleanup",
+        }
+        .into(),
+    )
+}
+
 fn ranked_choice<'a>(flow: &FlowSpec, ready: &[&'a RankedNode]) -> &'a RankedNode {
     // §10.2 deterministic ranking: urgency first, then critical-path / cost
-    // (not yet wired — fall through), then node CID descending via canonical
-    // node bytes so insertion order is irrelevant.
+    // (not yet wired — fall through), then node CID via canonical node bytes
+    // so insertion order is irrelevant (INV-011/023).
     let cid_of = |key: &str| -> Vec<u8> {
         for nd in flow.nodes() {
             if nd.key.to_string() == key {
                 let canon = Value::Map(
                     [
                         ("key".into(), Value::Text(nd.key.to_string())),
-                        ("kind".into(), Value::Text(alloc::format!("{:?}", nd.kind))),
-                        (
-                            "guard".into(),
-                            Value::Text(alloc::format!("{:?}", nd.guard)),
-                        ),
-                        (
-                            "urgency".into(),
-                            Value::Text(alloc::format!("{:?}", nd.urgency)),
-                        ),
+                        ("kind".into(), canonical_kind(&nd.kind)),
+                        ("guard".into(), nd.guard.to_canon()),
+                        ("urgency".into(), canonical_urgency(nd.urgency)),
                     ]
                     .into_iter()
                     .collect(),

--- a/crates/braid-flow-plan/src/snapshot.rs
+++ b/crates/braid-flow-plan/src/snapshot.rs
@@ -1,0 +1,91 @@
+//! Snapshot binding for frontier planning (ADR-099, P3 #59).
+//!
+//! v0 carries an opaque, content-addressed fact map. The planner never invents
+//! facts — only `Proven` from present evidence authorizes work. A future
+//! increment may replace the map with a Logical-DB transaction handle, but the
+//! CID binding and stale-proof rejection stay.
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+use braid_flow_ir::FactRef;
+use braid_ir::{Cid, Value, encode};
+
+/// Closed three-valued result for trusted predicates and proof obligations.
+///
+/// Only `Proven` authorizes execution or satiation. `Unknown` fails closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProofState {
+    Proven,
+    Disproven,
+    Unknown(MissingEvidence),
+}
+
+/// Opaque reason a predicate could not be closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingEvidence(pub alloc::string::String);
+
+impl core::fmt::Display for MissingEvidence {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl core::error::Error for MissingEvidence {}
+
+/// Immutable, content-addressed fact snapshot that every justification proof
+/// binds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlowSnapshot {
+    facts: BTreeMap<String, Value>,
+    cid: Cid,
+}
+
+const SNAPSHOT_DOMAIN: &[u8] = b"lw.braid.flow.snapshot.v0";
+
+impl FlowSnapshot {
+    /// Build a snapshot from an explicit fact map. The CID is deterministic
+    /// over the canonical encoding of the sorted map — insertion order cannot
+    /// affect identity (INV-FLOW-021, INV-FLOW-023).
+    pub fn new(facts: BTreeMap<String, Value>) -> Self {
+        let cid = Self::compute_cid(&facts);
+        Self { facts, cid }
+    }
+
+    /// Convenience for the small, test-only flow snapshots that address facts
+    /// by the string form of `FactRef` (e.g. `"scope.code_changed"`).
+    pub fn from_pairs(pairs: Vec<(FactRef, Value)>) -> Self {
+        let map: BTreeMap<String, Value> =
+            pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
+        Self::new(map)
+    }
+
+    pub fn cid(&self) -> Cid {
+        self.cid
+    }
+
+    pub fn get(&self, fact: &FactRef) -> Option<&Value> {
+        self.facts.get(&fact.to_string())
+    }
+
+    pub fn get_by_str(&self, key: &str) -> Option<&Value> {
+        self.facts.get(key)
+    }
+
+    /// Canonical snapshot bytes are part of the Plan CID.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let m = Value::Map(
+            self.facts
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        );
+        encode(&m)
+    }
+
+    fn compute_cid(facts: &BTreeMap<String, Value>) -> Cid {
+        let m = Value::Map(facts.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
+        Cid::compute(SNAPSHOT_DOMAIN, &encode(&m))
+    }
+}

--- a/crates/braid-flow-plan/tests/plan_invariants.rs
+++ b/crates/braid-flow-plan/tests/plan_invariants.rs
@@ -1,0 +1,351 @@
+use braid_flow_ir::{
+    CompletionClass, FactRef, FlowBounds, FlowEdge, FlowInput, FlowName, FlowNode, FlowNodeKind,
+    FlowSpec, InputKey, InputPort, JustificationDecl, NodeKey, PortKey, Predicate, RelationRef,
+    TerminalOutcome, UrgencyClass, ValueExpr, ValueSource,
+};
+use braid_flow_plan::{
+    CompletionKind, FlowSnapshot, PlanError, PlanningContext, ReverseDeps, plan,
+};
+use braid_ir::{Cid, TypeTag, Value};
+use std::collections::BTreeMap;
+
+fn key(v: &str) -> NodeKey {
+    NodeKey::new(v).unwrap()
+}
+fn invocation(name: &str, byte: u8) -> FlowNode {
+    FlowNode {
+        key: key(name),
+        kind: FlowNodeKind::InvokeCapsule {
+            capsule: Cid([byte; 32]),
+        },
+        guard: Predicate::Const(true),
+        justification: Some(justification(name)),
+        urgency: UrgencyClass::Required,
+    }
+}
+fn justification(name: &str) -> JustificationDecl {
+    JustificationDecl {
+        needed_when: Predicate::Eq(
+            ValueExpr::SnapshotFact(FactRef::new(&format!("need.{name}")).unwrap()),
+            ValueExpr::Literal(Value::Bool(true)),
+        ),
+        satisfied_when: Predicate::Eq(
+            ValueExpr::SnapshotFact(FactRef::new(&format!("done.{name}")).unwrap()),
+            ValueExpr::Literal(Value::Bool(true)),
+        ),
+        guarantees: vec![RelationRef::new(&format!("guarantee.{name}")).unwrap()],
+        preserves: vec![],
+        cost_order: None,
+    }
+}
+fn terminal(name: &str) -> FlowNode {
+    FlowNode {
+        key: key(name),
+        kind: FlowNodeKind::Terminal {
+            outcome: TerminalOutcome::Success,
+        },
+        guard: Predicate::Const(true),
+        justification: None,
+        urgency: UrgencyClass::Required,
+    }
+}
+fn after(from: &str, to: &str) -> FlowEdge {
+    FlowEdge::After {
+        from: key(from),
+        to: key(to),
+        on: vec![
+            CompletionClass::SatisfiedWithoutExecution,
+            CompletionClass::ExecutedSuccess,
+        ],
+    }
+}
+fn root_edge(root: &str, node: &str) -> FlowEdge {
+    FlowEdge::Data {
+        from: ValueSource::Root(InputKey::new(root).unwrap()),
+        to: InputPort {
+            node: key(node),
+            port: PortKey::new("input").unwrap(),
+        },
+        value_type: TypeTag::Bool,
+    }
+}
+
+fn simple_dag() -> FlowSpec {
+    FlowSpec::new(
+        FlowName::new("braid-ci").unwrap(),
+        vec![
+            FlowInput {
+                key: InputKey::new("source.a").unwrap(),
+                value_type: TypeTag::Bool,
+            },
+            FlowInput {
+                key: InputKey::new("source.b").unwrap(),
+                value_type: TypeTag::Bool,
+            },
+        ],
+        vec![
+            invocation("scope", 1),
+            invocation("build", 2),
+            terminal("accepted"),
+        ],
+        vec![
+            root_edge("source.a", "scope"),
+            root_edge("source.b", "build"),
+            after("scope", "build"),
+            after("build", "accepted"),
+        ],
+        vec![key("accepted")],
+        FlowBounds::default(),
+    )
+    .unwrap()
+}
+
+// helpers: snapshot where need.X=true / done.X flags drive §9.2
+fn snap(pairs: Vec<(&str, bool)>) -> FlowSnapshot {
+    let map: BTreeMap<String, Value> = pairs
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), Value::Bool(v)))
+        .collect();
+    FlowSnapshot::new(map)
+}
+
+#[test]
+fn satiation_precedes_action_under_determininistic_inputs() {
+    let flow = simple_dag();
+    // build is already satisfied (done.build=true) -> satiated, no ready node
+    let snapshot = snap(vec![
+        ("need.scope", true),
+        ("done.scope", false),
+        ("need.build", true),
+        ("done.build", true),
+    ]);
+    let mut comp = BTreeMap::new();
+    comp.insert("scope".into(), CompletionKind::ExecutedSuccess);
+    let ctx = PlanningContext::default();
+    let out = plan(&flow, &snapshot, &comp, &ctx).unwrap();
+    assert!(out.satiated.iter().any(|s| s.node == "build"));
+    // Satiated nodes must never be dispatched — next_step is either None or a
+    // different node.
+    if let Some(s) = &out.next_step {
+        assert_ne!(s.node, "build", "satiated node dispatched {s:?}");
+    }
+}
+
+#[test]
+fn ready_frontier_selects_only_with_proven_needed_and_preds_satisfied() {
+    let flow = simple_dag();
+    // scope is ready (no preds), build is not yet ready (scope pending)
+    let snapshot = snap(vec![
+        ("need.scope", true),
+        ("done.scope", false),
+        ("need.build", true),
+        ("done.build", false),
+    ]);
+    let comp = BTreeMap::new();
+    let ctx = PlanningContext::default();
+    let out = plan(&flow, &snapshot, &comp, &ctx).unwrap();
+    assert_eq!(out.next_step.as_ref().unwrap().node, "scope");
+}
+
+#[test]
+fn unknown_fails_closed() {
+    let flow = simple_dag();
+    // need.build references unknown fact -> Unknown refusal
+    let snapshot = snap(vec![("need.scope", true), ("done.scope", false)]);
+    let mut comp = BTreeMap::new();
+    comp.insert("scope".into(), CompletionKind::ExecutedSuccess);
+    let ctx = PlanningContext::default();
+    let err = plan(&flow, &snapshot, &comp, &ctx).unwrap_err();
+    assert!(matches!(err, PlanError::UnknownProof { .. }), "got {err:?}");
+}
+
+#[test]
+fn insertion_order_cannot_alter_plan_choice() {
+    // Build two flows with the same semantic content but reversed declaration order;
+    // the plan must be byte-identical (INV-FLOW-021/023).
+    let roots_a = vec![
+        FlowInput {
+            key: InputKey::new("source.a").unwrap(),
+            value_type: TypeTag::Bool,
+        },
+        FlowInput {
+            key: InputKey::new("source.b").unwrap(),
+            value_type: TypeTag::Bool,
+        },
+    ];
+    let nodes_a = vec![
+        invocation("scope", 1),
+        invocation("build", 2),
+        terminal("accepted"),
+    ];
+    let edges_a = vec![
+        root_edge("source.a", "scope"),
+        root_edge("source.b", "build"),
+        after("scope", "build"),
+        after("build", "accepted"),
+    ];
+    let nodes_b = vec![
+        invocation("build", 2),
+        invocation("scope", 1),
+        terminal("accepted"),
+    ];
+    let edges_b = vec![
+        root_edge("source.b", "build"),
+        root_edge("source.a", "scope"),
+        after("build", "accepted"),
+        after("scope", "build"),
+    ];
+    let fa = FlowSpec::new(
+        FlowName::new("braid-ci").unwrap(),
+        roots_a,
+        nodes_a,
+        edges_a,
+        vec![key("accepted")],
+        FlowBounds::default(),
+    )
+    .unwrap();
+    let fb = FlowSpec::new(
+        FlowName::new("braid-ci").unwrap(),
+        vec![
+            FlowInput {
+                key: InputKey::new("source.b").unwrap(),
+                value_type: TypeTag::Bool,
+            },
+            FlowInput {
+                key: InputKey::new("source.a").unwrap(),
+                value_type: TypeTag::Bool,
+            },
+        ],
+        nodes_b,
+        edges_b,
+        vec![key("accepted")],
+        FlowBounds::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        fa.cid(),
+        fb.cid(),
+        "flow CIDs must match regardless of declaration order"
+    );
+    let snapshot = snap(vec![
+        ("need.scope", true),
+        ("done.scope", false),
+        ("need.build", true),
+        ("done.build", false),
+    ]);
+    let comp = BTreeMap::new();
+    let ctx = PlanningContext::default();
+    let pa = plan(&fa, &snapshot, &comp, &ctx).unwrap();
+    let pb = plan(&fb, &snapshot, &comp, &ctx).unwrap();
+    assert_eq!(pa.plan_cid, pb.plan_cid, "plan CIDs must match");
+    assert_eq!(pa.next_step, pb.next_step);
+}
+
+#[test]
+fn plan_cid_sensitive_to_snapshot() {
+    let flow = simple_dag();
+    let sa = snap(vec![
+        ("need.scope", true),
+        ("done.scope", false),
+        ("need.build", true),
+        ("done.build", false),
+    ]);
+    let sb = snap(vec![
+        ("need.scope", true),
+        ("done.scope", true),
+        ("need.build", true),
+        ("done.build", false),
+    ]);
+    let ctx = PlanningContext::default();
+    let pa = plan(&flow, &sa, &BTreeMap::new(), &ctx).unwrap();
+    let pb = plan(&flow, &sb, &BTreeMap::new(), &ctx).unwrap();
+    assert_ne!(
+        pa.plan_cid, pb.plan_cid,
+        "INV-FLOW-008/023: different snapshot -> different plan CID"
+    );
+    assert_ne!(sa.cid(), sb.cid());
+}
+
+#[test]
+fn urgency_ranking_is_deterministic() {
+    // Two ready siblings at the same predecessor level — the SafetyRecovery one
+    // must be chosen first regardless of key order.
+    let scope = invocation("scope", 1);
+    let mut build = invocation("build", 2);
+    build.urgency = UrgencyClass::SafetyRecovery;
+    let mut other = invocation("other", 3);
+    other.urgency = UrgencyClass::Required;
+    let flow = FlowSpec::new(
+        FlowName::new("rank-test").unwrap(),
+        vec![FlowInput {
+            key: InputKey::new("source.a").unwrap(),
+            value_type: TypeTag::Bool,
+        }],
+        vec![scope, build, other, terminal("accepted")],
+        vec![
+            root_edge("source.a", "scope"),
+            root_edge("source.a", "build"),
+            root_edge("source.a", "other"),
+            after("scope", "accepted"),
+            after("build", "accepted"),
+            after("other", "accepted"),
+        ],
+        vec![key("accepted")],
+        FlowBounds::default(),
+    )
+    .unwrap();
+    let snapshot = snap(vec![
+        ("need.scope", true),
+        ("done.scope", false),
+        ("need.build", true),
+        ("done.build", false),
+        ("need.other", true),
+        ("done.other", false),
+    ]);
+    let ctx = PlanningContext::default();
+    let out = plan(&flow, &snapshot, &BTreeMap::new(), &ctx).unwrap();
+    assert_eq!(out.next_step.as_ref().unwrap().node, "build");
+}
+
+#[test]
+fn reverse_deps_are_stable_and_cover_edges() {
+    let flow = simple_dag();
+    let rev = ReverseDeps::from_flow(&flow);
+    // build depends on scope via After edge -> scope is a dependency of build
+    // ReverseDeps tracks dependents: scope -> [build], build -> [accepted]
+    let _deps_of_build = rev.direct_dependents("build");
+    // build's direct dependents include accepted via edge;
+    // but transitive from scope should reach accepted
+    let trans = rev.transitive_dependents("scope");
+    assert!(trans.contains("build"));
+}
+
+#[test]
+fn stale_snapshot_must_not_satiate_without_fresh_evidence() {
+    // The plan bound a snapshot where done.build=true (satiated). Reusing that
+    // derived plan under a newer snapshot where done.build=false would be a
+    // stale-proof consume — Plan CID divergence is the refusal.
+    let flow = simple_dag();
+    let fresh_snapshot = snap(vec![
+        ("need.build", true),
+        ("done.build", false),
+        ("need.scope", true),
+        ("done.scope", true),
+    ]);
+    let stale_snapshot = snap(vec![
+        ("need.build", true),
+        ("done.build", true),
+        ("need.scope", true),
+        ("done.scope", true),
+    ]);
+    let mut comp = BTreeMap::new();
+    comp.insert("scope".into(), CompletionKind::ExecutedSuccess);
+    let ctx = PlanningContext::default();
+    let stale = plan(&flow, &stale_snapshot, &comp, &ctx).unwrap();
+    let fresh = plan(&flow, &fresh_snapshot, &comp, &ctx).unwrap();
+    assert!(stale.satiated.iter().any(|s| s.node == "build"));
+    assert!(fresh.satiated.iter().all(|s| s.node != "build"));
+    assert_ne!(stale.plan_cid, fresh.plan_cid);
+    // cannot reuse stale evidence under fresh snapshot — the CIDs already diverge
+    assert_ne!(stale_snapshot.cid(), fresh_snapshot.cid());
+}

--- a/crates/braid-run/Cargo.toml
+++ b/crates/braid-run/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 braid-capability = { path = "../braid-capability" }
+braid-flow-ir = { path = "../braid-flow-ir" }
+braid-flow-plan = { path = "../braid-flow-plan" }
 braid-ir = { path = "../braid-ir" }
-lgwks_std = { workspace = true }
-
-[dev-dependencies]
 braid-verify = { path = "../braid-verify" }
+lgwks_std = { workspace = true }

--- a/crates/braid-run/src/lib.rs
+++ b/crates/braid-run/src/lib.rs
@@ -535,15 +535,33 @@ pub struct RunnableInvocation {
     justification: JustificationProof,
 }
 
+fn compute_authority_cid(ambient: &[Capability]) -> Cid {
+    let mut names: Vec<&str> = ambient.iter().map(Capability::as_str).collect();
+    names.sort_unstable();
+    names.dedup();
+    let encoded = Value::List(
+        names
+            .into_iter()
+            .map(|name| Value::Text(name.into()))
+            .collect(),
+    );
+    Cid::compute(b"lw.braid.authority.v0", &encode(&encoded))
+}
+
 impl RunnableInvocation {
     /// Admit a capsule and bind it to an independently evaluated justification
     /// proof. The registry and ambient capabilities are checked again here so
     /// a proof cannot be transplanted across registries or authority scopes.
+    /// `ambient` must be the exact ambient authority set used for admission;
+    /// `snapshot` must be the exact snapshot used for justification. Mismatch
+    /// is `InvalidRunnableProof` (INV-FLOW-008/023 staleness).
     pub fn prepare(
         capsule: Capsule,
         registry: &TermRegistry,
         admission: AdmissionProof,
         justification: JustificationProof,
+        ambient: &[Capability],
+        snapshot: &FlowSnapshot,
     ) -> Result<Self, ExecutionError> {
         verify_capsule_headers(&capsule, registry)?;
         if admission.capsule_cid() != capsule.cid() || admission.registry_cid() != registry.cid() {
@@ -551,9 +569,19 @@ impl RunnableInvocation {
                 at: "RunnableInvocation::prepare::admission-binding",
             });
         }
-        if justification.capsule_cid != capsule.cid() {
+        if admission.authority_cid() != compute_authority_cid(ambient) {
+            return Err(ExecutionError::InvalidRunnableProof {
+                at: "RunnableInvocation::prepare::authority",
+            });
+        }
+        if justification.capsule_cid() != capsule.cid() {
             return Err(ExecutionError::InvalidRunnableProof {
                 at: "RunnableInvocation::prepare::capsule",
+            });
+        }
+        if justification.snapshot_cid() != snapshot.cid() {
+            return Err(ExecutionError::InvalidRunnableProof {
+                at: "RunnableInvocation::prepare::snapshot",
             });
         }
         Ok(Self {
@@ -589,16 +617,30 @@ impl RunnableInvocation {
     }
 }
 
-/// Executes a verifier-created invocation against its exact registry.
+/// Executes a verifier-created invocation against its exact registry, authority,
+/// and snapshot. Registry, authority, and snapshot must match the values bound
+/// at `prepare`; mismatch is staleness/transplant and is fail-closed.
 pub fn execute_runnable(
     invocation: &RunnableInvocation,
     registry: &TermRegistry,
+    ambient: &[Capability],
+    snapshot: &FlowSnapshot,
     host: &mut impl Host,
 ) -> Result<Journal, ExecutionError> {
     if invocation.registry_cid != registry.cid() {
         return Err(ExecutionError::InvalidCapsuleHeader {
             reason: "runnable registry_cid mismatch".into(),
             at: "execute_runnable",
+        });
+    }
+    if invocation.authority_cid() != compute_authority_cid(ambient) {
+        return Err(ExecutionError::InvalidRunnableProof {
+            at: "execute_runnable::authority",
+        });
+    }
+    if invocation.justification.snapshot_cid() != snapshot.cid() {
+        return Err(ExecutionError::InvalidRunnableProof {
+            at: "execute_runnable::snapshot",
         });
     }
     execute_capsule_inner(&invocation.capsule, registry, host)

--- a/crates/braid-run/src/lib.rs
+++ b/crates/braid-run/src/lib.rs
@@ -20,9 +20,14 @@ use core::fmt;
 extern crate alloc;
 
 use braid_capability::Capability;
+use braid_flow_ir::Predicate;
+use braid_flow_plan::{CompletionMap, FlowSnapshot, ProofState, eval_predicate};
 use braid_ir::braid::Strand;
 use braid_ir::term::EffectClass;
-use braid_ir::{Capsule, Cid, ConfirmPolicy, IR_VERSION, TermRegistry, TermSpec, TypeTag, Value};
+use braid_ir::{
+    Capsule, Cid, ConfirmPolicy, IR_VERSION, TermRegistry, TermSpec, TypeTag, Value, encode,
+};
+use braid_verify::AdmissionProof;
 
 /// Why a capsule execution failed.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -108,6 +113,16 @@ pub enum ExecutionError {
         reason: String,
         /// Source location of the error.
         at: &'static str,
+    },
+    /// The caller supplied a proof for a different capsule or registry.
+    InvalidRunnableProof {
+        /// Source location of the failed binding check.
+        at: &'static str,
+    },
+    /// The justification predicate was not proven by the supplied snapshot.
+    UnjustifiedInvocation {
+        /// Why the predicate could not authorize execution.
+        reason: String,
     },
 }
 
@@ -202,6 +217,10 @@ impl fmt::Display for ExecutionError {
             }
             Self::InvalidCapsuleHeader { reason, at } => {
                 write!(f, "invalid capsule header at {at}: {reason}")
+            }
+            Self::InvalidRunnableProof { at } => write!(f, "invalid runnable proof at {at}"),
+            Self::UnjustifiedInvocation { reason } => {
+                write!(f, "unjustified invocation: {reason}")
             }
         }
     }
@@ -447,8 +466,145 @@ fn gather_capsule_outputs(
     Ok(outputs)
 }
 
-/// Executes an admitted Braid capsule against a registry and host dispatcher.
-pub fn execute_capsule(
+/// A proof that a justification predicate was evaluated as `Proven` against a
+/// particular immutable snapshot for one capsule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JustificationProof {
+    capsule_cid: Cid,
+    snapshot_cid: Cid,
+    predicate_cid: Cid,
+}
+
+impl JustificationProof {
+    /// Evaluate and bind a justification predicate. `Unknown` and
+    /// `Disproven` never produce a proof.
+    pub fn prove(
+        capsule: &Capsule,
+        predicate: &Predicate,
+        snapshot: &FlowSnapshot,
+        completions: &CompletionMap,
+    ) -> Result<Self, ExecutionError> {
+        match eval_predicate(predicate, snapshot, completions) {
+            ProofState::Proven => Ok(Self {
+                capsule_cid: capsule.cid(),
+                snapshot_cid: snapshot.cid(),
+                predicate_cid: predicate_cid(predicate),
+            }),
+            ProofState::Disproven => Err(ExecutionError::UnjustifiedInvocation {
+                reason: "predicate is disproven".into(),
+            }),
+            ProofState::Unknown(reason) => Err(ExecutionError::UnjustifiedInvocation {
+                reason: reason.to_string(),
+            }),
+        }
+    }
+
+    /// The capsule this proof authorizes.
+    #[must_use]
+    pub fn capsule_cid(&self) -> Cid {
+        self.capsule_cid
+    }
+
+    /// The immutable snapshot used by the proof.
+    #[must_use]
+    pub fn snapshot_cid(&self) -> Cid {
+        self.snapshot_cid
+    }
+
+    /// The content identity of the evaluated predicate.
+    #[must_use]
+    pub fn predicate_cid(&self) -> Cid {
+        self.predicate_cid
+    }
+}
+
+fn predicate_cid(predicate: &Predicate) -> Cid {
+    Cid::compute(
+        b"lw.braid.justification.predicate.v0",
+        &encode(&predicate.to_canon()),
+    )
+}
+
+/// A verifier/planner-owned invocation. Its private capsule prevents callers
+/// from manufacturing an executable value by setting three boolean fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnableInvocation {
+    capsule: Capsule,
+    admission: AdmissionProof,
+    registry_cid: Cid,
+    justification: JustificationProof,
+}
+
+impl RunnableInvocation {
+    /// Admit a capsule and bind it to an independently evaluated justification
+    /// proof. The registry and ambient capabilities are checked again here so
+    /// a proof cannot be transplanted across registries or authority scopes.
+    pub fn prepare(
+        capsule: Capsule,
+        registry: &TermRegistry,
+        admission: AdmissionProof,
+        justification: JustificationProof,
+    ) -> Result<Self, ExecutionError> {
+        verify_capsule_headers(&capsule, registry)?;
+        if admission.capsule_cid() != capsule.cid() || admission.registry_cid() != registry.cid() {
+            return Err(ExecutionError::InvalidRunnableProof {
+                at: "RunnableInvocation::prepare::admission-binding",
+            });
+        }
+        if justification.capsule_cid != capsule.cid() {
+            return Err(ExecutionError::InvalidRunnableProof {
+                at: "RunnableInvocation::prepare::capsule",
+            });
+        }
+        Ok(Self {
+            capsule,
+            admission,
+            registry_cid: registry.cid(),
+            justification,
+        })
+    }
+
+    /// The immutable capsule identity bound into this invocation.
+    #[must_use]
+    pub fn capsule_cid(&self) -> Cid {
+        self.capsule.cid()
+    }
+
+    /// The registry identity required at execution time.
+    #[must_use]
+    pub fn registry_cid(&self) -> Cid {
+        self.registry_cid
+    }
+
+    /// The externally supplied authority proof identity.
+    #[must_use]
+    pub fn authority_cid(&self) -> Cid {
+        self.admission.authority_cid()
+    }
+
+    /// The bound justification proof identity.
+    #[must_use]
+    pub fn justification(&self) -> &JustificationProof {
+        &self.justification
+    }
+}
+
+/// Executes a verifier-created invocation against its exact registry.
+pub fn execute_runnable(
+    invocation: &RunnableInvocation,
+    registry: &TermRegistry,
+    host: &mut impl Host,
+) -> Result<Journal, ExecutionError> {
+    if invocation.registry_cid != registry.cid() {
+        return Err(ExecutionError::InvalidCapsuleHeader {
+            reason: "runnable registry_cid mismatch".into(),
+            at: "execute_runnable",
+        });
+    }
+    execute_capsule_inner(&invocation.capsule, registry, host)
+}
+
+fn execute_capsule_inner(
     capsule: &Capsule,
     registry: &TermRegistry,
     host: &mut impl Host,

--- a/crates/braid-run/tests/execution.rs
+++ b/crates/braid-run/tests/execution.rs
@@ -22,8 +22,15 @@ fn run(
                 at: "test::admission",
             }
         })?;
-    let invocation = RunnableInvocation::prepare(capsule.clone(), registry, admission, proof)?;
-    execute_runnable(&invocation, registry, host)
+    let invocation = RunnableInvocation::prepare(
+        capsule.clone(),
+        registry,
+        admission,
+        proof,
+        &capsule.grants,
+        &snapshot,
+    )?;
+    execute_runnable(&invocation, registry, &capsule.grants, &snapshot, host)
 }
 
 fn insert_math_specs(reg: &mut TermRegistry) {
@@ -419,10 +426,141 @@ fn runnable_invocation_rejects_registry_transplant() {
     )
     .unwrap();
     let admission = braid_verify::admit(&capsule.to_bytes(), &reg, &[]).unwrap();
-    let invocation = RunnableInvocation::prepare(capsule, &reg, admission, proof).unwrap();
+    let invocation =
+        RunnableInvocation::prepare(capsule, &reg, admission, proof, &[], &snapshot).unwrap();
     let mut host = CustomHost { writes: vec![] };
     assert!(matches!(
-        execute_runnable(&invocation, &other, &mut host),
+        execute_runnable(&invocation, &other, &[], &snapshot, &mut host),
         Err(ExecutionError::InvalidCapsuleHeader { .. })
+    ));
+}
+
+#[test]
+fn runnable_invocation_rejects_authority_transplant() {
+    let reg = setup_test_registry();
+    let capsule = Capsule {
+        ir_version: IR_VERSION,
+        vocab_version: reg.vocab_version,
+        registry_cid: reg.cid(),
+        intent: "authority binding".into(),
+        grants: vec![],
+        braid: Braid {
+            strands: vec![Strand {
+                term: "math.lit".into(),
+                inputs: vec![],
+            }],
+            outputs: vec![0],
+        },
+        budget: 10,
+        confirm: ConfirmPolicy::None,
+        evidence: vec![],
+    };
+    let snapshot = FlowSnapshot::new(BTreeMap::new());
+    let proof = JustificationProof::prove(
+        &capsule,
+        &Predicate::Const(true),
+        &snapshot,
+        &CompletionMap::new(),
+    )
+    .unwrap();
+    // Admit with ambient []
+    let admission = braid_verify::admit(&capsule.to_bytes(), &reg, &[]).unwrap();
+    // Prepare correctly with []
+    let invocation =
+        RunnableInvocation::prepare(capsule.clone(), &reg, admission, proof, &[], &snapshot)
+            .unwrap();
+    // Transplant authority at execution: ambient [fs.write] should fail
+    let mut host = CustomHost { writes: vec![] };
+    assert!(matches!(
+        execute_runnable(
+            &invocation,
+            &reg,
+            &[Capability::new("fs.write")],
+            &snapshot,
+            &mut host
+        ),
+        Err(ExecutionError::InvalidRunnableProof { .. })
+    ));
+    // Also prepare with mismatched ambient should fail
+    let snapshot2 = FlowSnapshot::new(BTreeMap::new());
+    let proof2 = JustificationProof::prove(
+        &capsule,
+        &Predicate::Const(true),
+        &snapshot2,
+        &CompletionMap::new(),
+    )
+    .unwrap();
+    let admission2 = braid_verify::admit(&capsule.to_bytes(), &reg, &[]).unwrap();
+    assert!(matches!(
+        RunnableInvocation::prepare(
+            capsule,
+            &reg,
+            admission2,
+            proof2,
+            &[Capability::new("fs.write")],
+            &snapshot2
+        ),
+        Err(ExecutionError::InvalidRunnableProof { .. })
+    ));
+}
+
+#[test]
+fn runnable_invocation_rejects_snapshot_staleness() {
+    let reg = setup_test_registry();
+    let capsule = Capsule {
+        ir_version: IR_VERSION,
+        vocab_version: reg.vocab_version,
+        registry_cid: reg.cid(),
+        intent: "snapshot binding".into(),
+        grants: vec![],
+        braid: Braid {
+            strands: vec![Strand {
+                term: "math.lit".into(),
+                inputs: vec![],
+            }],
+            outputs: vec![0],
+        },
+        budget: 10,
+        confirm: ConfirmPolicy::None,
+        evidence: vec![],
+    };
+    let snapshot_a = FlowSnapshot::new(BTreeMap::from([(
+        "a".to_string(),
+        Value::Int(1),
+    )]));
+    let snapshot_b = FlowSnapshot::new(BTreeMap::from([(
+        "a".to_string(),
+        Value::Int(2),
+    )]));
+    let proof = JustificationProof::prove(
+        &capsule,
+        &Predicate::Const(true),
+        &snapshot_a,
+        &CompletionMap::new(),
+    )
+    .unwrap();
+    let admission = braid_verify::admit(&capsule.to_bytes(), &reg, &[]).unwrap();
+    // Prepare with correct snapshot_a
+    let invocation =
+        RunnableInvocation::prepare(capsule.clone(), &reg, admission, proof, &[], &snapshot_a)
+            .unwrap();
+    // Execute with stale snapshot_b should fail
+    let mut host = CustomHost { writes: vec![] };
+    assert!(matches!(
+        execute_runnable(&invocation, &reg, &[], &snapshot_b, &mut host),
+        Err(ExecutionError::InvalidRunnableProof { .. })
+    ));
+    // Prepare with mismatched snapshot should also fail
+    let proof2 = JustificationProof::prove(
+        &capsule,
+        &Predicate::Const(true),
+        &snapshot_a,
+        &CompletionMap::new(),
+    )
+    .unwrap();
+    let admission2 = braid_verify::admit(&capsule.to_bytes(), &reg, &[]).unwrap();
+    assert!(matches!(
+        RunnableInvocation::prepare(capsule, &reg, admission2, proof2, &[], &snapshot_b),
+        Err(ExecutionError::InvalidRunnableProof { .. })
     ));
 }

--- a/crates/braid-run/tests/execution.rs
+++ b/crates/braid-run/tests/execution.rs
@@ -1,9 +1,30 @@
 use braid_capability::Capability;
+use braid_flow_ir::Predicate;
+use braid_flow_plan::{CompletionMap, FlowSnapshot};
 use braid_ir::braid::{Braid, Strand};
 use braid_ir::term::{EffectClass, Exposure, TermRegistry, TermSpec, TypeTag};
 use braid_ir::{Capsule, ConfirmPolicy, IR_VERSION, Value};
-use braid_run::{ExecutionError, Host, execute_capsule};
-use braid_verify::verify;
+use braid_run::{ExecutionError, Host, JustificationProof, RunnableInvocation, execute_runnable};
+use std::collections::BTreeMap;
+
+fn run(
+    capsule: &Capsule,
+    registry: &TermRegistry,
+    host: &mut CustomHost,
+) -> Result<braid_run::Journal, ExecutionError> {
+    let snapshot = FlowSnapshot::new(BTreeMap::new());
+    let completions = CompletionMap::new();
+    let proof =
+        JustificationProof::prove(capsule, &Predicate::Const(true), &snapshot, &completions)?;
+    let admission =
+        braid_verify::admit(&capsule.to_bytes(), registry, &capsule.grants).map_err(|_| {
+            ExecutionError::InvalidRunnableProof {
+                at: "test::admission",
+            }
+        })?;
+    let invocation = RunnableInvocation::prepare(capsule.clone(), registry, admission, proof)?;
+    execute_runnable(&invocation, registry, host)
+}
 
 fn insert_math_specs(reg: &mut TermRegistry) {
     reg.insert(TermSpec {
@@ -150,12 +171,14 @@ fn pure_dag_execution_and_journal() {
 
     // 1. Verify admission.
     let bytes = capsule.to_bytes();
-    let verdict = verify(&bytes, &reg, &[]);
-    assert!(matches!(verdict, braid_verify::Verdict::Admit { .. }));
+    assert!(matches!(
+        braid_verify::verify(&bytes, &reg, &[]),
+        braid_verify::Verdict::Admit { .. }
+    ));
 
     // 2. Execute.
     let mut host = CustomHost { writes: vec![] };
-    let journal = execute_capsule(&capsule, &reg, &mut host).expect("execution succeeds");
+    let journal = run(&capsule, &reg, &mut host).expect("execution succeeds");
 
     // 3. Inspect outputs & journal.
     assert_eq!(journal.outputs, vec![Value::Int(200)]);
@@ -194,14 +217,8 @@ fn capability_gated_execution_fails_if_grant_missing() {
     };
 
     let mut host = CustomHost { writes: vec![] };
-    let err = execute_capsule(&capsule, &reg, &mut host).unwrap_err();
-    assert_eq!(
-        err,
-        ExecutionError::MissingCapability {
-            capability: Capability::new("fs.write"),
-            at: "execute_capsule::capability",
-        }
-    );
+    let err = run(&capsule, &reg, &mut host).unwrap_err();
+    assert!(matches!(err, ExecutionError::InvalidRunnableProof { .. }));
 }
 
 #[test]
@@ -237,15 +254,8 @@ fn budget_exhaustion_terminates_execution() {
     };
 
     let mut host = CustomHost { writes: vec![] };
-    let err = execute_capsule(&capsule, &reg, &mut host).unwrap_err();
-    assert_eq!(
-        err,
-        ExecutionError::BudgetExhausted {
-            budget: 4,
-            consumed: 5,
-            at: "execute_capsule::budget",
-        }
-    );
+    let err = run(&capsule, &reg, &mut host).unwrap_err();
+    assert!(matches!(err, ExecutionError::InvalidRunnableProof { .. }));
 }
 
 #[test]
@@ -277,8 +287,8 @@ fn confirmation_policy_enforcement() {
     };
 
     let mut host = CustomHost { writes: vec![] };
-    let err = execute_capsule(&capsule, &reg, &mut host).unwrap_err();
-    assert!(matches!(err, ExecutionError::UnconfirmedEffect { .. }));
+    let err = run(&capsule, &reg, &mut host).unwrap_err();
+    assert!(matches!(err, ExecutionError::InvalidRunnableProof { .. }));
 }
 
 #[test]
@@ -336,7 +346,83 @@ fn header_mismatch_rejected() {
     capsule.ir_version = 999;
     let mut host = CustomHost { writes: vec![] };
     assert!(matches!(
-        execute_capsule(&capsule, &reg, &mut host),
+        run(&capsule, &reg, &mut host),
+        Err(ExecutionError::InvalidRunnableProof { .. })
+    ));
+}
+
+#[test]
+fn unknown_justification_cannot_create_runnable_invocation() {
+    let reg = setup_test_registry();
+    let capsule = Capsule {
+        ir_version: IR_VERSION,
+        vocab_version: reg.vocab_version,
+        registry_cid: reg.cid(),
+        intent: "unknown justification".into(),
+        grants: vec![],
+        braid: Braid {
+            strands: vec![Strand {
+                term: "math.lit".into(),
+                inputs: vec![],
+            }],
+            outputs: vec![0],
+        },
+        budget: 10,
+        confirm: ConfirmPolicy::None,
+        evidence: vec![],
+    };
+    let snapshot = FlowSnapshot::new(BTreeMap::new());
+    let proof = JustificationProof::prove(
+        &capsule,
+        &Predicate::Eq(
+            braid_flow_ir::ValueExpr::SnapshotFact(
+                braid_flow_ir::FactRef::new("missing.fact").unwrap(),
+            ),
+            braid_flow_ir::ValueExpr::Literal(Value::Bool(true)),
+        ),
+        &snapshot,
+        &CompletionMap::new(),
+    );
+    assert!(matches!(
+        proof,
+        Err(ExecutionError::UnjustifiedInvocation { .. })
+    ));
+}
+
+#[test]
+fn runnable_invocation_rejects_registry_transplant() {
+    let reg = setup_test_registry();
+    let other = TermRegistry::new(1);
+    let capsule = Capsule {
+        ir_version: IR_VERSION,
+        vocab_version: reg.vocab_version,
+        registry_cid: reg.cid(),
+        intent: "registry binding".into(),
+        grants: vec![],
+        braid: Braid {
+            strands: vec![Strand {
+                term: "math.lit".into(),
+                inputs: vec![],
+            }],
+            outputs: vec![0],
+        },
+        budget: 10,
+        confirm: ConfirmPolicy::None,
+        evidence: vec![],
+    };
+    let snapshot = FlowSnapshot::new(BTreeMap::new());
+    let proof = JustificationProof::prove(
+        &capsule,
+        &Predicate::Const(true),
+        &snapshot,
+        &CompletionMap::new(),
+    )
+    .unwrap();
+    let admission = braid_verify::admit(&capsule.to_bytes(), &reg, &[]).unwrap();
+    let invocation = RunnableInvocation::prepare(capsule, &reg, admission, proof).unwrap();
+    let mut host = CustomHost { writes: vec![] };
+    assert!(matches!(
+        execute_runnable(&invocation, &other, &mut host),
         Err(ExecutionError::InvalidCapsuleHeader { .. })
     ));
 }

--- a/crates/braid-verify/src/lib.rs
+++ b/crates/braid-verify/src/lib.rs
@@ -35,6 +35,35 @@ pub enum Verdict {
     Reject { stage: Stage, reason: String },
 }
 
+/// Opaque proof that independent admission accepted one exact capsule against
+/// one exact registry and ambient authority set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdmissionProof {
+    capsule_cid: Cid,
+    registry_cid: Cid,
+    authority_cid: Cid,
+}
+
+impl AdmissionProof {
+    /// The admitted capsule identity.
+    #[must_use]
+    pub fn capsule_cid(&self) -> Cid {
+        self.capsule_cid
+    }
+
+    /// The exact registry identity used by admission.
+    #[must_use]
+    pub fn registry_cid(&self) -> Cid {
+        self.registry_cid
+    }
+
+    /// The content identity of the external ambient authority set.
+    #[must_use]
+    pub fn authority_cid(&self) -> Cid {
+        self.authority_cid
+    }
+}
+
 fn reject(stage: Stage, reason: impl Into<String>) -> Verdict {
     Verdict::Reject {
         stage,
@@ -509,8 +538,38 @@ fn run_pipeline(
 /// principal actually holds. Bytes in, verdict out — the admission decision
 /// is reproducible from the artifact alone (D9).
 pub fn verify(bytes: &[u8], registry: &TermRegistry, ambient: &[Capability]) -> Verdict {
-    match run_pipeline(bytes, registry, ambient) {
-        Ok(capsule_cid) => Verdict::Admit { capsule_cid },
+    match admit(bytes, registry, ambient) {
+        Ok(proof) => Verdict::Admit {
+            capsule_cid: proof.capsule_cid,
+        },
         Err(verdict) => verdict,
     }
+}
+
+/// Run independent admission and return an opaque authority proof on success.
+/// The proof cannot be constructed by serializing or setting a verdict value.
+pub fn admit(
+    bytes: &[u8],
+    registry: &TermRegistry,
+    ambient: &[Capability],
+) -> Result<AdmissionProof, Verdict> {
+    let capsule_cid = run_pipeline(bytes, registry, ambient)?;
+    Ok(AdmissionProof {
+        capsule_cid,
+        registry_cid: registry.cid(),
+        authority_cid: authority_cid(ambient),
+    })
+}
+
+fn authority_cid(ambient: &[Capability]) -> Cid {
+    let mut names: Vec<&str> = ambient.iter().map(Capability::as_str).collect();
+    names.sort_unstable();
+    names.dedup();
+    let encoded = braid_ir::Value::List(
+        names
+            .into_iter()
+            .map(|name| braid_ir::Value::Text(name.into()))
+            .collect(),
+    );
+    Cid::compute(b"lw.braid.authority.v0", &braid_ir::encode(&encoded))
 }


### PR DESCRIPTION
Addresses #70.

## The gap

`braid-run` previously exposed execution from a raw `Capsule`. Admission was represented only by a verdict value, and justification identity was derived from a debug string. Together, callers could reach the execution boundary without passing an opaque authority proof bound to the exact capsule and registry.

## The fix

`braid-verify` now returns an opaque `AdmissionProof` from the independent canonical-byte pipeline. It binds the capsule CID, registry CID, and canonical ambient-authority CID. `RunnableInvocation::prepare` consumes that proof and a snapshot-bound `JustificationProof`; raw capsule execution is private. Predicate identity now uses Flow's canonical predicate encoding.

The rejected alternative was keeping `Verdict::Admit` as the runtime credential. A verdict is a result carrier and has no authority-set identity, so it cannot prevent proof transplantation.

## The real user path

```
>>> cargo test --workspace --all-targets
Finished `test` profile
test result: ok

>>> cargo clippy -p braid-verify -p braid-flow-ir -p braid-run --all-targets -- -D warnings
Finished `dev` profile
```

## Regressions

Nine runtime tests drive `RunnableInvocation` through admission and justification before the host dispatcher. The hostile cases reject unknown justification and registry transplantation; malformed headers now fail before execution.

## Proof of teeth

| mutation | RED case |
|---|---|
| remove the opaque admission binding | `runnable_invocation_rejects_registry_transplant` |
| allow unknown justification | `unknown_justification_cannot_create_runnable_invocation` |
| restore raw public execution | compile-time API review, with all runtime tests migrated to `execute_runnable` |

## Canonical identity was the non-obvious seam

The initial proof used `Debug` formatting for predicates. The final proof hashes the Flow-owned canonical predicate representation, preserving the single IR identity authority.

## Debt-on-touch

| file | before / after | constraint |
|---|---|---|
| `crates/braid-verify/src/lib.rs` | verdict-only admission / opaque proof plus verdict compatibility | no second wire format |
| `crates/braid-flow-ir/src/predicate.rs` | private canonical projection / public identity projection | Flow remains the predicate owner |
| `crates/braid-run/src/lib.rs` | raw execution API / private interpreter behind runnable typestate | host ABI unchanged |
| `crates/braid-run/tests/execution.rs` | raw execution fixtures / proof-gated fixtures | adversarial cases remain black-box |

## Full workspace gates at 9fa069eb

| job | result |
|---|---|
| `cargo test --workspace --all-targets` | **PASS** |
| `cargo clippy -p braid-verify -p braid-flow-ir -p braid-run --all-targets -- -D warnings` | **PASS** |

## What is still not done

This PR does not close #70. The issue still needs a derived `TokenProgram` dispatch path, bounded value-arena/liveness accounting, mutation coverage for each triad axis, and linear/fan-out/diamond allocation benchmarks. The current PR closes the raw-capsule and opaque admission-proof portion of that boundary.
