### PR TITLE
Harden capsule decoder preflight budgets

### DIFF
--- a/.wwfd/local-ci.sh
+++ b/.wwfd/local-ci.sh
@@ -13,11 +13,10 @@
 # written ONLY after every step exits 0. There is no --skip, no || true,
 # and no set +e: a gate that can be talked out of a failure is not a gate.
 #
-# Subject resolution (lessons L202/L206): the receipt certifies the tree
-# `git push` will publish, so the subject is git HEAD — in a colocated repo
-# that is @- (the bookmarked parent), never the possibly-empty working-copy
-# commit. An unreachable subject is refused instead of dying later inside a
-# clone with `fatal: unable to read tree`.
+# Subject resolution (lessons L202/L206): the receipt certifies the exact
+# Jujutsu working-copy commit that the feature bookmark will publish. A working
+# copy without a local bookmark is refused; certifying colocated Git HEAD would
+# attest @- while omitting the feature bytes in @.
 #
 # Usage:  bash .wwfd/local-ci.sh
 #
@@ -26,7 +25,7 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="$(jj root)"
 RECEIPT="/Users/srinji/wwfd/state/local-ci-receipt.json"
 cd "$REPO_ROOT"
 
@@ -38,17 +37,21 @@ run() {
   "$@"
 }
 
+locked_metadata() {
+  cargo metadata --locked --no-deps --format-version 1 >/dev/null
+}
+
 # ── Subject reachability ──────────────────────────────────────────────────────
 
-SUBJECT_SHA="$(git rev-parse HEAD)"
-if ! git for-each-ref --contains "$SUBJECT_SHA" --count=1 refs/heads refs/tags |
-     grep -q .; then
-  echo "local-ci: subject $SUBJECT_SHA is not reachable from any ref." >&2
+SUBJECT_SHA="$(jj --no-pager log --no-graph -r @ -T 'commit_id')"
+BOOKMARKS="$(jj --no-pager log --no-graph -r @ -T 'bookmarks')"
+if [[ -z "$BOOKMARKS" ]]; then
+  echo "local-ci: subject $SUBJECT_SHA has no local bookmark." >&2
   echo "  Put a bookmark on it first:" >&2
   echo "    jj bookmark create local-ci-subject -r @" >&2
   exit 128
 fi
-echo "subject: $SUBJECT_SHA (ref-reachable)"
+echo "subject: $SUBJECT_SHA (bookmarks: $BOOKMARKS)"
 
 # ── Lane 1: swallow budget (ci.yml · swallow-budget) ─────────────────────────
 
@@ -62,13 +65,14 @@ run "cargo fmt --check" cargo fmt --all -- --check
 
 # ── Lane 3–5: build, tests, doc tests (ci.yml · build/tests) ─────────────────
 
-run "build all targets"      cargo test --workspace --all-targets --no-run
-run "workspace tests"        cargo test --workspace --all-targets
-run "doc tests"              cargo test --workspace --doc
+run "locked metadata"        locked_metadata
+run "build all targets"      cargo test --workspace --all-targets --locked --no-run
+run "workspace tests"        cargo test --workspace --all-targets --locked
+run "doc tests"              cargo test --workspace --doc --locked
 
 # ── Lane 6: clippy (ci.yml · clippy) ─────────────────────────────────────────
 
-run "clippy -D warnings" cargo clippy --workspace --all-targets -- -D warnings
+run "clippy -D warnings" cargo clippy --workspace --all-targets --locked -- -D warnings
 
 # ── Lane 7: lgwks-std feature matrix (ci.yml · lgwks-std-feature-matrix) ─────
 
@@ -152,8 +156,8 @@ run "local patch present" rg -q \
 
 # ── Receipt ──────────────────────────────────────────────────────────────────
 
-BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-HEAD_SHA="$(git rev-parse HEAD | cut -c1-12)"
+BRANCH="$BOOKMARKS"
+HEAD_SHA="${SUBJECT_SHA:0:12}"
 printf '{"repo_root":"%s","branch":"%s","head_sha":"%s","attested_at":%s,"ci_script":"bash .wwfd/local-ci.sh"}\n' \
   "$REPO_ROOT" "$BRANCH" "$HEAD_SHA" "$(date +%s)" > "$RECEIPT"
 echo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "braid-ir",
  "braid-vocab-cms",
  "lgwks_std",
+ "proptest",
 ]
 
 [[package]]

--- a/crates/braid-verify/Cargo.toml
+++ b/crates/braid-verify/Cargo.toml
@@ -15,3 +15,8 @@ braid-capability = { workspace = true }
 [dev-dependencies]
 lgwks_std = { workspace = true }
 braid-vocab-cms = { workspace = true }
+proptest = { workspace = true }
+
+[[bench]]
+name = "preflight_alloc"
+harness = false

--- a/crates/braid-verify/benches/preflight_alloc.rs
+++ b/crates/braid-verify/benches/preflight_alloc.rs
@@ -1,0 +1,125 @@
+use braid_verify::decode::{MAX_VALUE_NODES, decode_canonical, preflight_canonical};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Instant;
+
+struct CountingAllocator;
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static TOTAL_BYTES: AtomicUsize = AtomicUsize::new(0);
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static PEAK_LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+fn record_allocation(size: usize) {
+    ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+    TOTAL_BYTES.fetch_add(size, Ordering::Relaxed);
+    let live = LIVE_BYTES.fetch_add(size, Ordering::Relaxed) + size;
+    PEAK_LIVE_BYTES.fetch_max(live, Ordering::Relaxed);
+}
+
+fn record_deallocation(size: usize) {
+    let mut live = LIVE_BYTES.load(Ordering::Relaxed);
+    loop {
+        let next = live.saturating_sub(size);
+        match LIVE_BYTES.compare_exchange_weak(live, next, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(observed) => live = observed,
+        }
+    }
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: forwarding the exact layout to the process System allocator.
+        let pointer = unsafe { System.alloc(layout) };
+        if ENABLED.load(Ordering::Relaxed) && !pointer.is_null() {
+            record_allocation(layout.size());
+        }
+        pointer
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: forwarding the exact layout to the process System allocator.
+        let pointer = unsafe { System.alloc_zeroed(layout) };
+        if ENABLED.load(Ordering::Relaxed) && !pointer.is_null() {
+            record_allocation(layout.size());
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        if ENABLED.load(Ordering::Relaxed) {
+            record_deallocation(layout.size());
+        }
+        // SAFETY: `pointer` and `layout` are the pair supplied by Rust for the
+        // allocation originally delegated to System.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, old: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: forwarding the original pointer/layout pair and requested
+        // size unchanged to the process System allocator.
+        let replacement = unsafe { System.realloc(pointer, old, new_size) };
+        if ENABLED.load(Ordering::Relaxed) && !replacement.is_null() {
+            record_deallocation(old.size());
+            record_allocation(new_size);
+        }
+        replacement
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn reset() {
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    TOTAL_BYTES.store(0, Ordering::Relaxed);
+    LIVE_BYTES.store(0, Ordering::Relaxed);
+    PEAK_LIVE_BYTES.store(0, Ordering::Relaxed);
+}
+
+fn measure(label: &str, iterations: usize, mut operation: impl FnMut()) {
+    reset();
+    ENABLED.store(true, Ordering::SeqCst);
+    let started = Instant::now();
+    for _ in 0..iterations {
+        operation();
+    }
+    let elapsed = started.elapsed();
+    ENABLED.store(false, Ordering::SeqCst);
+
+    println!(
+        "{label} iterations={iterations} allocations={} total_bytes={} peak_live_bytes={} elapsed_us={}",
+        ALLOCATIONS.load(Ordering::Relaxed),
+        TOTAL_BYTES.load(Ordering::Relaxed),
+        PEAK_LIVE_BYTES.load(Ordering::Relaxed),
+        elapsed.as_micros()
+    );
+}
+
+fn hostile_value_nodes() -> Vec<u8> {
+    let mut bytes = vec![0x9a];
+    bytes.extend_from_slice(&(MAX_VALUE_NODES as u32).to_be_bytes());
+    bytes.resize(bytes.len() + MAX_VALUE_NODES as usize, 0xf4);
+    bytes
+}
+
+fn main() {
+    let accepted = braid_vocab_cms::edit_section_capsule().to_bytes();
+    let rejected = hostile_value_nodes();
+
+    measure("accepted_preflight", 10_000, || {
+        black_box(preflight_canonical(black_box(&accepted))).unwrap();
+    });
+    measure("rejected_preflight", 100, || {
+        black_box(preflight_canonical(black_box(&rejected))).unwrap_err();
+    });
+    measure("accepted_owned_decode", 1_000, || {
+        drop(black_box(decode_canonical(black_box(&accepted))).unwrap());
+    });
+    measure("rejected_owned_decode", 100, || {
+        black_box(decode_canonical(black_box(&rejected))).unwrap_err();
+    });
+}

--- a/crates/braid-verify/src/decode.rs
+++ b/crates/braid-verify/src/decode.rs
@@ -14,6 +14,61 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 pub const MAX_DEPTH: usize = 64;
+pub const MAX_WIRE_BYTES: usize = 16 * 1024 * 1024;
+pub const MAX_VALUE_NODES: u64 = 262_144;
+pub const MAX_TEXT_BYTES: u64 = 16 * 1024 * 1024;
+pub const MAX_BYTE_STRING_BYTES: u64 = 16 * 1024 * 1024;
+pub const MAX_LIST_ITEMS: u64 = 262_144;
+pub const MAX_MAP_ENTRIES: u64 = 262_144;
+pub const MAX_KEY_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Aggregate resource envelope enforced before canonical values are allocated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LimitKind {
+    WireBytes,
+    ValueNodes,
+    TextBytes,
+    ByteStringBytes,
+    ListItems,
+    MapEntries,
+    KeyBytes,
+}
+
+/// Counts established by the allocation-free canonical byte preflight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreflightStats {
+    pub wire_bytes: usize,
+    pub value_nodes: u64,
+    pub text_bytes: u64,
+    pub byte_string_bytes: u64,
+    pub list_items: u64,
+    pub map_entries: u64,
+    pub key_bytes: u64,
+    pub max_depth: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PreflightLimits {
+    wire_bytes: usize,
+    value_nodes: u64,
+    text_bytes: u64,
+    byte_string_bytes: u64,
+    list_items: u64,
+    map_entries: u64,
+    key_bytes: u64,
+    depth: usize,
+}
+
+const DEFAULT_LIMITS: PreflightLimits = PreflightLimits {
+    wire_bytes: MAX_WIRE_BYTES,
+    value_nodes: MAX_VALUE_NODES,
+    text_bytes: MAX_TEXT_BYTES,
+    byte_string_bytes: MAX_BYTE_STRING_BYTES,
+    list_items: MAX_LIST_ITEMS,
+    map_entries: MAX_MAP_ENTRIES,
+    key_bytes: MAX_KEY_BYTES,
+    depth: MAX_DEPTH,
+};
 
 /// Error variants encountered during canonical CBOR decoding.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -65,6 +120,22 @@ pub enum DecodeError {
         /// Byte offset where integer was decoded.
         at: usize,
     },
+    /// A pre-allocation aggregate resource ceiling was exceeded.
+    LimitExceeded {
+        /// Resource whose aggregate ceiling was exceeded.
+        kind: LimitKind,
+        /// Observed or declared aggregate.
+        actual: u64,
+        /// Configured aggregate ceiling.
+        limit: u64,
+        /// Byte offset where the over-limit value was observed.
+        at: usize,
+    },
+    /// Checked offset or counter arithmetic overflowed.
+    ArithmeticOverflow {
+        /// Byte offset where the overflow was detected.
+        at: usize,
+    },
 }
 
 impl fmt::Display for DecodeError {
@@ -81,6 +152,18 @@ impl fmt::Display for DecodeError {
             Self::Depth { at } => write!(f, "max nesting depth exceeded at offset {at}"),
             Self::NotBijective { at } => write!(f, "non-bijective encoding at offset {at}"),
             Self::IntRange { at } => write!(f, "integer out of range at offset {at}"),
+            Self::LimitExceeded {
+                kind,
+                actual,
+                limit,
+                at,
+            } => write!(
+                f,
+                "{kind:?} limit exceeded at offset {at}: {actual} > {limit}"
+            ),
+            Self::ArithmeticOverflow { at } => {
+                write!(f, "checked arithmetic overflow at offset {at}")
+            }
         }
     }
 }
@@ -90,6 +173,401 @@ impl std::error::Error for DecodeError {}
 /// Canonical key order (length, then bytes) — restated here, not imported.
 fn key_lt(a: &str, b: &str) -> bool {
     (a.len(), a.as_bytes()) < (b.len(), b.as_bytes())
+}
+
+fn key_bytes_lt(a: &[u8], b: &[u8]) -> bool {
+    (a.len(), a) < (b.len(), b)
+}
+
+#[derive(Clone, Copy)]
+enum ContainerKind {
+    List,
+    Map,
+}
+
+#[derive(Clone, Copy)]
+struct Frame<'a> {
+    kind: ContainerKind,
+    remaining: u64,
+    expecting_key: bool,
+    previous_key: Option<&'a [u8]>,
+}
+
+const EMPTY_FRAME: Frame<'static> = Frame {
+    kind: ContainerKind::List,
+    remaining: 0,
+    expecting_key: false,
+    previous_key: None,
+};
+
+struct PreflightScanner<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+    stack: [Frame<'a>; MAX_DEPTH + 1],
+    stack_len: usize,
+    root_started: bool,
+    stats: PreflightStats,
+    limits: PreflightLimits,
+}
+
+impl<'a> PreflightScanner<'a> {
+    fn new(bytes: &'a [u8], limits: PreflightLimits) -> Result<Self, DecodeError> {
+        if bytes.len() > limits.wire_bytes {
+            let limit = u64::try_from(limits.wire_bytes)
+                .map_err(|_| DecodeError::ArithmeticOverflow { at: 0 })?;
+            return Err(DecodeError::LimitExceeded {
+                kind: LimitKind::WireBytes,
+                actual: u64::try_from(bytes.len()).unwrap_or(u64::MAX),
+                limit,
+                at: 0,
+            });
+        }
+        Ok(Self {
+            bytes,
+            offset: 0,
+            stack: [EMPTY_FRAME; MAX_DEPTH + 1],
+            stack_len: 0,
+            root_started: false,
+            stats: PreflightStats {
+                wire_bytes: bytes.len(),
+                value_nodes: 0,
+                text_bytes: 0,
+                byte_string_bytes: 0,
+                list_items: 0,
+                map_entries: 0,
+                key_bytes: 0,
+                max_depth: 0,
+            },
+            limits,
+        })
+    }
+
+    fn read_u8(&mut self) -> Result<u8, DecodeError> {
+        let byte = *self
+            .bytes
+            .get(self.offset)
+            .ok_or(DecodeError::Truncated { at: self.offset })?;
+        self.offset = self
+            .offset
+            .checked_add(1)
+            .ok_or(DecodeError::ArithmeticOverflow { at: self.offset })?;
+        Ok(byte)
+    }
+
+    fn read_slice(&mut self, length: u64) -> Result<&'a [u8], DecodeError> {
+        let length = usize::try_from(length)
+            .map_err(|_| DecodeError::ArithmeticOverflow { at: self.offset })?;
+        let end = self
+            .offset
+            .checked_add(length)
+            .ok_or(DecodeError::ArithmeticOverflow { at: self.offset })?;
+        let slice = self
+            .bytes
+            .get(self.offset..end)
+            .ok_or(DecodeError::Truncated { at: self.offset })?;
+        self.offset = end;
+        Ok(slice)
+    }
+
+    fn read_argument(&mut self, head: u8) -> Result<u64, DecodeError> {
+        match head & 0x1f {
+            inline @ 0..=23 => Ok(u64::from(inline)),
+            24 => {
+                let value = u64::from(self.read_u8()?);
+                if value < 24 {
+                    Err(DecodeError::NonMinimal { at: self.offset })
+                } else {
+                    Ok(value)
+                }
+            }
+            25 => {
+                let bytes = self.read_slice(2)?;
+                let value = u64::from(u16::from_be_bytes(bytes.try_into().unwrap()));
+                if value <= u64::from(u8::MAX) {
+                    Err(DecodeError::NonMinimal { at: self.offset })
+                } else {
+                    Ok(value)
+                }
+            }
+            26 => {
+                let bytes = self.read_slice(4)?;
+                let value = u64::from(u32::from_be_bytes(bytes.try_into().unwrap()));
+                if value <= u64::from(u16::MAX) {
+                    Err(DecodeError::NonMinimal { at: self.offset })
+                } else {
+                    Ok(value)
+                }
+            }
+            27 => {
+                let bytes = self.read_slice(8)?;
+                let value = u64::from_be_bytes(bytes.try_into().unwrap());
+                if value <= u64::from(u32::MAX) {
+                    Err(DecodeError::NonMinimal { at: self.offset })
+                } else {
+                    Ok(value)
+                }
+            }
+            _ => Err(DecodeError::Forbidden {
+                at: self.offset,
+                reason: "reserved/indefinite",
+            }),
+        }
+    }
+
+    fn add_counter(
+        counter: &mut u64,
+        amount: u64,
+        limit: u64,
+        kind: LimitKind,
+        at: usize,
+    ) -> Result<(), DecodeError> {
+        let actual = counter
+            .checked_add(amount)
+            .ok_or(DecodeError::ArithmeticOverflow { at })?;
+        if actual > limit {
+            return Err(DecodeError::LimitExceeded {
+                kind,
+                actual,
+                limit,
+                at,
+            });
+        }
+        *counter = actual;
+        Ok(())
+    }
+
+    fn record_value(&mut self, depth: usize, at: usize) -> Result<(), DecodeError> {
+        if depth > self.limits.depth {
+            return Err(DecodeError::Depth { at });
+        }
+        Self::add_counter(
+            &mut self.stats.value_nodes,
+            1,
+            self.limits.value_nodes,
+            LimitKind::ValueNodes,
+            at,
+        )?;
+        self.stats.max_depth = self.stats.max_depth.max(depth);
+        Ok(())
+    }
+
+    fn ensure_minimum_payload(&self, count: u64, bytes_per_item: u64) -> Result<(), DecodeError> {
+        let minimum = count
+            .checked_mul(bytes_per_item)
+            .ok_or(DecodeError::ArithmeticOverflow { at: self.offset })?;
+        let remaining_bytes = self
+            .bytes
+            .len()
+            .checked_sub(self.offset)
+            .ok_or(DecodeError::ArithmeticOverflow { at: self.offset })?;
+        let remaining = u64::try_from(remaining_bytes)
+            .map_err(|_| DecodeError::ArithmeticOverflow { at: self.offset })?;
+        if minimum > remaining {
+            Err(DecodeError::Truncated { at: self.offset })
+        } else {
+            Ok(())
+        }
+    }
+
+    fn push_container(&mut self, kind: ContainerKind, count: u64) -> Result<(), DecodeError> {
+        if count == 0 {
+            return Ok(());
+        }
+        let slot = self
+            .stack
+            .get_mut(self.stack_len)
+            .ok_or(DecodeError::Depth { at: self.offset })?;
+        *slot = Frame {
+            kind,
+            remaining: count,
+            expecting_key: matches!(kind, ContainerKind::Map),
+            previous_key: None,
+        };
+        self.stack_len = self
+            .stack_len
+            .checked_add(1)
+            .ok_or(DecodeError::ArithmeticOverflow { at: self.offset })?;
+        Ok(())
+    }
+
+    fn scan_text_payload(&mut self, length: u64, key: bool) -> Result<&'a [u8], DecodeError> {
+        let at = self.offset;
+        if key {
+            Self::add_counter(
+                &mut self.stats.key_bytes,
+                length,
+                self.limits.key_bytes,
+                LimitKind::KeyBytes,
+                at,
+            )?;
+        } else {
+            Self::add_counter(
+                &mut self.stats.text_bytes,
+                length,
+                self.limits.text_bytes,
+                LimitKind::TextBytes,
+                at,
+            )?;
+        }
+        let payload = self.read_slice(length)?;
+        if let Err(error) = std::str::from_utf8(payload) {
+            let invalid_at = at
+                .checked_add(error.valid_up_to())
+                .ok_or(DecodeError::ArithmeticOverflow { at })?;
+            return Err(DecodeError::Utf8 { at: invalid_at });
+        }
+        Ok(payload)
+    }
+
+    fn scan_key(&mut self) -> Result<&'a [u8], DecodeError> {
+        let at = self.offset;
+        let head = self.read_u8()?;
+        if head >> 5 != 3 {
+            return Err(DecodeError::Forbidden {
+                at,
+                reason: "map key",
+            });
+        }
+        let length = self.read_argument(head)?;
+        self.scan_text_payload(length, true)
+    }
+
+    fn scan_value(&mut self, depth: usize) -> Result<(), DecodeError> {
+        let at = self.offset;
+        self.record_value(depth, at)?;
+        let head = self.read_u8()?;
+        let major = head >> 5;
+        if major == 7 {
+            return match head {
+                0xf4 | 0xf5 => Ok(()),
+                _ => Err(DecodeError::Forbidden {
+                    at,
+                    reason: "simple/float",
+                }),
+            };
+        }
+
+        let argument = self.read_argument(head)?;
+        match major {
+            0 => {
+                i64::try_from(argument).map_err(|_| DecodeError::IntRange { at })?;
+                Ok(())
+            }
+            1 => {
+                i64::try_from(argument).map_err(|_| DecodeError::IntRange { at })?;
+                Ok(())
+            }
+            2 => {
+                Self::add_counter(
+                    &mut self.stats.byte_string_bytes,
+                    argument,
+                    self.limits.byte_string_bytes,
+                    LimitKind::ByteStringBytes,
+                    at,
+                )?;
+                self.read_slice(argument)?;
+                Ok(())
+            }
+            3 => {
+                self.scan_text_payload(argument, false)?;
+                Ok(())
+            }
+            4 => {
+                Self::add_counter(
+                    &mut self.stats.list_items,
+                    argument,
+                    self.limits.list_items,
+                    LimitKind::ListItems,
+                    at,
+                )?;
+                self.ensure_minimum_payload(argument, 1)?;
+                self.push_container(ContainerKind::List, argument)
+            }
+            5 => {
+                Self::add_counter(
+                    &mut self.stats.map_entries,
+                    argument,
+                    self.limits.map_entries,
+                    LimitKind::MapEntries,
+                    at,
+                )?;
+                self.ensure_minimum_payload(argument, 2)?;
+                self.push_container(ContainerKind::Map, argument)
+            }
+            _ => Err(DecodeError::Forbidden {
+                at,
+                reason: "tag/unknown",
+            }),
+        }
+    }
+
+    fn pop_completed(&mut self) {
+        while self.stack_len > 0 {
+            let frame = self.stack[self.stack_len - 1];
+            let complete = frame.remaining == 0
+                && (!matches!(frame.kind, ContainerKind::Map) || frame.expecting_key);
+            if !complete {
+                break;
+            }
+            self.stack_len -= 1;
+        }
+    }
+
+    fn scan(mut self) -> Result<PreflightStats, DecodeError> {
+        loop {
+            self.pop_completed();
+            if self.root_started && self.stack_len == 0 {
+                break;
+            }
+
+            if self.stack_len > 0 {
+                let frame_index = self.stack_len - 1;
+                let frame = self.stack[frame_index];
+                if matches!(frame.kind, ContainerKind::Map) && frame.expecting_key {
+                    let key = self.scan_key()?;
+                    if let Some(previous) = frame.previous_key
+                        && !key_bytes_lt(previous, key)
+                    {
+                        return Err(DecodeError::KeyOrder { at: self.offset });
+                    }
+                    self.stack[frame_index].previous_key = Some(key);
+                    self.stack[frame_index].expecting_key = false;
+                    continue;
+                }
+
+                self.stack[frame_index].remaining = frame
+                    .remaining
+                    .checked_sub(1)
+                    .ok_or(DecodeError::ArithmeticOverflow { at: self.offset })?;
+                if matches!(frame.kind, ContainerKind::Map) {
+                    self.stack[frame_index].expecting_key = true;
+                }
+            } else {
+                self.root_started = true;
+            }
+
+            self.scan_value(self.stack_len)?;
+        }
+
+        if self.offset != self.bytes.len() {
+            return Err(DecodeError::Trailing { at: self.offset });
+        }
+        Ok(self.stats)
+    }
+}
+
+fn preflight_with_limits(
+    bytes: &[u8],
+    limits: PreflightLimits,
+) -> Result<PreflightStats, DecodeError> {
+    PreflightScanner::new(bytes, limits)?.scan()
+}
+
+/// Validate canonical bytes and all aggregate resource ceilings without heap
+/// allocation. Only borrowed slices, scalar counters, and a fixed-size stack
+/// are used before this function returns successfully.
+pub fn preflight_canonical(bytes: &[u8]) -> Result<PreflightStats, DecodeError> {
+    preflight_with_limits(bytes, DEFAULT_LIMITS)
 }
 
 struct Cursor<'a> {
@@ -103,7 +581,10 @@ impl<'a> Cursor<'a> {
             .buffer
             .get(self.offset)
             .ok_or(DecodeError::Truncated { at: self.offset })?;
-        self.offset += 1;
+        self.offset = self
+            .offset
+            .checked_add(1)
+            .ok_or(DecodeError::ArithmeticOverflow { at: self.offset })?;
         Ok(byte_val)
     }
 
@@ -116,11 +597,7 @@ impl<'a> Cursor<'a> {
     }
 
     fn check_slice_len(&self, length: u64) -> Result<usize, DecodeError> {
-        if let Ok(slice_len) = usize::try_from(length) {
-            Ok(slice_len)
-        } else {
-            Err(DecodeError::Truncated { at: self.offset })
-        }
+        usize::try_from(length).map_err(|_| DecodeError::ArithmeticOverflow { at: self.offset })
     }
 
     fn read_slice(&mut self, length: u64) -> Result<&'a [u8], DecodeError> {
@@ -193,13 +670,21 @@ impl<'a> Cursor<'a> {
         match std::str::from_utf8(slice_bytes) {
             Ok(valid_str) => Ok(valid_str.to_owned()),
             Err(utf_err) => Err(DecodeError::Utf8 {
-                at: current_at + utf_err.valid_up_to(),
+                at: current_at
+                    .checked_add(utf_err.valid_up_to())
+                    .ok_or(DecodeError::ArithmeticOverflow { at: current_at })?,
             }),
         }
     }
 
     fn check_list_bounds(&self, count: u64) -> Result<(), DecodeError> {
-        let remaining_bytes = (self.buffer.len() - self.offset) as u64;
+        let remaining = self
+            .buffer
+            .len()
+            .checked_sub(self.offset)
+            .ok_or(DecodeError::ArithmeticOverflow { at: self.offset })?;
+        let remaining_bytes = u64::try_from(remaining)
+            .map_err(|_| DecodeError::ArithmeticOverflow { at: self.offset })?;
         if count > remaining_bytes {
             Err(DecodeError::Truncated { at: self.offset })
         } else {
@@ -209,7 +694,9 @@ impl<'a> Cursor<'a> {
 
     fn read_list(&mut self, count: u64, depth: usize) -> Result<Value, DecodeError> {
         self.check_list_bounds(count)?;
-        let mut list_items = Vec::with_capacity(count as usize);
+        let capacity = usize::try_from(count)
+            .map_err(|_| DecodeError::ArithmeticOverflow { at: self.offset })?;
+        let mut list_items = Vec::with_capacity(capacity);
         for _ in 0..count {
             let item_val = self.read_val(depth + 1)?;
             list_items.push(item_val);
@@ -259,7 +746,13 @@ impl<'a> Cursor<'a> {
     }
 
     fn check_map_bounds(&self, count: u64) -> Result<(), DecodeError> {
-        let remaining_pairs = ((self.buffer.len() - self.offset) / 2) as u64;
+        let remaining = self
+            .buffer
+            .len()
+            .checked_sub(self.offset)
+            .ok_or(DecodeError::ArithmeticOverflow { at: self.offset })?;
+        let remaining_pairs = u64::try_from(remaining / 2)
+            .map_err(|_| DecodeError::ArithmeticOverflow { at: self.offset })?;
         if count > remaining_pairs {
             Err(DecodeError::Truncated { at: self.offset })
         } else {
@@ -418,16 +911,6 @@ pub fn reencode(val: &Value, out: &mut Vec<u8>) {
     }
 }
 
-fn verify_bijection(bytes: &[u8], decoded_val: &Value, at: usize) -> Result<(), DecodeError> {
-    let mut reencoded = Vec::with_capacity(bytes.len());
-    reencode(decoded_val, &mut reencoded);
-    if reencoded != bytes {
-        Err(DecodeError::NotBijective { at })
-    } else {
-        Ok(())
-    }
-}
-
 fn check_cursor_at_end(offset: usize, total_len: usize) -> Result<(), DecodeError> {
     if offset != total_len {
         Err(DecodeError::Trailing { at: offset })
@@ -436,14 +919,185 @@ fn check_cursor_at_end(offset: usize, total_len: usize) -> Result<(), DecodeErro
     }
 }
 
-/// Strict decode + independent bijection guard.
+/// Allocation-free canonical preflight followed by bounded owned projection.
+///
+/// The preflight validates the exact byte grammar, minimal integer widths,
+/// borrowed map-key order, and complete input consumption. The owned decoder
+/// then independently parses the same bytes. This establishes byte bijection
+/// without allocating a second full-size encoded buffer.
 pub fn decode_canonical(bytes: &[u8]) -> Result<Value, DecodeError> {
+    preflight_canonical(bytes)?;
     let mut cursor = Cursor {
         buffer: bytes,
         offset: 0,
     };
     let decoded_val = cursor.read_val(0)?;
     check_cursor_at_end(cursor.offset, bytes.len())?;
-    verify_bijection(bytes, &decoded_val, cursor.offset)?;
     Ok(decoded_val)
+}
+
+#[cfg(test)]
+mod preflight_tests {
+    use super::*;
+
+    fn test_limits() -> PreflightLimits {
+        PreflightLimits {
+            wire_bytes: 1024,
+            value_nodes: 64,
+            text_bytes: 64,
+            byte_string_bytes: 64,
+            list_items: 64,
+            map_entries: 64,
+            key_bytes: 64,
+            depth: 8,
+        }
+    }
+
+    #[test]
+    fn counts_every_resource_without_materializing_values() {
+        // {"a": [h'ff', "hi"], "b": 1}
+        let bytes = [
+            0xa2, 0x61, b'a', 0x82, 0x41, 0xff, 0x62, b'h', b'i', 0x61, b'b', 0x01,
+        ];
+        let stats = preflight_with_limits(&bytes, test_limits()).unwrap();
+
+        assert_eq!(stats.wire_bytes, bytes.len());
+        assert_eq!(stats.value_nodes, 5);
+        assert_eq!(stats.text_bytes, 2);
+        assert_eq!(stats.byte_string_bytes, 1);
+        assert_eq!(stats.list_items, 2);
+        assert_eq!(stats.map_entries, 2);
+        assert_eq!(stats.key_bytes, 2);
+        assert_eq!(stats.max_depth, 2);
+    }
+
+    #[test]
+    fn many_tiny_values_hit_the_node_budget() {
+        let mut limits = test_limits();
+        limits.value_nodes = 4;
+        assert!(matches!(
+            preflight_with_limits(&[0x84, 0xf4, 0xf4, 0xf4, 0xf4], limits),
+            Err(DecodeError::LimitExceeded {
+                kind: LimitKind::ValueNodes,
+                actual: 5,
+                limit: 4,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn aggregate_text_budget_spans_multiple_valid_items() {
+        let mut limits = test_limits();
+        limits.text_bytes = 3;
+        assert!(matches!(
+            preflight_with_limits(&[0x82, 0x62, b'a', b'a', 0x62, b'b', b'b'], limits),
+            Err(DecodeError::LimitExceeded {
+                kind: LimitKind::TextBytes,
+                actual: 4,
+                limit: 3,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn aggregate_byte_string_budget_spans_multiple_valid_items() {
+        let mut limits = test_limits();
+        limits.byte_string_bytes = 3;
+        assert!(matches!(
+            preflight_with_limits(&[0x82, 0x42, 1, 2, 0x42, 3, 4], limits),
+            Err(DecodeError::LimitExceeded {
+                kind: LimitKind::ByteStringBytes,
+                actual: 4,
+                limit: 3,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn nested_lists_hit_the_aggregate_item_budget() {
+        let mut limits = test_limits();
+        limits.list_items = 5;
+        assert!(matches!(
+            preflight_with_limits(&[0x82, 0x82, 0xf5, 0xf5, 0x82, 0xf5, 0xf5], limits),
+            Err(DecodeError::LimitExceeded {
+                kind: LimitKind::ListItems,
+                actual: 6,
+                limit: 5,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn aggregate_map_entries_and_key_bytes_have_separate_budgets() {
+        let bytes = [0xa2, 0x61, b'a', 0x01, 0x61, b'b', 0x02];
+        let mut entry_limits = test_limits();
+        entry_limits.map_entries = 1;
+        assert!(matches!(
+            preflight_with_limits(&bytes, entry_limits),
+            Err(DecodeError::LimitExceeded {
+                kind: LimitKind::MapEntries,
+                actual: 2,
+                limit: 1,
+                ..
+            })
+        ));
+
+        let mut key_limits = test_limits();
+        key_limits.key_bytes = 1;
+        assert!(matches!(
+            preflight_with_limits(&bytes, key_limits),
+            Err(DecodeError::LimitExceeded {
+                kind: LimitKind::KeyBytes,
+                actual: 2,
+                limit: 1,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn borrowed_map_keys_must_be_canonically_ordered() {
+        let unordered = [0xa2, 0x61, b'b', 0x01, 0x61, b'a', 0x02];
+        assert!(matches!(
+            preflight_with_limits(&unordered, test_limits()),
+            Err(DecodeError::KeyOrder { .. })
+        ));
+    }
+
+    #[test]
+    fn nonempty_container_beyond_depth_limit_is_refused() {
+        let mut limits = test_limits();
+        limits.depth = 2;
+        assert!(matches!(
+            preflight_with_limits(&[0x81, 0x81, 0x81, 0xf5], limits),
+            Err(DecodeError::Depth { .. })
+        ));
+    }
+
+    #[test]
+    fn hostile_declared_count_is_refused_before_iteration() {
+        let mut bytes = vec![0x9b];
+        bytes.extend_from_slice(&u64::MAX.to_be_bytes());
+        assert!(matches!(
+            preflight_canonical(&bytes),
+            Err(DecodeError::LimitExceeded {
+                kind: LimitKind::ListItems,
+                actual: u64::MAX,
+                limit: MAX_LIST_ITEMS,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn truncated_payload_is_refused_by_checked_slice_bounds() {
+        assert!(matches!(
+            preflight_with_limits(&[0x44, 1, 2], test_limits()),
+            Err(DecodeError::Truncated { .. })
+        ));
+    }
 }

--- a/crates/braid-verify/tests/preflight_fuzz.rs
+++ b/crates/braid-verify/tests/preflight_fuzz.rs
@@ -1,0 +1,87 @@
+use braid_verify::decode::{
+    DecodeError, LimitKind, MAX_VALUE_NODES, MAX_WIRE_BYTES, decode_canonical, preflight_canonical,
+    reencode,
+};
+use proptest::prelude::*;
+use std::collections::BTreeMap;
+
+fn canonical_value() -> impl Strategy<Value = braid_ir::Value> {
+    let leaf = prop_oneof![
+        any::<bool>().prop_map(braid_ir::Value::Bool),
+        any::<i64>().prop_map(braid_ir::Value::Int),
+        proptest::collection::vec(any::<u8>(), 0..32).prop_map(braid_ir::Value::Bytes),
+        "[a-zA-Z0-9 _.\\-]{0,24}".prop_map(braid_ir::Value::Text),
+    ];
+    leaf.prop_recursive(5, 256, 8, |inner| {
+        prop_oneof![
+            proptest::collection::vec(inner.clone(), 0..8).prop_map(braid_ir::Value::List),
+            proptest::collection::btree_map("[a-z]{0,8}", inner, 0..8).prop_map(
+                |entries: BTreeMap<String, braid_ir::Value>| { braid_ir::Value::Map(entries) }
+            ),
+        ]
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn arbitrary_bounded_wire_never_panics_or_bypasses_owned_decode(
+        bytes in proptest::collection::vec(any::<u8>(), 0..=64 * 1024)
+    ) {
+        if preflight_canonical(&bytes).is_ok() {
+            let value = decode_canonical(&bytes)
+                .expect("bytes accepted by preflight must survive bounded owned decode");
+            let mut encoded = Vec::with_capacity(bytes.len());
+            reencode(&value, &mut encoded);
+            prop_assert_eq!(encoded, bytes);
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn canonical_nested_values_preserve_independent_byte_bijection(value in canonical_value()) {
+        let bytes = braid_ir::encode(&value);
+        let stats = preflight_canonical(&bytes)
+            .expect("producer output within the generated envelope must pass preflight");
+        let decoded = decode_canonical(&bytes)
+            .expect("preflight-approved producer output must survive owned decode");
+        prop_assert_eq!(decoded, value);
+        prop_assert_eq!(stats.wire_bytes, bytes.len());
+    }
+}
+
+#[test]
+fn hard_wire_ceiling_is_refused_before_scanning() {
+    let bytes = vec![0; MAX_WIRE_BYTES + 1];
+    assert!(matches!(
+        preflight_canonical(&bytes),
+        Err(DecodeError::LimitExceeded {
+            kind: LimitKind::WireBytes,
+            actual,
+            limit,
+            at: 0,
+        }) if actual == (MAX_WIRE_BYTES + 1) as u64 && limit == MAX_WIRE_BYTES as u64
+    ));
+}
+
+#[test]
+fn owned_decode_cannot_bypass_the_value_node_preflight() {
+    let item_count = MAX_VALUE_NODES;
+    let mut bytes = vec![0x9a];
+    bytes.extend_from_slice(&(item_count as u32).to_be_bytes());
+    bytes.resize(bytes.len() + item_count as usize, 0xf4);
+
+    assert!(matches!(
+        decode_canonical(&bytes),
+        Err(DecodeError::LimitExceeded {
+            kind: LimitKind::ValueNodes,
+            actual,
+            limit: MAX_VALUE_NODES,
+            ..
+        }) if actual == MAX_VALUE_NODES + 1
+    ));
+}

--- a/docs/STRATEGIC-VISION.md
+++ b/docs/STRATEGIC-VISION.md
@@ -166,7 +166,7 @@ Every byte passes through independent stages in order. Any stage may REJECT with
 
 ```mermaid
 flowchart LR
-    Bytes["Canonical bytes<br/>≤16 MiB wire<br/>≤128 MiB preflight"] --> S1
+    Bytes["Canonical capsule bytes<br/>≤16 MiB wire<br/>≤262k values"] --> S1
 
     S1["Stage 1<br/>CanonicalForm<br/>CBOR bijection guard"] --> S2
     S2["Stage 2<br/>VersionPin<br/>ir / vocab / registry"] --> S3
@@ -303,7 +303,8 @@ Every hostile input is a typed rejection, not a panic, not a silent fallback:
 - Unknown capability → `MissingCapability` / `UnregisteredCrate` (boundary gate)
 - Float smuggled → `Rejected at canonical-form`
 - `let _ =` / `.ok()` swallowed → `swallow-budget ≤5` CI gate
-- Massive wire → 16 MiB / 128 MiB preflight, 262k Value node ceiling
+- Massive capsule wire → 16 MiB wire and 262k Value-node preflight;
+  Frontier Flow separately retains its 128 MiB wire envelope
 - Unknown justification → `UnknownProof` fail-closed; registry transplant → `InvalidRunnableProof`
 
 Evidence: `cargo test --workspace --all-targets` (225+ suites today), `cargo clippy -- -D warnings`, `cargo fmt --check`, `lgwks_std_gate`, plus KAT vectors and mutation-ledger prover for anti-dredging.

--- a/docs/adr-101-root-admission-triad-and-token-plan.md
+++ b/docs/adr-101-root-admission-triad-and-token-plan.md
@@ -121,8 +121,19 @@ These are not papered over by this ADR:
 2. **Runtime allocation amplification:** execution still performs string dispatch and clones every input/output/journal value. It has not yet migrated to `TokenProgram` plus a bounded value arena.
 3. **Justification proof:** the Flow planner must evaluate `needed_when` and `satisfied_when` against a CID-bound snapshot and return the third proof.
 4. **Choice disjointness:** v0 checks choice shape and duplicate targets; it does not prove predicate disjointness. The verifier must not describe that as solved.
-5. **Decoder preflight:** the capsule independent decoder still needs explicit wire-byte and total-value ceilings before allocating the complete canonical value tree.
-6. **Cross-process proof transport:** a future runnable artifact needs identity-bound evidence/receipt references; the one-byte triad is insufficient.
+5. **Cross-process proof transport:** a future runnable artifact needs identity-bound evidence/receipt references; the one-byte triad is insufficient.
+
+## Subsequent resolution
+
+- **Decoder preflight (#72, 2026-08-29):** the independent capsule decoder now
+  performs an allocation-free, iterative canonical byte scan before owned
+  projection. The default envelope is 16 MiB wire bytes, 262,144 value nodes,
+  262,144 aggregate list items, 262,144 aggregate map entries, 16 MiB each of
+  text, byte-string, and key payload, and depth 64. Canonical integer widths,
+  checked offsets, borrowed key order, UTF-8, and complete input consumption
+  are established before allocation. `cargo bench -p braid-verify --bench
+  preflight_alloc --locked` reports allocation counts and peak live bytes for
+  accepted and hostile-rejected boundaries.
 
 ## Consequences
 


### PR DESCRIPTION
Based on `main` at `b800d1e87ad5`. Closes #72.

## The gap

`decode_canonical` bounded nesting depth, but it allocated the complete `Value` tree before aggregate limits were known. `verify_bijection` then allocated a second encoded byte vector. A shallow capsule made of many small values could therefore amplify memory during admission, before later capsule bounds ran.

## The fix

Pass 1 is an iterative canonical-byte scanner with a fixed `[Frame; 65]` stack. It establishes wire, node, text, byte-string, list-item, map-entry, key-byte, and depth totals with checked arithmetic. Map ordering is compared from borrowed key slices. No owned strings, maps, lists, or payload vectors exist in this pass.

Pass 2 runs only after every ceiling passes. The independent decoder builds the owned value once. Because pass 1 accepts only the exact canonical grammar and consumes the full input, admission no longer needs a second full-size encoded vector to establish byte bijection.

Reusing the producer decoder or a general CBOR serializer was the rejected alternative. It would collapse the independent anti-trusting-trust boundary that this crate exists to preserve.

## The real admission path

Final benchmark at `705a1469b834`, exit 0:

```text
accepted_preflight iterations=10000 allocations=0 total_bytes=0 peak_live_bytes=0 elapsed_us=2261
rejected_preflight iterations=100 allocations=0 total_bytes=0 peak_live_bytes=0 elapsed_us=34843
accepted_owned_decode iterations=1000 allocations=59000 total_bytes=4551000 peak_live_bytes=4449 elapsed_us=1470
rejected_owned_decode iterations=100 allocations=0 total_bytes=0 peak_live_bytes=0 elapsed_us=31520
```

The hostile input declares 262,144 array items. Counting the container itself produces 262,145 value nodes, so both public admission paths reject it before owned decoding.

## Regressions

The external test target drives public `preflight_canonical`, `decode_canonical`, and `reencode` rather than scanner internals. It runs 512 arbitrary byte vectors up to 64 KiB and 256 recursively generated canonical values. Dedicated cases cover the 16 MiB wire ceiling and the 262,144-node boundary. Ten internal cases isolate each aggregate budget, canonical borrowed-key ordering, nesting depth, huge counts, and truncation.

## Proof of teeth

| mutation | result |
|---|---|
| Final code calls `preflight_canonical(bytes)?` before owned decoding | `owned_decode_cannot_bypass_the_value_node_preflight` passes |
| Temporarily remove that call | the same test fails, exit 101 |

Same hostile value, same public decoder, rebuilt between runs.

## The local gate had been attesting the Git parent

The colocated checkout leaves Git `HEAD` on the parent while Jujutsu `@` owns the feature. The local gate previously wrote a green receipt for `@-`. It now resolves the repository, bookmark, and receipt SHA directly from Jujutsu `@`, and locks workspace dependency resolution in the core Cargo lanes.

## Full CI, run locally at `705a1469b834`

| boundary | result |
|---|---|
| `bash .wwfd/local-ci.sh` | **GREEN, 27 lanes** |
| receipt bookmark | `feat/capsule-preflight-budgets` |
| receipt SHA | `705a1469b834` |
| `cargo bench -p braid-verify --bench preflight_alloc --locked` | accepted and rejected preflight: **0 allocations** |

## What is still not done

The aggregate ceilings are constants, not a caller-selectable policy. Pass 2 still projects the complete owned `Value`; direct borrowed capsule-field projection remains outside this issue. The benchmark measures the process allocator on one representative accepted capsule and one hostile node-count input, not RSS across every ceiling category.
