### PR TITLE
contract: approve rusternetes as boundary dep (0.1, rung 6)

### DIFF
--- a/contract/APPROVED.toml
+++ b/contract/APPROVED.toml
@@ -26,3 +26,12 @@
 # braid-cli` with exit 101 and one `cargo::error` per unapproved crate. The
 # ratchet works; the register is what is not ready.
 enforce = false
+
+[[approved]]
+crate = "rusternetes"
+tier = "boundary"
+version = "0.1"
+reason = "Reimplementing the Kubernetes control plane in Rust is a multi-year project with no std or lgwks_std alternative."
+approved_by = "Director"
+approved_on = "2026-08-27"
+review = "https://github.com/calfonso/rusternetes"


### PR DESCRIPTION
Replaces #80 (closed: its eb3f40e base has unrelated history to post-#82 main, so its merge commit could never go green).

Adds the `[[approved]]` block for `rusternetes` (`calfonso/rusternetes` @ f689efdb, Apache-2.0, tier=boundary) to `contract/APPROVED.toml` per `docs/ADMISSION.md` rung 6. Keel consumes this approval for its Oracle 24GB pool / rusternetes all-in-one SQLite plan.

Base is post-#82 main, so the merge commit no longer carries the broken `secure-authority` path dep.