### PR TITLE
Ship bounded native Braid Capsule DSL v0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ name = "braid-cli"
 version = "0.1.0"
 dependencies = [
  "braid-capability",
+ "braid-elaborate-dsl",
  "braid-ir",
  "braid-manifest",
  "braid-render",
@@ -104,6 +105,24 @@ dependencies = [
  "braid-vocab-cms",
  "lgwks_std",
  "lgwks_std_gate",
+ "serde",
+]
+
+[[package]]
+name = "braid-elaborate-dsl"
+version = "0.1.0"
+dependencies = [
+ "braid-capability",
+ "braid-flow-ir",
+ "braid-flow-plan",
+ "braid-ir",
+ "braid-render",
+ "braid-run",
+ "braid-sdk",
+ "braid-verify",
+ "braid-vocab-cms",
+ "lgwks_std",
+ "proptest",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/braid-render",
     "crates/braid-sdk",
     "crates/braid-cli",
+    "crates/braid-elaborate-dsl",
     "crates/braid-elaborate-js",
     "crates/braid-project",
     "crates/braid-runtime",
@@ -69,6 +70,7 @@ braid-render = { path = "crates/braid-render" }
 braid-sdk = { path = "crates/braid-sdk" }
 braid-manifest = { path = "crates/braid-manifest" }
 braid-runtime = { path = "crates/braid-runtime" }
+braid-elaborate-dsl = { path = "crates/braid-elaborate-dsl" }
 
 [patch.crates-io]
 # While developing against the in-repo implementation, keep the public contract

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ path; that plan is a cache, never a second wire or an authority credential.
 | `crates/braid-verify` | Independent strict decoder + fail-closed admission pipeline; emits CID-bound `AdmissionProof` + `P × P × U` compact `AdmittedCapsule` projection. |
 | `crates/braid-render` | CID-bound manifest, deterministic text rendering, widening/narrowing diff, DOT export. |
 | `crates/braid-sdk` | Typed authoring builder over `braid-ir`. |
-| `crates/braid-cli` | The `braid` binary: encode, decode, verify, render, diff, catalog, store. |
+| `crates/braid-cli` | The `braid` binary: DSL check/compile, encode, decode, verify, render, diff, catalog, store. |
 | `crates/braid-manifest` | Repository-manifest sibling artifact (closed dimensions, canonical bytes, CID). |
 | `crates/braid-run` | Deterministic DAG evaluation + capability-gated effect dispatch. |
 | `crates/braid-governance` | Signed Keel change envelopes, budgets, allowlists, commitments, expiry. |
 | `crates/braid-runtime` | Executable startup contract (validated args + one startup-failure path). |
 | `crates/braid-elaborate-js` | Operator-precedence JS expression frontend that elaborates text into admitted capsules. |
+| `crates/braid-elaborate-dsl` | Bounded native Braid DSL frontend for namespaced capsule graphs; lowers to the existing wire and independent verifier. |
 | `crates/braid-project` | Multi-capsule project manifest and deterministic `braid-project build`. |
 | `crates/braid-integrate` | Repo-graph advisor — proposes `lgwks_std` / `lgwks_bot` seams (`braid-integrate --json`). |
 | `crates/braid-vocab-cms` | CMS vocabulary — the kernel term registry and capability verbs. |
@@ -51,6 +52,14 @@ path; that plan is a cache, never a second wire or an authority credential.
 | `spec/braid/` | PRD, decision register, threat model, KAT vectors. |
 
 ## Build & test
+
+Check or compile a native Braid DSL source without introducing another wire or
+verifier:
+
+```bash
+cargo run -p braid-cli -- dsl check crates/braid-elaborate-dsl/tests/fixtures/edit-home-hero.brd
+cargo run -p braid-cli -- dsl compile crates/braid-elaborate-dsl/tests/fixtures/edit-home-hero.brd -o /tmp/edit-home-hero.braid
+```
 
 ```bash
 cargo check --workspace

--- a/crates/braid-cli/Cargo.toml
+++ b/crates/braid-cli/Cargo.toml
@@ -26,6 +26,7 @@ braid-sdk = { path = "../braid-sdk" }
 braid-capability = { workspace = true }
 braid-vocab-cms = { workspace = true }
 braid-manifest = { workspace = true }
+braid-elaborate-dsl = { workspace = true }
 lgwks_std = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 

--- a/crates/braid-cli/src/cli.rs
+++ b/crates/braid-cli/src/cli.rs
@@ -36,6 +36,7 @@
 
 use std::process::ExitCode;
 
+use braid_elaborate_dsl::{ErrorCode as DslErrorCode, MAX_SOURCE_BYTES, elaborate};
 use braid_ir::{Capsule, ConfirmPolicy};
 use braid_render::{DeltaKind, has_widening, manifest, manifest_diff, render_text};
 use braid_sdk::Builder;
@@ -99,6 +100,7 @@ pub fn run(args: &[String]) -> ExitCode {
         "verify" => cmd_verify(rest),
         "render" => cmd_render(rest),
         "diff" => cmd_diff(rest),
+        "dsl" => cmd_dsl(rest),
         "store" => crate::store::cmd_store(rest),
         "catalog" => crate::store::cmd_catalog(rest),
         "summary" => crate::store::cmd_summary(rest),
@@ -139,6 +141,9 @@ USAGE:
     braid verify <capsule.braid> [--grant <cap>] run the admission pipeline (exit 1 on Reject)
     braid render <capsule.braid>                 the human-review manifest
     braid diff <old.braid> <new.braid>           manifest delta (exit 1 on any Widening)
+    braid dsl check <source.brd>                  parse + lower + independently admit, write nothing
+    braid dsl compile <source.brd> -o <out.braid> [--emit-json <out.json>]
+                                                  admitted Braid DSL -> canonical bytes
     braid store put <repo-manifest.json> [--store <dir>] [--replace]
                                                   validate + install one repo manifest
     braid catalog [--store <dir>]                 the org map (declared inventory == store)
@@ -148,6 +153,97 @@ EXIT CODES: 0 ok · 1 policy-negative / fail-closed denial · 2 operator error
 
 `verify --grant` may repeat; it sets the ambient authority the principal holds.
 Default ambient = the capsule's own declared grants (the happy-path check).";
+
+// ───────────────────────────────── DSL ────────────────────────────────────
+
+fn read_dsl_source(path: &str) -> Result<String, String> {
+    let metadata = std::fs::metadata(path).map_err(|error| format!("read {path}: {error}"))?;
+    let length = usize::try_from(metadata.len())
+        .map_err(|_| format!("{path}: source length does not fit this platform"))?;
+    if length > MAX_SOURCE_BYTES {
+        return Err(format!(
+            "{path}: {} at byte 0: source is {length} bytes; maximum is {MAX_SOURCE_BYTES}",
+            DslErrorCode::SourceTooLarge.as_str()
+        ));
+    }
+    let bytes = std::fs::read(path).map_err(|error| format!("read {path}: {error}"))?;
+    String::from_utf8(bytes).map_err(|error| {
+        format!(
+            "{path}: BRD003_INVALID_TOKEN at byte {}: source is not UTF-8",
+            error.utf8_error().valid_up_to()
+        )
+    })
+}
+
+fn cmd_dsl(args: &[String]) -> CliResult {
+    let Some(action) = args.first() else {
+        return Err("dsl needs `check` or `compile`".into());
+    };
+    let mut source_path = None;
+    let mut output_path = None;
+    let mut json_path = None;
+    let mut cursor = 1;
+    while cursor < args.len() {
+        match args[cursor].as_str() {
+            "-o" | "--out" => {
+                output_path = Some(args.get(cursor + 1).ok_or("`--out` needs a path")?.as_str());
+                cursor += 2;
+            }
+            "--emit-json" => {
+                json_path = Some(
+                    args.get(cursor + 1)
+                        .ok_or("`--emit-json` needs a path")?
+                        .as_str(),
+                );
+                cursor += 2;
+            }
+            value if !value.starts_with('-') && source_path.is_none() => {
+                source_path = Some(value);
+                cursor += 1;
+            }
+            other => return Err(format!("unexpected arg `{other}` (dsl {action})")),
+        }
+    }
+    let source_path = source_path.ok_or_else(|| format!("dsl {action} needs <source.brd>"))?;
+    match action.as_str() {
+        "check" if output_path.is_some() || json_path.is_some() => {
+            return Err("dsl check does not accept output paths; use `dsl compile`".into());
+        }
+        "check" => {}
+        "compile" if output_path.is_none() => {
+            return Err("dsl compile needs `-o <out.braid>`".into());
+        }
+        "compile" => {}
+        other => {
+            return Err(format!(
+                "unknown dsl action `{other}`; use `check` or `compile`"
+            ));
+        }
+    }
+
+    let source = read_dsl_source(source_path)?;
+    let result = match elaborate(&source) {
+        Ok(value) => value,
+        Err(error) if error.code == DslErrorCode::VerificationRejected => {
+            println!("REJECT {}", error);
+            return Err(POLICY_NEGATIVE.into());
+        }
+        Err(error) => return Err(format!("{source_path}: {error}")),
+    };
+
+    if let Some(path) = output_path {
+        std::fs::write(path, &result.bytes).map_err(|error| format!("write {path}: {error}"))?;
+        eprintln!("wrote {path} ({} bytes)", result.bytes.len());
+    }
+    if let Some(path) = json_path {
+        std::fs::write(path, result.json_ir.as_bytes())
+            .map_err(|error| format!("write {path}: {error}"))?;
+        eprintln!("wrote {path} (JSON-of-IR parity transport)");
+    }
+    eprintln!("cid {}", result.capsule.cid().to_hex());
+    println!("{}", result.manifest_text);
+    Ok(())
+}
 
 // ───────────────────────────────── encode ─────────────────────────────────
 

--- a/crates/braid-cli/tests/dsl.rs
+++ b/crates/braid-cli/tests/dsl.rs
@@ -1,0 +1,141 @@
+//! Black-box Braid DSL journey: source -> canonical bytes -> independent
+//! admission, with JSON-of-IR parity and widening visibility.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn braid() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_braid"))
+}
+
+fn dsl_fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../braid-elaborate-dsl/tests/fixtures")
+        .join(name)
+}
+
+fn tmp(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_TARGET_TMPDIR")).join(name)
+}
+
+fn run(args: &[&str]) -> Output {
+    braid().args(args).output().expect("braid binary runs")
+}
+
+fn compile_and_compare(name: &str, stem: &str, expected_cid: &str) -> PathBuf {
+    let source = dsl_fixture(name);
+    let dsl_bytes = tmp(&format!("{stem}.braid"));
+    let json = tmp(&format!("{stem}.json"));
+    let json_bytes = tmp(&format!("{stem}-json.braid"));
+    let output = run(&[
+        "dsl",
+        "compile",
+        source.to_str().unwrap(),
+        "-o",
+        dsl_bytes.to_str().unwrap(),
+        "--emit-json",
+        json.to_str().unwrap(),
+    ]);
+    assert!(
+        output.status.success(),
+        "DSL compile failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected_cid),
+        "compile receipt did not contain pinned CID"
+    );
+
+    let encoded = run(&[
+        "encode",
+        json.to_str().unwrap(),
+        "-o",
+        json_bytes.to_str().unwrap(),
+    ]);
+    assert!(
+        encoded.status.success(),
+        "JSON parity encode failed: {}",
+        String::from_utf8_lossy(&encoded.stderr)
+    );
+    assert_eq!(
+        std::fs::read(&dsl_bytes).unwrap(),
+        std::fs::read(&json_bytes).unwrap(),
+        "DSL and JSON-of-IR paths must emit identical canonical bytes"
+    );
+    dsl_bytes
+}
+
+#[test]
+fn three_demo_port_sources_match_json_transport_and_pinned_cids() {
+    let cases = [
+        (
+            "edit-home-hero.brd",
+            "dsl-edit",
+            "26f6162e1a5fb5f6e3a46724a991a8b4dc48e08c223016fb86c3c8de38594226",
+        ),
+        (
+            "publish-services.brd",
+            "dsl-publish",
+            "195a7455e56b42dde32a79218c1b675420bc2de310184d16413a027d6261f33a",
+        ),
+        (
+            "render-work-listing.brd",
+            "dsl-listing",
+            "43ed11f1d863a214ca4ac51bbfaa5078166ddcc228fda717c25fa358bf8da3a6",
+        ),
+    ];
+    for (name, stem, cid) in cases {
+        let artifact = compile_and_compare(name, stem, cid);
+        let verified = run(&["verify", artifact.to_str().unwrap()]);
+        assert!(verified.status.success());
+        assert!(String::from_utf8_lossy(&verified.stdout).contains("ADMIT"));
+    }
+}
+
+#[test]
+fn source_capability_change_is_a_visible_widening() {
+    let edit = compile_and_compare(
+        "edit-home-hero.brd",
+        "dsl-diff-edit",
+        "26f6162e1a5fb5f6e3a46724a991a8b4dc48e08c223016fb86c3c8de38594226",
+    );
+    let publish = compile_and_compare(
+        "publish-services.brd",
+        "dsl-diff-publish",
+        "195a7455e56b42dde32a79218c1b675420bc2de310184d16413a027d6261f33a",
+    );
+    let diff = run(&["diff", edit.to_str().unwrap(), publish.to_str().unwrap()]);
+    assert_eq!(diff.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&diff.stdout);
+    assert!(stdout.contains("WIDENING"), "got: {stdout}");
+    assert!(stdout.contains("intent.emit"), "got: {stdout}");
+}
+
+#[test]
+fn failed_source_writes_no_artifact() {
+    let source_path = tmp("dsl-unconfirmed.brd");
+    let artifact_path = tmp("dsl-unconfirmed.braid");
+    let source = std::fs::read_to_string(dsl_fixture("publish-services.brd"))
+        .unwrap()
+        .replace("confirm human", "confirm none");
+    std::fs::write(&source_path, source).unwrap();
+    drop(std::fs::remove_file(&artifact_path));
+
+    let output = run(&[
+        "dsl",
+        "compile",
+        source_path.to_str().unwrap(),
+        "-o",
+        artifact_path.to_str().unwrap(),
+    ]);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(!artifact_path.exists(), "failed compile wrote an artifact");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("BRD014_BUILD_REJECTED"));
+}
+
+#[test]
+fn public_help_exposes_the_dsl_entrypoint() {
+    let output = run(&["--help"]);
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("braid dsl compile"));
+}

--- a/crates/braid-elaborate-dsl/Cargo.toml
+++ b/crates/braid-elaborate-dsl/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "braid-elaborate-dsl"
+version = "0.1.0"
+edition = "2024"
+description = "Bounded Braid DSL frontend: namespaced source to independently admitted canonical capsules"
+repository = "https://github.com/srinji-kaggss/Braid"
+homepage = "https://github.com/srinji-kaggss/Braid"
+license = "MIT"
+
+[dependencies]
+braid-capability = { workspace = true }
+braid-ir = { workspace = true }
+braid-render = { workspace = true }
+braid-sdk = { workspace = true }
+braid-verify = { workspace = true }
+braid-vocab-cms = { workspace = true }
+lgwks_std = { workspace = true, features = ["json"] }
+serde = { workspace = true }
+
+[dev-dependencies]
+braid-flow-ir = { workspace = true }
+braid-flow-plan = { path = "../braid-flow-plan" }
+braid-run = { path = "../braid-run" }
+proptest = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+all = "warn"
+pedantic = "warn"

--- a/crates/braid-elaborate-dsl/src/lib.rs
+++ b/crates/braid-elaborate-dsl/src/lib.rs
@@ -1,0 +1,1169 @@
+//! Bounded Braid DSL frontend.
+//!
+//! This crate is deliberately outside the verifier trust base. It parses the
+//! versioned Braid DSL v0 subset, lowers through [`braid_sdk::Builder`], emits
+//! the existing canonical capsule bytes, and asks the independent
+//! `braid-verify` implementation to admit those bytes. It owns no wire format
+//! and no admission rule.
+
+#![forbid(unsafe_code)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use braid_ir::{Capsule, ConfirmPolicy, EffectClass};
+use braid_render::{manifest, render_text};
+use braid_sdk::{Builder, Strand};
+use braid_verify::{Verdict, verify};
+use braid_vocab_cms::registry_v0;
+use serde::Serialize;
+
+/// Source-language version accepted by this implementation.
+pub const DSL_VERSION: u64 = 0;
+/// Whole-source ceiling, enforced before tokens or AST nodes are allocated.
+pub const MAX_SOURCE_BYTES: usize = 65_536;
+/// Maximum token count.
+pub const MAX_TOKENS: usize = 4_096;
+/// Maximum bindings in one step.
+pub const MAX_BINDINGS: usize = 1_024;
+/// Maximum calls in one pipeline expression.
+pub const MAX_PIPELINE_CALLS: usize = 64;
+/// Maximum identifier length in bytes.
+pub const MAX_IDENTIFIER_BYTES: usize = 128;
+/// Maximum decoded string length in bytes.
+pub const MAX_STRING_BYTES: usize = 4_096;
+
+/// Stable machine-readable DSL failure category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCode {
+    SourceTooLarge,
+    TooManyTokens,
+    InvalidToken,
+    UnexpectedToken,
+    MissingField,
+    DuplicateField,
+    UnsupportedConstruct,
+    UnsupportedVersion,
+    UnsupportedRegistry,
+    LimitExceeded,
+    DuplicateBinding,
+    UnknownBinding,
+    UnknownTerm,
+    BuildRejected,
+    CapabilityMismatch,
+    EffectMismatch,
+    VerificationRejected,
+    RenderFailed,
+    SerializationFailed,
+}
+
+impl ErrorCode {
+    /// Stable diagnostic identifier suitable for scripts and refusal corpora.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SourceTooLarge => "BRD001_SOURCE_TOO_LARGE",
+            Self::TooManyTokens => "BRD002_TOO_MANY_TOKENS",
+            Self::InvalidToken => "BRD003_INVALID_TOKEN",
+            Self::UnexpectedToken => "BRD004_UNEXPECTED_TOKEN",
+            Self::MissingField => "BRD005_MISSING_FIELD",
+            Self::DuplicateField => "BRD006_DUPLICATE_FIELD",
+            Self::UnsupportedConstruct => "BRD007_UNSUPPORTED_CONSTRUCT",
+            Self::UnsupportedVersion => "BRD008_UNSUPPORTED_VERSION",
+            Self::UnsupportedRegistry => "BRD009_UNSUPPORTED_REGISTRY",
+            Self::LimitExceeded => "BRD010_LIMIT_EXCEEDED",
+            Self::DuplicateBinding => "BRD011_DUPLICATE_BINDING",
+            Self::UnknownBinding => "BRD012_UNKNOWN_BINDING",
+            Self::UnknownTerm => "BRD013_UNKNOWN_TERM",
+            Self::BuildRejected => "BRD014_BUILD_REJECTED",
+            Self::CapabilityMismatch => "BRD015_CAPABILITY_MISMATCH",
+            Self::EffectMismatch => "BRD016_EFFECT_MISMATCH",
+            Self::VerificationRejected => "BRD017_VERIFICATION_REJECTED",
+            Self::RenderFailed => "BRD018_RENDER_FAILED",
+            Self::SerializationFailed => "BRD019_SERIALIZATION_FAILED",
+        }
+    }
+}
+
+/// Typed source or lowering diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DslError {
+    /// Stable category.
+    pub code: ErrorCode,
+    /// UTF-8 byte offset in source, or zero for post-parse failures.
+    pub offset: usize,
+    /// Human-readable cause and correction.
+    pub message: String,
+}
+
+impl DslError {
+    fn new(code: ErrorCode, offset: usize, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            offset,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for DslError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} at byte {}: {}",
+            self.code.as_str(),
+            self.offset,
+            self.message
+        )
+    }
+}
+
+impl std::error::Error for DslError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TokenKind {
+    Ident(String),
+    String(String),
+    Integer(u64),
+    LeftBrace,
+    RightBrace,
+    LeftBracket,
+    RightBracket,
+    LeftParen,
+    RightParen,
+    Comma,
+    Semicolon,
+    Equals,
+    PathSep,
+    Pipe,
+    Eof,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Token {
+    kind: TokenKind,
+    offset: usize,
+}
+
+fn push_token(tokens: &mut Vec<Token>, kind: TokenKind, offset: usize) -> Result<(), DslError> {
+    if tokens.len() >= MAX_TOKENS {
+        return Err(DslError::new(
+            ErrorCode::TooManyTokens,
+            offset,
+            format!("source exceeds the {MAX_TOKENS}-token ceiling"),
+        ));
+    }
+    tokens.push(Token { kind, offset });
+    Ok(())
+}
+
+fn is_ident_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+fn is_ident_continue(byte: u8) -> bool {
+    is_ident_start(byte) || byte.is_ascii_digit()
+}
+
+fn lex_identifier(source: &str, start: usize, end: usize) -> Result<String, DslError> {
+    let len = end - start;
+    if len > MAX_IDENTIFIER_BYTES {
+        return Err(DslError::new(
+            ErrorCode::LimitExceeded,
+            start,
+            format!("identifier is {len} bytes; maximum is {MAX_IDENTIFIER_BYTES}"),
+        ));
+    }
+    Ok(source[start..end].to_owned())
+}
+
+fn lex_string(source: &str, start: usize) -> Result<(String, usize), DslError> {
+    let bytes = source.as_bytes();
+    let mut cursor = start + 1;
+    let mut value = String::new();
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'"' => return Ok((value, cursor + 1)),
+            b'\\' => {
+                let escape_offset = cursor;
+                cursor += 1;
+                let escaped = *bytes.get(cursor).ok_or_else(|| {
+                    DslError::new(
+                        ErrorCode::InvalidToken,
+                        escape_offset,
+                        "unterminated string escape; close the quoted string",
+                    )
+                })?;
+                let decoded = match escaped {
+                    b'"' => '"',
+                    b'\\' => '\\',
+                    b'n' => '\n',
+                    b'r' => '\r',
+                    b't' => '\t',
+                    _ => {
+                        return Err(DslError::new(
+                            ErrorCode::InvalidToken,
+                            escape_offset,
+                            r#"unsupported escape; use \" \\ \n \r or \t"#,
+                        ));
+                    }
+                };
+                value.push(decoded);
+                cursor += 1;
+            }
+            byte if byte.is_ascii_control() => {
+                return Err(DslError::new(
+                    ErrorCode::InvalidToken,
+                    cursor,
+                    "raw control characters are forbidden in strings; use an explicit escape",
+                ));
+            }
+            _ => {
+                let ch = source[cursor..].chars().next().ok_or_else(|| {
+                    DslError::new(ErrorCode::InvalidToken, cursor, "invalid UTF-8 boundary")
+                })?;
+                value.push(ch);
+                cursor += ch.len_utf8();
+            }
+        }
+        if value.len() > MAX_STRING_BYTES {
+            return Err(DslError::new(
+                ErrorCode::LimitExceeded,
+                start,
+                format!("string exceeds the {MAX_STRING_BYTES}-byte ceiling"),
+            ));
+        }
+    }
+    Err(DslError::new(
+        ErrorCode::InvalidToken,
+        start,
+        "unterminated string; add a closing quote",
+    ))
+}
+
+// A single exhaustive byte dispatch keeps the accepted character surface
+// reviewable beside the grammar; splitting it would hide that security boundary.
+#[allow(clippy::too_many_lines)]
+fn lex(source: &str) -> Result<Vec<Token>, DslError> {
+    if source.len() > MAX_SOURCE_BYTES {
+        return Err(DslError::new(
+            ErrorCode::SourceTooLarge,
+            0,
+            format!(
+                "source is {} bytes; maximum is {MAX_SOURCE_BYTES}",
+                source.len()
+            ),
+        ));
+    }
+
+    let bytes = source.as_bytes();
+    let mut tokens = Vec::new();
+    let mut cursor = 0;
+    while cursor < bytes.len() {
+        let start = cursor;
+        match bytes[cursor] {
+            byte if byte.is_ascii_whitespace() => cursor += 1,
+            b'/' if bytes.get(cursor + 1) == Some(&b'/') => {
+                cursor += 2;
+                while cursor < bytes.len() && bytes[cursor] != b'\n' {
+                    cursor += 1;
+                }
+            }
+            byte if is_ident_start(byte) => {
+                cursor += 1;
+                while cursor < bytes.len() && is_ident_continue(bytes[cursor]) {
+                    cursor += 1;
+                }
+                let ident = lex_identifier(source, start, cursor)?;
+                push_token(&mut tokens, TokenKind::Ident(ident), start)?;
+            }
+            byte if byte.is_ascii_digit() => {
+                cursor += 1;
+                while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+                    cursor += 1;
+                }
+                let value = source[start..cursor].parse::<u64>().map_err(|_| {
+                    DslError::new(
+                        ErrorCode::LimitExceeded,
+                        start,
+                        "integer exceeds the unsigned 64-bit source limit",
+                    )
+                })?;
+                push_token(&mut tokens, TokenKind::Integer(value), start)?;
+            }
+            b'"' => {
+                let (value, end) = lex_string(source, start)?;
+                cursor = end;
+                push_token(&mut tokens, TokenKind::String(value), start)?;
+            }
+            b'{' => {
+                cursor += 1;
+                push_token(&mut tokens, TokenKind::LeftBrace, start)?;
+            }
+            b'}' => {
+                cursor += 1;
+                push_token(&mut tokens, TokenKind::RightBrace, start)?;
+            }
+            b'[' => {
+                cursor += 1;
+                push_token(&mut tokens, TokenKind::LeftBracket, start)?;
+            }
+            b']' => {
+                cursor += 1;
+                push_token(&mut tokens, TokenKind::RightBracket, start)?;
+            }
+            b'(' => {
+                cursor += 1;
+                push_token(&mut tokens, TokenKind::LeftParen, start)?;
+            }
+            b')' => {
+                cursor += 1;
+                push_token(&mut tokens, TokenKind::RightParen, start)?;
+            }
+            b',' => {
+                cursor += 1;
+                push_token(&mut tokens, TokenKind::Comma, start)?;
+            }
+            b';' => {
+                cursor += 1;
+                push_token(&mut tokens, TokenKind::Semicolon, start)?;
+            }
+            b'=' => {
+                cursor += 1;
+                push_token(&mut tokens, TokenKind::Equals, start)?;
+            }
+            b':' if bytes.get(cursor + 1) == Some(&b':') => {
+                cursor += 2;
+                push_token(&mut tokens, TokenKind::PathSep, start)?;
+            }
+            b'|' if bytes.get(cursor + 1) == Some(&b'>') => {
+                cursor += 2;
+                push_token(&mut tokens, TokenKind::Pipe, start)?;
+            }
+            other => {
+                return Err(DslError::new(
+                    ErrorCode::InvalidToken,
+                    start,
+                    format!(
+                        "unsupported byte `{}`; v0 accepts only the closed grammar",
+                        char::from(other)
+                    ),
+                ));
+            }
+        }
+    }
+    tokens.push(Token {
+        kind: TokenKind::Eof,
+        offset: source.len(),
+    });
+    Ok(tokens)
+}
+
+/// Parsed Braid DSL document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Document {
+    name: String,
+    version: u64,
+    intent: String,
+    registry: String,
+    capabilities: Vec<String>,
+    effects: Vec<String>,
+    budget: Option<u64>,
+    confirm: ConfirmPolicy,
+    evidence: Vec<String>,
+    step: Step,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Step {
+    name: String,
+    bindings: Vec<Binding>,
+    outputs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Binding {
+    name: String,
+    expression: Expression,
+    offset: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Expression {
+    seed: Option<String>,
+    calls: Vec<Call>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Call {
+    path: String,
+    args: Vec<String>,
+    offset: usize,
+}
+
+struct Parser {
+    tokens: Vec<Token>,
+    cursor: usize,
+}
+
+impl Parser {
+    fn new(tokens: Vec<Token>) -> Self {
+        Self { tokens, cursor: 0 }
+    }
+
+    fn current(&self) -> &Token {
+        &self.tokens[self.cursor]
+    }
+
+    fn advance(&mut self) -> Token {
+        let token = self.current().clone();
+        if !matches!(token.kind, TokenKind::Eof) {
+            self.cursor += 1;
+        }
+        token
+    }
+
+    fn peek_keyword(&self, keyword: &str) -> bool {
+        matches!(&self.current().kind, TokenKind::Ident(value) if value == keyword)
+    }
+
+    fn next_is_pipe(&self) -> bool {
+        matches!(self.current().kind, TokenKind::Ident(_))
+            && matches!(
+                self.tokens.get(self.cursor + 1).map(|token| &token.kind),
+                Some(TokenKind::Pipe)
+            )
+    }
+
+    fn expect_keyword(&mut self, keyword: &str) -> Result<usize, DslError> {
+        let token = self.advance();
+        match token.kind {
+            TokenKind::Ident(value) if value == keyword => Ok(token.offset),
+            other => Err(DslError::new(
+                ErrorCode::UnexpectedToken,
+                token.offset,
+                format!("expected keyword `{keyword}`, found {other:?}"),
+            )),
+        }
+    }
+
+    // Punctuation tokens are tiny. Passing the expected value makes each call
+    // site read like the grammar and avoids reference noise.
+    #[allow(clippy::needless_pass_by_value)]
+    fn expect_simple(&mut self, expected: TokenKind, label: &str) -> Result<usize, DslError> {
+        let token = self.advance();
+        if token.kind == expected {
+            Ok(token.offset)
+        } else {
+            Err(DslError::new(
+                ErrorCode::UnexpectedToken,
+                token.offset,
+                format!("expected {label}, found {:?}", token.kind),
+            ))
+        }
+    }
+
+    fn parse_ident(&mut self) -> Result<(String, usize), DslError> {
+        let token = self.advance();
+        match token.kind {
+            TokenKind::Ident(value) => Ok((value, token.offset)),
+            other => Err(DslError::new(
+                ErrorCode::UnexpectedToken,
+                token.offset,
+                format!("expected identifier, found {other:?}"),
+            )),
+        }
+    }
+
+    fn parse_integer(&mut self) -> Result<u64, DslError> {
+        let token = self.advance();
+        match token.kind {
+            TokenKind::Integer(value) => Ok(value),
+            other => Err(DslError::new(
+                ErrorCode::UnexpectedToken,
+                token.offset,
+                format!("expected integer, found {other:?}"),
+            )),
+        }
+    }
+
+    fn parse_string(&mut self) -> Result<String, DslError> {
+        let token = self.advance();
+        match token.kind {
+            TokenKind::String(value) => Ok(value),
+            other => Err(DslError::new(
+                ErrorCode::UnexpectedToken,
+                token.offset,
+                format!("expected quoted string, found {other:?}"),
+            )),
+        }
+    }
+
+    fn parse_path(&mut self) -> Result<(String, usize), DslError> {
+        let (first, offset) = self.parse_ident()?;
+        self.expect_simple(TokenKind::PathSep, "`::` in a namespaced path")?;
+        let (second, _) = self.parse_ident()?;
+        let mut path = format!("{first}::{second}");
+        while matches!(self.current().kind, TokenKind::PathSep) {
+            self.advance();
+            let (part, _) = self.parse_ident()?;
+            path.push_str("::");
+            path.push_str(&part);
+        }
+        Ok((path, offset))
+    }
+
+    fn parse_path_list(&mut self) -> Result<Vec<String>, DslError> {
+        self.expect_simple(TokenKind::LeftBracket, "`[`")?;
+        let mut values = Vec::new();
+        if !matches!(self.current().kind, TokenKind::RightBracket) {
+            loop {
+                values.push(self.parse_path()?.0);
+                if matches!(self.current().kind, TokenKind::Comma) {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+        }
+        self.expect_simple(TokenKind::RightBracket, "`]`")?;
+        Ok(values)
+    }
+
+    fn parse_ident_list(&mut self) -> Result<Vec<String>, DslError> {
+        self.expect_simple(TokenKind::LeftBracket, "`[`")?;
+        let mut values = Vec::new();
+        if !matches!(self.current().kind, TokenKind::RightBracket) {
+            loop {
+                values.push(self.parse_ident()?.0);
+                if matches!(self.current().kind, TokenKind::Comma) {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+        }
+        self.expect_simple(TokenKind::RightBracket, "`]`")?;
+        Ok(values)
+    }
+
+    fn parse_string_list(&mut self) -> Result<Vec<String>, DslError> {
+        self.expect_simple(TokenKind::LeftBracket, "`[`")?;
+        let mut values = Vec::new();
+        if !matches!(self.current().kind, TokenKind::RightBracket) {
+            loop {
+                values.push(self.parse_string()?);
+                if matches!(self.current().kind, TokenKind::Comma) {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+        }
+        self.expect_simple(TokenKind::RightBracket, "`]`")?;
+        Ok(values)
+    }
+
+    fn parse_require(&mut self) -> Result<(Vec<String>, Vec<String>), DslError> {
+        self.expect_keyword("require")?;
+        self.expect_simple(TokenKind::LeftBrace, "`{`")?;
+        let mut capabilities = None;
+        let mut effects = None;
+        while !matches!(self.current().kind, TokenKind::RightBrace) {
+            if self.peek_keyword("capabilities") {
+                let offset = self.expect_keyword("capabilities")?;
+                if capabilities.is_some() {
+                    return Err(DslError::new(
+                        ErrorCode::DuplicateField,
+                        offset,
+                        "`capabilities` appears more than once",
+                    ));
+                }
+                capabilities = Some(self.parse_path_list()?);
+            } else if self.peek_keyword("effects") {
+                let offset = self.expect_keyword("effects")?;
+                if effects.is_some() {
+                    return Err(DslError::new(
+                        ErrorCode::DuplicateField,
+                        offset,
+                        "`effects` appears more than once",
+                    ));
+                }
+                effects = Some(self.parse_ident_list()?);
+            } else {
+                return Err(DslError::new(
+                    ErrorCode::UnexpectedToken,
+                    self.current().offset,
+                    "require block accepts only `capabilities` and `effects`",
+                ));
+            }
+            self.expect_simple(TokenKind::Semicolon, "`;`")?;
+        }
+        self.expect_simple(TokenKind::RightBrace, "`}`")?;
+        Ok((
+            capabilities.ok_or_else(|| {
+                DslError::new(
+                    ErrorCode::MissingField,
+                    0,
+                    "require block needs `capabilities [...]`",
+                )
+            })?,
+            effects.ok_or_else(|| {
+                DslError::new(
+                    ErrorCode::MissingField,
+                    0,
+                    "require block needs `effects [...]`",
+                )
+            })?,
+        ))
+    }
+
+    fn parse_call(&mut self) -> Result<Call, DslError> {
+        let (path, offset) = self.parse_path()?;
+        self.expect_simple(TokenKind::LeftParen, "`(`")?;
+        let mut args = Vec::new();
+        if !matches!(self.current().kind, TokenKind::RightParen) {
+            loop {
+                args.push(self.parse_ident()?.0);
+                if matches!(self.current().kind, TokenKind::Comma) {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+        }
+        self.expect_simple(TokenKind::RightParen, "`)`")?;
+        Ok(Call { path, args, offset })
+    }
+
+    fn parse_expression(&mut self) -> Result<Expression, DslError> {
+        let seed = if self.next_is_pipe() {
+            let (name, _) = self.parse_ident()?;
+            self.expect_simple(TokenKind::Pipe, "`|>`")?;
+            Some(name)
+        } else {
+            None
+        };
+        let mut calls = vec![self.parse_call()?];
+        while matches!(self.current().kind, TokenKind::Pipe) {
+            if calls.len() >= MAX_PIPELINE_CALLS {
+                return Err(DslError::new(
+                    ErrorCode::LimitExceeded,
+                    self.current().offset,
+                    format!("pipeline exceeds {MAX_PIPELINE_CALLS} calls"),
+                ));
+            }
+            self.advance();
+            calls.push(self.parse_call()?);
+        }
+        Ok(Expression { seed, calls })
+    }
+
+    fn parse_step(&mut self) -> Result<Step, DslError> {
+        self.expect_keyword("step")?;
+        let (name, _) = self.parse_ident()?;
+        self.expect_simple(TokenKind::LeftBrace, "`{`")?;
+        let mut bindings = Vec::new();
+        let mut outputs = None;
+        while !matches!(self.current().kind, TokenKind::RightBrace) {
+            if self.peek_keyword("output") {
+                self.expect_keyword("output")?;
+                outputs = Some(self.parse_ident_list()?);
+                self.expect_simple(TokenKind::Semicolon, "`;`")?;
+                if !matches!(self.current().kind, TokenKind::RightBrace) {
+                    return Err(DslError::new(
+                        ErrorCode::UnexpectedToken,
+                        self.current().offset,
+                        "`output` must be the final statement in a step",
+                    ));
+                }
+                continue;
+            }
+            if bindings.len() >= MAX_BINDINGS {
+                return Err(DslError::new(
+                    ErrorCode::LimitExceeded,
+                    self.current().offset,
+                    format!("step exceeds {MAX_BINDINGS} bindings"),
+                ));
+            }
+            let (binding_name, offset) = self.parse_ident()?;
+            self.expect_simple(TokenKind::Equals, "`=`")?;
+            let expression = self.parse_expression()?;
+            self.expect_simple(TokenKind::Semicolon, "`;`")?;
+            bindings.push(Binding {
+                name: binding_name,
+                expression,
+                offset,
+            });
+        }
+        self.expect_simple(TokenKind::RightBrace, "`}`")?;
+        Ok(Step {
+            name,
+            bindings,
+            outputs: outputs.ok_or_else(|| {
+                DslError::new(
+                    ErrorCode::MissingField,
+                    0,
+                    "step needs a final `output [...]` declaration",
+                )
+            })?,
+        })
+    }
+
+    fn duplicate_header(offset: usize, name: &str) -> DslError {
+        DslError::new(
+            ErrorCode::DuplicateField,
+            offset,
+            format!("header `{name}` appears more than once"),
+        )
+    }
+
+    // Keeping the closed top-level dispatch together makes unsupported
+    // constructs and duplicate-header behavior auditable as one table.
+    #[allow(clippy::too_many_lines)]
+    fn parse_document(&mut self) -> Result<Document, DslError> {
+        self.expect_keyword("capsule")?;
+        let (name, _) = self.parse_path()?;
+        self.expect_keyword("version")?;
+        let version = self.parse_integer()?;
+        self.expect_simple(TokenKind::LeftBrace, "`{`")?;
+
+        let mut intent = None;
+        let mut registry = None;
+        let mut requirements = None;
+        let mut budget = None;
+        let mut confirm = None;
+        let mut evidence = None;
+        let mut step = None;
+
+        while !matches!(self.current().kind, TokenKind::RightBrace) {
+            if self.peek_keyword("intent") {
+                let offset = self.expect_keyword("intent")?;
+                if intent.is_some() {
+                    return Err(Self::duplicate_header(offset, "intent"));
+                }
+                intent = Some(self.parse_string()?);
+                self.expect_simple(TokenKind::Semicolon, "`;`")?;
+            } else if self.peek_keyword("registry") {
+                let offset = self.expect_keyword("registry")?;
+                if registry.is_some() {
+                    return Err(Self::duplicate_header(offset, "registry"));
+                }
+                registry = Some(self.parse_path()?.0);
+                self.expect_simple(TokenKind::Semicolon, "`;`")?;
+            } else if self.peek_keyword("require") {
+                let offset = self.current().offset;
+                if requirements.is_some() {
+                    return Err(Self::duplicate_header(offset, "require"));
+                }
+                requirements = Some(self.parse_require()?);
+            } else if self.peek_keyword("budget") {
+                let offset = self.expect_keyword("budget")?;
+                if budget.is_some() {
+                    return Err(Self::duplicate_header(offset, "budget"));
+                }
+                budget = Some(self.parse_integer()?);
+                self.expect_simple(TokenKind::Semicolon, "`;`")?;
+            } else if self.peek_keyword("confirm") {
+                let offset = self.expect_keyword("confirm")?;
+                if confirm.is_some() {
+                    return Err(Self::duplicate_header(offset, "confirm"));
+                }
+                let (value, value_offset) = self.parse_ident()?;
+                confirm = Some(match value.as_str() {
+                    "none" => ConfirmPolicy::None,
+                    "human" => ConfirmPolicy::HumanConfirm,
+                    _ => {
+                        return Err(DslError::new(
+                            ErrorCode::UnexpectedToken,
+                            value_offset,
+                            "confirm must be `none` or `human`",
+                        ));
+                    }
+                });
+                self.expect_simple(TokenKind::Semicolon, "`;`")?;
+            } else if self.peek_keyword("evidence") {
+                let offset = self.expect_keyword("evidence")?;
+                if evidence.is_some() {
+                    return Err(Self::duplicate_header(offset, "evidence"));
+                }
+                evidence = Some(self.parse_string_list()?);
+                self.expect_simple(TokenKind::Semicolon, "`;`")?;
+            } else if self.peek_keyword("step") {
+                let offset = self.current().offset;
+                if step.is_some() {
+                    return Err(Self::duplicate_header(offset, "step"));
+                }
+                step = Some(self.parse_step()?);
+            } else if matches!(
+                &self.current().kind,
+                TokenKind::Ident(value)
+                    if matches!(
+                        value.as_str(),
+                        "schema" | "state" | "statechart" | "orchestration" | "import" | "macro"
+                    )
+            ) {
+                return Err(DslError::new(
+                    ErrorCode::UnsupportedConstruct,
+                    self.current().offset,
+                    "construct is reserved but not representable by the v0 Capsule contract",
+                ));
+            } else {
+                return Err(DslError::new(
+                    ErrorCode::UnexpectedToken,
+                    self.current().offset,
+                    "expected intent, registry, require, budget, confirm, evidence, or step",
+                ));
+            }
+        }
+        self.expect_simple(TokenKind::RightBrace, "`}`")?;
+        self.expect_simple(TokenKind::Eof, "end of source")?;
+
+        let (capabilities, effects) = requirements.ok_or_else(|| {
+            DslError::new(ErrorCode::MissingField, 0, "capsule needs a require block")
+        })?;
+        Ok(Document {
+            name,
+            version,
+            intent: intent.ok_or_else(|| {
+                DslError::new(ErrorCode::MissingField, 0, "capsule needs `intent`")
+            })?,
+            registry: registry.ok_or_else(|| {
+                DslError::new(
+                    ErrorCode::MissingField,
+                    0,
+                    "capsule needs `registry cms::v1`",
+                )
+            })?,
+            capabilities,
+            effects,
+            budget,
+            confirm: confirm.unwrap_or(ConfirmPolicy::None),
+            evidence: evidence.unwrap_or_default(),
+            step: step.ok_or_else(|| {
+                DslError::new(ErrorCode::MissingField, 0, "capsule needs exactly one step")
+            })?,
+        })
+    }
+}
+
+/// Parse Braid DSL source without lowering it.
+///
+/// # Errors
+///
+/// Returns a typed [`DslError`] when source violates the grammar or a
+/// pre-allocation bound.
+pub fn parse(source: &str) -> Result<Document, DslError> {
+    Parser::new(lex(source)?).parse_document()
+}
+
+fn dotted(path: &str) -> String {
+    path.replace("::", ".")
+}
+
+fn lookup_binding(
+    bindings: &BTreeMap<String, Strand>,
+    name: &str,
+    offset: usize,
+) -> Result<Strand, DslError> {
+    bindings.get(name).copied().ok_or_else(|| {
+        DslError::new(
+            ErrorCode::UnknownBinding,
+            offset,
+            format!("binding `{name}` is not defined before this use"),
+        )
+    })
+}
+
+fn effect_name(effect: EffectClass) -> &'static str {
+    match effect {
+        EffectClass::Pure => "pure",
+        EffectClass::Read => "read",
+        EffectClass::ReversibleWrite => "reversible_write",
+        EffectClass::Irreversible => "irreversible",
+        EffectClass::Egress => "egress",
+    }
+}
+
+fn canonical_set(values: impl IntoIterator<Item = String>) -> BTreeSet<String> {
+    values.into_iter().collect()
+}
+
+fn reject_duplicates(values: &[String], label: &str) -> Result<(), DslError> {
+    let unique = canonical_set(values.iter().cloned());
+    if unique.len() == values.len() {
+        Ok(())
+    } else {
+        Err(DslError::new(
+            ErrorCode::DuplicateField,
+            0,
+            format!("{label} contains a duplicate entry"),
+        ))
+    }
+}
+
+fn compare_declared_set(
+    declared: &BTreeSet<String>,
+    derived: &BTreeSet<String>,
+    code: ErrorCode,
+    label: &str,
+) -> Result<(), DslError> {
+    if declared == derived {
+        return Ok(());
+    }
+    let missing: Vec<_> = derived.difference(declared).cloned().collect();
+    let extra: Vec<_> = declared.difference(derived).cloned().collect();
+    Err(DslError::new(
+        code,
+        0,
+        format!(
+            "declared {label} do not exactly match derived {label}; missing={missing:?}, extra={extra:?}"
+        ),
+    ))
+}
+
+// This is intentionally one visible lowering pipeline: validate source
+// declarations, build the graph, and compare derived authority before return.
+#[allow(clippy::too_many_lines)]
+fn lower_document(document: &Document) -> Result<Capsule, DslError> {
+    if document.version != DSL_VERSION {
+        return Err(DslError::new(
+            ErrorCode::UnsupportedVersion,
+            0,
+            format!(
+                "source version {} is unsupported; use version {DSL_VERSION}",
+                document.version
+            ),
+        ));
+    }
+    if document.registry != "cms::v1" {
+        return Err(DslError::new(
+            ErrorCode::UnsupportedRegistry,
+            0,
+            format!(
+                "registry `{}` is unsupported; v0 requires `cms::v1`",
+                document.registry
+            ),
+        ));
+    }
+    if document.step.name != "main" {
+        return Err(DslError::new(
+            ErrorCode::UnsupportedConstruct,
+            0,
+            "v0 requires the single step to be named `main`",
+        ));
+    }
+
+    reject_duplicates(&document.capabilities, "require.capabilities")?;
+    reject_duplicates(&document.effects, "require.effects")?;
+    reject_duplicates(&document.step.outputs, "step.output")?;
+
+    let registry = registry_v0();
+    let mut builder = Builder::new(&registry, document.intent.clone());
+    let mut bindings = BTreeMap::new();
+
+    for binding in &document.step.bindings {
+        if bindings.contains_key(&binding.name) {
+            return Err(DslError::new(
+                ErrorCode::DuplicateBinding,
+                binding.offset,
+                format!("binding `{}` is declared more than once", binding.name),
+            ));
+        }
+        let mut previous = binding
+            .expression
+            .seed
+            .as_deref()
+            .map(|name| lookup_binding(&bindings, name, binding.offset))
+            .transpose()?;
+        for call in &binding.expression.calls {
+            let term = dotted(&call.path);
+            if registry.get(&term).is_none() {
+                return Err(DslError::new(
+                    ErrorCode::UnknownTerm,
+                    call.offset,
+                    format!("term `{}` is not in registry cms::v1", call.path),
+                ));
+            }
+            let mut inputs = Vec::with_capacity(call.args.len() + usize::from(previous.is_some()));
+            if let Some(handle) = previous {
+                inputs.push(handle);
+            }
+            for arg in &call.args {
+                inputs.push(lookup_binding(&bindings, arg, call.offset)?);
+            }
+            previous = Some(builder.strand(&term, &inputs).map_err(|error| {
+                DslError::new(
+                    ErrorCode::BuildRejected,
+                    call.offset,
+                    format!("term `{}` failed typed lowering: {error}", call.path),
+                )
+            })?);
+        }
+        let result = previous.ok_or_else(|| {
+            DslError::new(
+                ErrorCode::MissingField,
+                binding.offset,
+                "binding expression contains no term call",
+            )
+        })?;
+        bindings.insert(binding.name.clone(), result);
+    }
+
+    for output in &document.step.outputs {
+        builder.output(lookup_binding(&bindings, output, 0)?);
+    }
+    if let Some(budget) = document.budget {
+        builder.budget(budget);
+    } else {
+        builder.budget_tight();
+    }
+    builder.confirm(document.confirm);
+    for evidence in &document.evidence {
+        builder.evidence(evidence.clone());
+    }
+    let capsule = builder.build().map_err(|error| {
+        DslError::new(
+            ErrorCode::BuildRejected,
+            0,
+            format!("capsule failed typed lowering: {error}"),
+        )
+    })?;
+
+    let declared_caps = canonical_set(document.capabilities.iter().map(|value| dotted(value)));
+    let derived_caps = canonical_set(
+        capsule
+            .grants
+            .iter()
+            .map(|capability| capability.as_str().to_owned()),
+    );
+    compare_declared_set(
+        &declared_caps,
+        &derived_caps,
+        ErrorCode::CapabilityMismatch,
+        "capabilities",
+    )?;
+
+    let declared_effects = canonical_set(document.effects.iter().cloned());
+    let derived_effects = canonical_set(capsule.braid.strands.iter().map(|strand| {
+        let spec = registry
+            .get(&strand.term)
+            .expect("builder already resolved every term");
+        effect_name(spec.effect).to_owned()
+    }));
+    compare_declared_set(
+        &declared_effects,
+        &derived_effects,
+        ErrorCode::EffectMismatch,
+        "effects",
+    )?;
+
+    Ok(capsule)
+}
+
+#[derive(Serialize)]
+struct JsonStrand<'a> {
+    term: &'a str,
+    inputs: &'a [u32],
+}
+
+#[derive(Serialize)]
+struct JsonCapsule<'a> {
+    intent: &'a str,
+    budget: u64,
+    confirm: &'static str,
+    evidence: &'a [String],
+    strands: Vec<JsonStrand<'a>>,
+    outputs: &'a [u32],
+}
+
+fn json_transport(capsule: &Capsule) -> Result<String, DslError> {
+    let value = JsonCapsule {
+        intent: &capsule.intent,
+        budget: capsule.budget,
+        confirm: match capsule.confirm {
+            ConfirmPolicy::None => "none",
+            ConfirmPolicy::HumanConfirm => "human-confirm",
+        },
+        evidence: &capsule.evidence,
+        strands: capsule
+            .braid
+            .strands
+            .iter()
+            .map(|strand| JsonStrand {
+                term: &strand.term,
+                inputs: &strand.inputs,
+            })
+            .collect(),
+        outputs: &capsule.braid.outputs,
+    };
+    lgwks_std::json::to_string_pretty(&value).map_err(|error| {
+        DslError::new(
+            ErrorCode::SerializationFailed,
+            0,
+            format!("failed to serialize JSON-of-IR transport: {error}"),
+        )
+    })
+}
+
+/// Fully checked result of source elaboration.
+#[derive(Debug, Clone)]
+pub struct Elaboration {
+    /// Parsed source name, used for receipts only and not as a second identity.
+    pub source_name: String,
+    /// Canonical admitted capsule.
+    pub capsule: Capsule,
+    /// Canonical wire bytes used for independent admission and CID identity.
+    pub bytes: Vec<u8>,
+    /// JSON-of-IR transport that must reproduce `bytes` through `braid encode`.
+    pub json_ir: String,
+    /// Deterministic human-review manifest.
+    pub manifest_text: String,
+}
+
+/// Parse, lower, canonically encode, independently admit, and render source.
+///
+/// # Errors
+///
+/// Returns a typed [`DslError`] for syntax, bounds, lowering, declaration
+/// mismatch, serialization, independent admission, or rendering failure.
+pub fn elaborate(source: &str) -> Result<Elaboration, DslError> {
+    let document = parse(source)?;
+    let capsule = lower_document(&document)?;
+    let bytes = capsule.to_bytes();
+    let registry = registry_v0();
+    match verify(&bytes, &registry, &capsule.grants) {
+        Verdict::Admit { capsule_cid } if capsule_cid == capsule.cid() => {}
+        Verdict::Admit { capsule_cid } => {
+            return Err(DslError::new(
+                ErrorCode::VerificationRejected,
+                0,
+                format!(
+                    "independent verifier returned mismatched CID {}",
+                    capsule_cid.to_hex()
+                ),
+            ));
+        }
+        Verdict::Reject { stage, reason } => {
+            return Err(DslError::new(
+                ErrorCode::VerificationRejected,
+                0,
+                format!("independent verifier rejected at {stage:?}: {reason}"),
+            ));
+        }
+    }
+    let manifest_value = manifest(&capsule, &registry).map_err(|error| {
+        DslError::new(
+            ErrorCode::RenderFailed,
+            0,
+            format!("manifest rendering failed: {error:?}"),
+        )
+    })?;
+    Ok(Elaboration {
+        source_name: document.name,
+        json_ir: json_transport(&capsule)?,
+        manifest_text: render_text(&manifest_value),
+        capsule,
+        bytes,
+    })
+}

--- a/crates/braid-elaborate-dsl/tests/elaborate.rs
+++ b/crates/braid-elaborate-dsl/tests/elaborate.rs
@@ -1,0 +1,235 @@
+use braid_elaborate_dsl::{ErrorCode, MAX_SOURCE_BYTES, elaborate};
+use proptest::prelude::*;
+
+const EDIT: &str = include_str!("fixtures/edit-home-hero.brd");
+const PUBLISH: &str = include_str!("fixtures/publish-services.brd");
+const LISTING: &str = include_str!("fixtures/render-work-listing.brd");
+
+fn assert_error(source: &str, code: ErrorCode) {
+    let error = elaborate(source).expect_err("source must fail closed");
+    assert_eq!(error.code, code, "unexpected error: {error}");
+}
+
+#[test]
+fn demo_port_sources_pin_existing_json_path_cids() {
+    let cases = [
+        (
+            EDIT,
+            "26f6162e1a5fb5f6e3a46724a991a8b4dc48e08c223016fb86c3c8de38594226",
+        ),
+        (
+            PUBLISH,
+            "195a7455e56b42dde32a79218c1b675420bc2de310184d16413a027d6261f33a",
+        ),
+        (
+            LISTING,
+            "43ed11f1d863a214ca4ac51bbfaa5078166ddcc228fda717c25fa358bf8da3a6",
+        ),
+    ];
+    for (source, expected) in cases {
+        let result = elaborate(source).expect("demo source must admit");
+        assert_eq!(result.capsule.cid().to_hex(), expected);
+        assert_eq!(result.bytes, result.capsule.to_bytes());
+        assert!(result.manifest_text.contains(expected));
+    }
+}
+
+#[test]
+fn same_source_is_byte_deterministic() {
+    let first = elaborate(EDIT).unwrap();
+    let second = elaborate(EDIT).unwrap();
+    assert_eq!(first.bytes, second.bytes);
+    assert_eq!(first.json_ir, second.json_ir);
+}
+
+#[test]
+fn pipeline_and_explicit_call_are_identical() {
+    let piped = LISTING;
+    let explicit = LISTING.replace("entity |> proj::listing()", "proj::listing(entity)");
+    assert_eq!(
+        elaborate(piped).unwrap().bytes,
+        elaborate(&explicit).unwrap().bytes
+    );
+}
+
+#[test]
+fn ten_golden_sources_have_pinned_cids() {
+    let templates = [
+        EDIT.to_owned(),
+        PUBLISH.to_owned(),
+        LISTING.to_owned(),
+        EDIT.replace("edit_home_hero", "edit_home_hero_copy"),
+        EDIT.replace("render a preview", "render a second preview"),
+        LISTING.replace("render_work_listing", "render_work_listing_copy"),
+        LISTING.replace("work case-study", "featured case-study"),
+        PUBLISH.replace("publish_services", "publish_services_copy"),
+        PUBLISH.replace("services page", "pricing page"),
+        EDIT.replace("home hero", "about hero"),
+    ];
+    let expected = [
+        "26f6162e1a5fb5f6e3a46724a991a8b4dc48e08c223016fb86c3c8de38594226",
+        "195a7455e56b42dde32a79218c1b675420bc2de310184d16413a027d6261f33a",
+        "43ed11f1d863a214ca4ac51bbfaa5078166ddcc228fda717c25fa358bf8da3a6",
+        "26f6162e1a5fb5f6e3a46724a991a8b4dc48e08c223016fb86c3c8de38594226",
+        "42354a2dd8aabf9a254f1ca3974db9d5a4647c7a0c7ec3133f2811d3bade0088",
+        "43ed11f1d863a214ca4ac51bbfaa5078166ddcc228fda717c25fa358bf8da3a6",
+        "b1bb95bdf288e56a788a4581eb5b8e16175d14c2537a70c5ce2f6272b71038d9",
+        "195a7455e56b42dde32a79218c1b675420bc2de310184d16413a027d6261f33a",
+        "0eccba2d5f6240b4792bd14510d4305b3bb392ab6a43a78c89ab0da83213c4ff",
+        "d4e98163b06098ae04e215a322973fb02fce0ebe77d0bf1b0019ffd185551d83",
+    ];
+    for (source, expected_cid) in templates.iter().zip(expected) {
+        assert_eq!(
+            elaborate(source).unwrap().capsule.cid().to_hex(),
+            expected_cid
+        );
+    }
+}
+
+#[test]
+fn unknown_term_is_typed_refusal() {
+    assert_error(
+        &EDIT.replace("view::section", "view::eval"),
+        ErrorCode::UnknownTerm,
+    );
+}
+
+#[test]
+fn authority_widening_is_typed_refusal() {
+    assert_error(
+        &EDIT.replace(
+            "capabilities [signal::emit]",
+            "capabilities [signal::emit, compute::remote]",
+        ),
+        ErrorCode::CapabilityMismatch,
+    );
+}
+
+#[test]
+fn missing_derived_capability_is_typed_refusal() {
+    assert_error(
+        &EDIT.replace("capabilities [signal::emit]", "capabilities []"),
+        ErrorCode::CapabilityMismatch,
+    );
+}
+
+#[test]
+fn hidden_effect_is_typed_refusal() {
+    assert_error(
+        &EDIT.replace("effects [pure, reversible_write]", "effects [pure]"),
+        ErrorCode::EffectMismatch,
+    );
+}
+
+#[test]
+fn unconfirmed_publish_is_refused_before_emission() {
+    assert_error(
+        &PUBLISH.replace("confirm human", "confirm none"),
+        ErrorCode::BuildRejected,
+    );
+}
+
+#[test]
+fn duplicate_binding_is_typed_refusal() {
+    assert_error(
+        &EDIT.replace("text = lit::text();", "entity = lit::text();"),
+        ErrorCode::DuplicateBinding,
+    );
+}
+
+#[test]
+fn forward_binding_is_typed_refusal() {
+    assert_error(
+        &EDIT.replace("entity = lit::entity();", "entity = bytes::id(future);"),
+        ErrorCode::UnknownBinding,
+    );
+}
+
+#[test]
+fn unsupported_state_is_loud_refusal() {
+    assert_error(
+        &EDIT.replace("step main", "state Session {}\nstep main"),
+        ErrorCode::UnsupportedConstruct,
+    );
+}
+
+#[test]
+fn floats_are_not_source_values() {
+    assert_error(
+        &EDIT.replace("lit::text()", "lit::text(3.14)"),
+        ErrorCode::InvalidToken,
+    );
+}
+
+#[test]
+fn unsupported_registry_is_typed_refusal() {
+    assert_error(
+        &EDIT.replace("registry cms::v1", "registry web::v1"),
+        ErrorCode::UnsupportedRegistry,
+    );
+}
+
+#[test]
+fn oversized_source_is_refused_before_parsing() {
+    let source = "x".repeat(MAX_SOURCE_BYTES + 1);
+    assert_error(&source, ErrorCode::SourceTooLarge);
+}
+
+#[test]
+fn excessive_pipeline_work_is_bounded() {
+    let mut calls = String::from("bytes::id(seed)");
+    for _ in 0..65 {
+        calls.push_str(" |> bytes::id()");
+    }
+    let source = format!(
+        "capsule test::bounded version 0 {{\n\
+         intent \"bounded\"; registry cms::v1;\n\
+         require {{ capabilities []; effects [pure]; }}\n\
+         step main {{ seed = lit::bytes(); result = {calls}; output [result]; }}\n\
+         }}"
+    );
+    assert_error(&source, ErrorCode::LimitExceeded);
+}
+
+#[test]
+fn duplicate_requirements_are_refused() {
+    assert_error(
+        &EDIT.replace(
+            "capabilities [signal::emit]",
+            "capabilities [signal::emit, signal::emit]",
+        ),
+        ErrorCode::DuplicateField,
+    );
+}
+
+#[test]
+fn embedded_code_and_raw_urls_are_not_expressions() {
+    assert_error(
+        &EDIT.replace("lit::text()", "eval::javascript(text)"),
+        ErrorCode::UnknownTerm,
+    );
+    assert_error(
+        &EDIT.replace("lit::text()", "net::fetch(\"https://example.invalid\")"),
+        ErrorCode::UnexpectedToken,
+    );
+}
+
+#[test]
+fn raw_newlines_inside_strings_are_refused() {
+    assert_error(
+        &EDIT.replace("render a preview", "render a\npreview"),
+        ErrorCode::InvalidToken,
+    );
+}
+
+proptest! {
+    #[test]
+    fn arbitrary_utf8_source_never_panics(
+        source in proptest::collection::vec(any::<char>(), 0..1_024)
+            .prop_map(|chars| chars.into_iter().collect::<String>())
+    ) {
+        // Success and typed refusal are both valid; process survival is the
+        // property under test, so consume the outcome explicitly.
+        drop(elaborate(&source));
+    }
+}

--- a/crates/braid-elaborate-dsl/tests/execution.rs
+++ b/crates/braid-elaborate-dsl/tests/execution.rs
@@ -1,0 +1,127 @@
+//! Issue #77 execution edge: real DSL source reaches the proof-gated
+//! `braid-run` reference interpreter, never a raw-capsule shortcut.
+
+use std::collections::BTreeMap;
+
+use braid_elaborate_dsl::elaborate;
+use braid_flow_ir::Predicate;
+use braid_flow_plan::{CompletionMap, FlowSnapshot};
+use braid_ir::{TypeTag, Value};
+use braid_run::{ExecutionError, Host, JustificationProof, RunnableInvocation, execute_runnable};
+use braid_vocab_cms::registry_v0;
+
+const EDIT: &str = include_str!("fixtures/edit-home-hero.brd");
+const PUBLISH: &str = include_str!("fixtures/publish-services.brd");
+const LISTING: &str = include_str!("fixtures/render-work-listing.brd");
+
+#[derive(Default)]
+struct ReferenceCmsHost {
+    calls: Vec<String>,
+}
+
+fn placeholder(output: &TypeTag) -> Value {
+    match output {
+        TypeTag::Bool => Value::Bool(false),
+        TypeTag::Int => Value::Int(0),
+        TypeTag::Bytes | TypeTag::Opaque(_, _) => Value::Bytes(Vec::new()),
+        TypeTag::Text => Value::Text("reference-value".into()),
+        TypeTag::Cid => Value::Bytes(vec![0; 32]),
+        TypeTag::List(_) => Value::List(Vec::new()),
+    }
+}
+
+impl Host for ReferenceCmsHost {
+    fn call(
+        &mut self,
+        term_id: &str,
+        _inputs: &[Value],
+        spec: &braid_ir::TermSpec,
+    ) -> Result<Value, ExecutionError> {
+        self.calls.push(term_id.to_owned());
+        Ok(placeholder(&spec.output))
+    }
+}
+
+fn execute_source(source: &str) -> (braid_run::Journal, ReferenceCmsHost) {
+    let elaboration = elaborate(source).expect("DSL source admits");
+    let registry = registry_v0();
+    let snapshot = FlowSnapshot::new(BTreeMap::new());
+    let justification = JustificationProof::prove(
+        &elaboration.capsule,
+        &Predicate::Const(true),
+        &snapshot,
+        &CompletionMap::new(),
+    )
+    .expect("constant-true justification produces proof");
+    let admission = braid_verify::admit(&elaboration.bytes, &registry, &elaboration.capsule.grants)
+        .expect("independent admission produces proof");
+    let invocation = RunnableInvocation::prepare(
+        elaboration.capsule.clone(),
+        &registry,
+        admission,
+        justification,
+        &elaboration.capsule.grants,
+        &snapshot,
+    )
+    .expect("proofs bind to exact capsule, authority, registry, and snapshot");
+    let mut host = ReferenceCmsHost::default();
+    let journal = execute_runnable(
+        &invocation,
+        &registry,
+        &elaboration.capsule.grants,
+        &snapshot,
+        &mut host,
+    )
+    .expect("reference execution succeeds");
+    (journal, host)
+}
+
+#[test]
+fn three_dsl_demo_actions_reach_proof_gated_execution() {
+    for (source, expected_calls) in [
+        (
+            EDIT,
+            vec!["lit.entity", "lit.text", "cms.edit_section", "view.section"],
+        ),
+        (
+            PUBLISH,
+            vec!["lit.entity", "lit.text", "cms.edit_section", "cms.publish"],
+        ),
+        (LISTING, vec!["lit.entity", "proj.listing"]),
+    ] {
+        let (journal, host) = execute_source(source);
+        assert_eq!(host.calls, expected_calls);
+        assert_eq!(journal.entries.len(), expected_calls.len());
+        assert!(!journal.outputs.is_empty());
+    }
+}
+
+#[test]
+fn execution_refuses_authority_transplant_after_dsl_admission() {
+    let elaboration = elaborate(EDIT).unwrap();
+    let registry = registry_v0();
+    let snapshot = FlowSnapshot::new(BTreeMap::new());
+    let justification = JustificationProof::prove(
+        &elaboration.capsule,
+        &Predicate::Const(true),
+        &snapshot,
+        &CompletionMap::new(),
+    )
+    .unwrap();
+    let admission =
+        braid_verify::admit(&elaboration.bytes, &registry, &elaboration.capsule.grants).unwrap();
+    let invocation = RunnableInvocation::prepare(
+        elaboration.capsule.clone(),
+        &registry,
+        admission,
+        justification,
+        &elaboration.capsule.grants,
+        &snapshot,
+    )
+    .unwrap();
+    let mut host = ReferenceCmsHost::default();
+    let error = execute_runnable(&invocation, &registry, &[], &snapshot, &mut host)
+        .expect_err("narrower ambient authority must not execute");
+    assert!(matches!(error, ExecutionError::InvalidRunnableProof { .. }));
+    assert!(host.calls.is_empty());
+}

--- a/crates/braid-elaborate-dsl/tests/fixtures/edit-home-hero.brd
+++ b/crates/braid-elaborate-dsl/tests/fixtures/edit-home-hero.brd
@@ -1,0 +1,19 @@
+capsule demo::edit_home_hero version 0 {
+    intent "demo-port: edit the home hero section and render a preview — reversible, local";
+    registry cms::v1;
+    require {
+        capabilities [signal::emit];
+        effects [pure, reversible_write];
+    }
+    budget 20;
+    confirm none;
+    evidence ["fact.cid"];
+
+    step main {
+        entity = lit::entity();
+        text = lit::text();
+        edit = cms::edit_section(entity, text);
+        preview = text |> view::section();
+        output [edit, preview];
+    }
+}

--- a/crates/braid-elaborate-dsl/tests/fixtures/publish-services.brd
+++ b/crates/braid-elaborate-dsl/tests/fixtures/publish-services.brd
@@ -1,0 +1,19 @@
+capsule demo::publish_services version 0 {
+    intent "demo-port: edit the services page then publish it — irreversible, human-confirmed";
+    registry cms::v1;
+    require {
+        capabilities [intent::emit, signal::emit];
+        effects [pure, reversible_write, irreversible];
+    }
+    budget 30;
+    confirm human;
+    evidence ["fact.cid", "confirmation.token"];
+
+    step main {
+        entity = lit::entity();
+        text = lit::text();
+        edit = cms::edit_section(entity, text);
+        published = cms::publish(edit);
+        output [published];
+    }
+}

--- a/crates/braid-elaborate-dsl/tests/fixtures/render-work-listing.brd
+++ b/crates/braid-elaborate-dsl/tests/fixtures/render-work-listing.brd
@@ -1,0 +1,17 @@
+capsule demo::render_work_listing version 0 {
+    intent "demo-port: read the work case-study listing — projection read, no writes";
+    registry cms::v1;
+    require {
+        capabilities [tape::read];
+        effects [pure, read];
+    }
+    budget 10;
+    confirm none;
+    evidence ["fact.cid"];
+
+    step main {
+        entity = lit::entity();
+        listing = entity |> proj::listing();
+        output [listing];
+    }
+}

--- a/docs/adr-100-braid-elaboration-seam.md
+++ b/docs/adr-100-braid-elaboration-seam.md
@@ -1,6 +1,6 @@
 # ADR-100: Braid elaboration seam — 95% deterministic, 5% semantic gate
 
-**Status:** PROPOSED — drafted from Director decisions given live
+**Status:** ACCEPTED — merged by PR #67; bounded native grammar later authorized by ADR-102/D33
 2026-08-26 session; ratifies on Director merge
 
 **Date:** 2026-08-26
@@ -13,8 +13,9 @@
 `spec/braid/units.md` debt anchors D-ELAB/D-VOCAB/D-CONSUMER/D-SEMANTICS
 already landed at U11–U14 — see that file
 
-**Supersedes:** nothing; enriches D1/D5/D6/D9/D17/D20/D21/D24/D25/D26/D30/D31
-without unlocking D6 grammar work
+**Supersedes:** nothing; enriches D1/D5/D6/D9/D17/D20/D21/D24/D25/D26/D30/D31.
+At acceptance it did not unlock D6 grammar work; ADR-102/D33 later unlocks only
+the bounded native Capsule DSL v0.
 
 **Authors:** Director Srinjon Gupta (decisions: 3D DSL, semantic stickiness,
 Safety^Capability^Justification, 95/5 split) + Claude (synthesis)
@@ -51,7 +52,8 @@ D31 made it a *global* IR (substrate `braid-ir` vs vocabulary packages
 registry-parametric `verify`). D30 split the world into
 *blocking* (binary gates) vs *advisory* (scalar scores the author never
 optimizes against) — because advisory-as-reward is guaranteed Goodhart.
-D6 still gates surface syntax on §16 triggers 2/3.
+D6 gated surface syntax at this ADR's acceptance. ADR-102/D33 later fires that
+gate for the bounded native Capsule DSL v0 only; broader grammar remains gated.
 
 Director vision for this ADR, verbatim compressed:
 

--- a/docs/adr-102-braid-dsl-v0.md
+++ b/docs/adr-102-braid-dsl-v0.md
@@ -1,0 +1,70 @@
+# ADR-102 — Bounded native Braid DSL v0
+
+**Status:** Accepted by explicit Director instruction on 2026-08-29  
+**Issue:** [#77](https://github.com/srinji-kaggss/Braid/issues/77)  
+**Decision entry:** D33  
+**Source contract:** `spec/braid/elaboration/braid-dsl-v0.md`
+
+## Context
+
+The JavaScript expression frontend proves that an external language can lower
+through the Braid elaboration seam. It is not the native Braid authoring
+surface requested by #77 and cannot express the CMS demo graph as a coherent
+declarative source document.
+
+D6 originally kept every custom textual grammar behind strategy triggers.
+After reviewing that result, the Director explicitly rejected treating the JS
+subset as the DSL and ordered implementation against the GitHub issues and
+repository specifications. This is the required D6 decision for one bounded
+surface, not permission to invent the broader state, schema, orchestration, or
+general-purpose language described in research documents.
+
+## Decision
+
+Braid adopts a versioned `version 0` native source grammar for one Capsule graph
+over the closed `cms::v1` vocabulary. It supports explicit intent, registry,
+capability and effect assertions, budget, confirmation, evidence, bindings,
+namespaced calls, pipelines, and outputs.
+
+The frontend:
+
+1. enforces byte, token, identifier, string, binding, and pipeline ceilings
+   before unbounded work;
+2. lowers only through `braid_sdk::Builder`;
+3. emits the existing canonical Capsule bytes, never a new wire format;
+4. compares declared authority and effects exactly with the derived graph;
+5. asks the independent `braid-verify` implementation to admit the bytes; and
+6. exposes `braid dsl check` and `braid dsl compile`, with optional JSON-of-IR
+   output for differential parity checks.
+
+The canonical grammar and refusal set live in
+`spec/braid/elaboration/braid-dsl-v0.md`. That file is the versioned language
+contract; parser behavior may not outrun it.
+
+## Boundaries
+
+This decision does not unlock schemas, state machines, Flow orchestration,
+imports, macros, loops, recurrence, runtime literals, embedded host code, raw
+URL expressions, arbitrary vocabularies, a second verifier, or a second wire.
+Those require their own substrate and decision records.
+
+The capsule source name remains a source-level label because Capsule v0 has no
+canonical name field. It is not smuggled into intent or evidence merely to make
+renames alter content identity.
+
+## Acceptance
+
+The implementation is acceptable only when all of the following remain green:
+
+- the three Day-0 CMS sources match the existing JSON-of-IR bytes and pinned
+  CIDs;
+- ten source programs have pinned CID goldens and at least ten hostile or
+  invalid programs fail with stable diagnostic codes;
+- changed authority is visible as a manifest widening;
+- all three demo sources pass independent admission and reach the proof-gated
+  reference execution boundary;
+- failed compilation leaves no artifact; and
+- the complete repository gate passes.
+
+Issue #77 remains the delivery contract. This ADR does not itself claim that
+the issue is closed or that a production runtime exists.

--- a/experience/journeys/author-braid-dsl.yaml
+++ b/experience/journeys/author-braid-dsl.yaml
@@ -1,0 +1,52 @@
+id: author-braid-dsl
+actor: human-or-agent-author
+job: Author a bounded Braid capsule in Braid syntax and receive canonical bytes that the independent verifier admits.
+prior_knowledge:
+  - Knows the public `braid dsl` help text and the vocabulary term catalog.
+  - Does not know the Rust SDK, canonical wire encoding, or verifier internals.
+start:
+  installation: clean Braid checkout or installed Braid CLI
+  state: a UTF-8 `.brd` source file
+success:
+  visible_outcome: Canonical capsule bytes, CID, manifest, and optional JSON-of-IR are emitted only after independent admission.
+states:
+  - name: source-read
+    expectation: Oversized or non-UTF-8 input is refused before parsing.
+  - name: parsed
+    expectation: Only the versioned closed grammar is accepted; unsupported constructs receive a stable typed diagnostic.
+  - name: lowered
+    expectation: Every term resolves through the selected registry and declared authority exactly matches derived authority.
+  - name: admitted
+    expectation: The independent verifier, not the parser or SDK, decides whether bytes are admissible.
+  - name: emitted
+    expectation: The byte artifact, CID, manifest, and JSON transport describe the same capsule.
+invariants:
+  - The DSL never creates a second wire format or verifier.
+  - Unknown syntax, terms, capabilities, effects, and fields fail closed.
+  - Declared capabilities and effects must equal the derived sets; authority cannot be widened or hidden.
+  - Same source and registry pin produce identical canonical bytes and CID.
+  - DSL and JSON-of-IR paths produce byte-identical capsules.
+  - No output file is written when parsing, lowering, or admission fails.
+trust_boundaries:
+  - The elaborator is outside the trusted core and every result is independently verified.
+  - Irreversible or egress terms require an explicit human-confirm policy.
+  - Runtime values, durable state, recurrence, and free-form code are not fabricated when the IR cannot represent them.
+recovery_contracts:
+  - Diagnostics include a stable code, byte offset, failed construct, and corrective action.
+  - Re-running an unchanged valid source overwrites only the explicitly selected output and reproduces its bytes.
+  - Invalid source preserves all existing artifacts.
+agent_contracts:
+  - Exit 0 means admitted artifact emitted; exit 1 means policy rejection; exit 2 means source, usage, or IO error.
+  - Standard output is reserved for artifact or structured data; diagnostics and CID receipts use standard error.
+  - Source bytes are bounded before token or AST allocation.
+probes:
+  - id: demo-edit-parity
+    action: Compile the edit-home-hero DSL fixture and prove byte equality with the existing JSON-of-IR fixture.
+  - id: demo-publish-confirm
+    action: Compile confirmed publish and refuse the same source when confirmation is removed.
+  - id: unknown-term
+    action: Compile a source containing an unregistered namespaced term and require a typed refusal.
+  - id: authority-mismatch
+    action: Add an unused capability or omit a derived effect and require a typed refusal.
+  - id: hostile-source
+    action: Exercise byte, token, nesting, identifier, and statement ceilings without panic or partial output.

--- a/spec/braid/DEBT_REGISTER.md
+++ b/spec/braid/DEBT_REGISTER.md
@@ -19,7 +19,8 @@
   crates.io-ready; the rest `cargo add --git`.
 - ✅ **Tier-2 safety-assurance CI** (U-SA, D32) — `braid.profile.json` binds
   Keel's 20 atoms (gate `NotSlop`); `keel/` vendored; the gate runs in CI.
-- ✅ **First real language frontend** (U11, D31) — `braid-elaborate-js`
+- ✅ **Real language frontends** (U11, D31, D33) — the JS expression proof and
+  bounded native `braid-elaborate-dsl` Capsule authoring surface
   compiles a JS expression subset (literals + `+`) into admitted capsules via
   the one verifier; "renders JS useless" is operational for that subset.
 - ✅ **JS expression language + vocab v2** (U12, D-VOCAB.1) — operator-
@@ -100,18 +101,24 @@ with no V. A Java-ecosystem substrate without execution is a spec, not a
 product.
 **Closes**: U7 (blocked); PRD §1 "self-sufficient runtime ecosystem."
 
-### D-ELAB — No real language frontend / elaborator *(first slice LANDED — U11)*
-🟡 **Partially closed.** `braid-elaborate-js` (U11) is the first real frontend:
-it lexes/parses a JS *expression* subset (string/number literals + `+`,
-parenthesizable) and **compiles JS text into an admitted capsule** via the one
-`braid-verify` — the "renders JS useless" claim (D31) is now *operational* for
-that subset, not just architectural. Remaining gap: it is an *expression* slice
-(no identifiers/statements/calls; valueless `js.lit.*`), there is no Java→Braid,
-and no D6-gated surface syntax for the human authoring direction. A Java
-ecosystem still needs a full `javac`-class frontend.
-**Closes**: U11 (the expression slice — done); U12 (JS at scale + literal
-payloads); D6-gated surface syntax (later); eventually a real multi-language
-frontend.
+### D-ELAB — Native language frontend / elaborator *(bounded v0 LANDED — D33)*
+🟡 **Partially closed.** `braid-elaborate-dsl` implements the versioned native
+Capsule DSL authorized by ADR-102/D33: bounded parsing, namespaced calls and
+pipelines, explicit authority/effect assertions, lowering through
+`braid_sdk::Builder`, existing-wire emission, and independent admission. The
+three CMS demo sources have JSON-of-IR byte parity, pinned CIDs, typed refusal
+coverage, and proof-gated reference-interpreter tests. `braid dsl check` and
+`braid dsl compile` expose the journey without Rust, JSON, or JavaScript.
+
+Remaining: Capsule v0 has no runtime literal payload contract; schema/state and
+Flow/RON authoring remain separately gated; #72 still owns hostile canonical
+Capsule decoder preflight; and `braid-run` remains a reference interpreter, not
+a production runtime. The JS expression frontend remains a useful independent
+elaboration-seam proof, not the native DSL.
+
+**Closes when:** issue #77's complete acceptance contract and repository gate
+are green and the issue is independently confirmed closed. Broader
+multi-language and production-runtime work remains separate debt.
 
 ### D-CONSUMER — Zero real consumers
 The browser engine has a parallel `BraidTerm` enum (steer note delivered at

--- a/spec/braid/DECISIONS.md
+++ b/spec/braid/DECISIONS.md
@@ -93,6 +93,10 @@ rendered manifest (audit), per Director's explicit option choice.
 "Custom lang replaces all languages currently is blue sky" (Director, task
 brief) — ratified as a non-goal for v0–v2.
 
+**2026-08-29 amendment:** D33 records the Director's explicit decision to fire
+this gate for the bounded native Capsule DSL v0 only. The general grammar,
+editor, schema/state, Flow, macro, and language-replacement work remains gated.
+
 ### D7 — Reference workflow: Day-0 CMS demo — **LOCKED**
 v0 acceptance = `blueprints/afternow-port/` CMS reference actions expressed
 as Braid capsules end-to-end. Director chose this over the research baseline's
@@ -699,3 +703,23 @@ Converts to LOCKED on Director merge of the ADR-100 PR. Awaits the
 braid-seam-conformance`: two surfaces → same bytes/CID → one verdict;
 hostile bytes rejected identically; no GNN in the trust base) to close
 D-FLOW.11.
+
+### D33 — Bounded native Braid Capsule DSL v0 — **LOCKED 2026-08-29**
+
+The Director explicitly rejected the JavaScript expression subset as the
+Braid DSL and instructed implementation against issue #77 and the repository
+specifications. ADR-102 therefore fires D6 for exactly one versioned surface:
+the bounded `cms::v1` Capsule graph grammar in
+`spec/braid/elaboration/braid-dsl-v0.md`.
+
+This surface lowers through `braid_sdk::Builder`, emits the existing canonical
+Capsule wire, checks exact declared authority/effects, and re-enters the one
+independent `braid-verify` admission path. It owns neither a wire format nor an
+admission rule. JSON-of-IR parity, pinned CIDs, typed refusals, proof-gated
+reference execution, and the complete repository gate are acceptance
+requirements.
+
+This does not unlock schemas, state/statecharts, Flow orchestration, imports,
+macros, loops, recurrence, runtime literals, embedded code, raw URL
+expressions, arbitrary registries, or replacement-language claims. Those remain
+D6-gated and require substrate support plus separate decisions.

--- a/spec/braid/elaboration/braid-dsl-v0.md
+++ b/spec/braid/elaboration/braid-dsl-v0.md
@@ -1,0 +1,95 @@
+# Braid DSL v0 source subset
+
+**Status:** implementation contract for Braid #77  
+**Authority:** D6, D9, D21, ADR-100, `BRAID-DSL-STATE-AND-SUBSTRATE.md`, and `BRAID-GRAPH-DSL.md`  
+**Wire:** none. This source always lowers to the existing canonical `Capsule` bytes.
+**Decision:** ADR-102 / D33 unlock only this bounded capsule-graph grammar.
+
+## Job
+
+Let a human or agent author the Day-0 CMS reference capsules without Rust,
+JSON-of-IR, or JavaScript while preserving the one independent admission path.
+
+## Grammar
+
+```text
+document      = "capsule" path "version" integer "{" header* step "}" EOF ;
+header        = intent | registry | require | budget | confirm | evidence ;
+intent        = "intent" string ";" ;
+registry      = "registry" "cms" "::" "v1" ";" ;
+require       = "require" "{" capabilities effects "}" ;
+capabilities  = "capabilities" "[" path-list? "]" ";" ;
+effects       = "effects" "[" ident-list? "]" ";" ;
+budget        = "budget" integer ";" ;
+confirm       = "confirm" ("none" | "human") ";" ;
+evidence      = "evidence" "[" string-list? "]" ";" ;
+step          = "step" identifier "{" statement* output "}" ;
+statement     = identifier "=" expression ";" ;
+expression    = call ("|>" call)* | identifier "|>" call ("|>" call)* ;
+call          = path "(" identifier-list? ")" ;
+output        = "output" "[" identifier-list "]" ";" ;
+path          = identifier ("::" identifier)+ ;
+```
+
+Namespaced term and capability paths lower by replacing `::` with `.`. For
+example, `cms::edit_section(entity, text)` resolves only if
+`cms.edit_section` exists in the pinned CMS registry.
+
+The source capsule name is a diagnostic and project label. It does not enter
+the canonical Capsule v0 wire because that wire has no name field; changing
+only this label therefore cannot change the CID.
+
+A pipeline prepends the previous result to the next call's explicit arguments:
+
+```text
+text |> view::section()
+```
+
+is identical to `view::section(text)`.
+
+## Semantic invariants
+
+- Exactly one registry is supported in v0: `cms::v1`. Its registry CID and
+  vocabulary version come from `braid-vocab-cms`, never source text.
+- `require.capabilities` and `require.effects` are exact assertions over the
+  derived capsule. Extra or missing entries are errors.
+- Grants are still produced by `braid-sdk::Builder`; source declarations cannot
+  create authority.
+- Every binding references only earlier bindings. Shadowing, forward references,
+  duplicate headers, duplicate requirements, and unused output names are errors.
+- The final artifact is admitted by `braid-verify` from canonical bytes. The
+  elaborator cannot return success for a verifier rejection.
+- Source is bounded to 65,536 bytes, 4,096 tokens, 1,024 bindings, 64 expression
+  pipeline stages, 128-byte identifiers, and 4,096-byte strings.
+
+## Explicit refusals
+
+The v0 parser refuses `schema`, `state`, `statechart`, `orchestration`, imports,
+macros, arbitrary loops, recurrence, floats, runtime literal expressions, raw
+URLs, embedded code, and any term outside the closed CMS vocabulary. These are
+not silently ignored or represented as intent text.
+
+`lit::text()`, `lit::bytes()`, and `lit::entity()` are existing zero-input
+vocabulary terms. They do not carry source literal payloads. Payload syntax
+therefore remains forbidden until the canonical Strand payload contract lands.
+
+## CLI contract
+
+```text
+braid dsl compile <source.brd> -o <capsule.braid> [--emit-json <capsule.json>]
+braid dsl check <source.brd>
+```
+
+`compile` writes nothing until parsing, lowering, canonical encoding, and
+independent admission all succeed. `check` performs the same work without
+writing artifacts. Both print the CID and manifest receipt.
+
+## Acceptance probes
+
+1. The three demo-port DSL fixtures produce bytes identical to their existing
+   JSON-of-IR fixtures and retain the pinned CIDs.
+2. Ten golden programs pin exact CIDs; ten invalid programs pin diagnostic
+   codes and fail without artifacts.
+3. Unknown terms, widened capabilities, missing effects, unconfirmed publish,
+   excessive depth/work, and non-canonical output attempts fail closed.
+4. A source change that adds `cms::publish` is visible as a manifest widening.


### PR DESCRIPTION
Based on `main` at `41c1a9cf`. Closes #77.

## The gap

The only human CLI authoring path was JSON shaped exactly like the IR. The JavaScript elaborator proved the frontend seam, but it could not express the Day-0 CMS graph as native Braid source. D6 therefore remained unfired and Braid still had no bounded language of its own.

## The fix

Ratify D33 and add one closed `cms::v1` Capsule grammar. The frontend bounds source work before allocation, lowers exclusively through `braid_sdk::Builder`, compares declared capabilities and effects to the derived graph, encodes the existing Capsule wire, and re-enters the independent verifier before returning success.

A general-purpose grammar was the rejected alternative. It is worse because schemas, state, Flow, imports, macros, recurrence, literals, and arbitrary registries do not have canonical substrate contracts. Accepting syntax for them would create a second authority by implication.

## The real user path

```text
$ braid dsl check crates/braid-elaborate-dsl/tests/fixtures/edit-home-hero.brd
capsule: 26f6162e1a5fb5f6e3a46724a991a8b4dc48e08c223016fb86c3c8de38594226
intent: demo-port: edit the home hero section and render a preview — reversible, local
ir_version: 0
vocab_version: 1
registry: afaa7dcc9ab2f7d1530da72306c7d821c573f8aa9eda2b5c6e463f121f634acd
capabilities: signal.emit
effects: pure, reversible-write
irreversible_strands: 0
egress_strands: 0
strands: 4
cost: 12 / budget 20
confirm: none
evidence: fact.cid

cid 26f6162e1a5fb5f6e3a46724a991a8b4dc48e08c223016fb86c3c8de38594226
exit 0

$ braid dsl check /dev/null
error: /dev/null: BRD004_UNEXPECTED_TOKEN at byte 0: expected keyword `capsule`, found Eof
exit 2
```

## Regressions

Twenty crate-level cases drive source through parse, lowering, canonical encoding, independent admission, and rendering. They include ten pinned CID programs, typed refusals for authority and effect mismatches, hostile UTF-8 generation, and bounded pipeline work. Four black-box CLI cases compare the DSL and JSON-of-IR bytes, verify widening behavior, and prove rejected source leaves no artifact. Two execution cases prepare the verifier and planner proofs and reach `execute_runnable`; a transplanted authority set is refused before any host call.

## Source-only names do not alter identity

Three golden variants rename only the source capsule or step label and retain the same CID. The labels are diagnostics, not hidden fields in the canonical wire.

## Touched-surface account

| surface | files | constraint |
|---|---:|---|
| parser, lowering, and source fixtures | 7 | one version, one registry, no new wire or verifier |
| CLI and black-box tests | 3 | `check` writes nothing; `compile` writes only after admission |
| workspace and lock wiring | 2 | only workspace-local crate edges added |
| decision, spec, debt, README, and journey | 7 | D33 unlocks only the enumerated v0 subset |

## Full CI, run locally at `3f287331f8c5`

| gate | result |
|---|---|
| `.wwfd/local-ci.sh` | **GREEN, 27/27 lanes** |
| workspace tests and doctests | passed |
| strict Clippy | passed with `-D warnings` |
| `lgwks_std` feature and MSRV matrix | passed |
| package smoke | packed and compiled an external consumer |
| no path fallback and version pin | passed |

Receipt: `/Users/srinji/wwfd/state/local-ci-receipt.json`, subject `3f287331f8c5`.

## What is still not done

Schemas, state and statecharts, Flow authoring, imports, macros, recurrence, runtime literal payloads, arbitrary registries, and replacement-language claims remain refused. This does not publish crates, update the installed binary, or fix the dependency register that is currently operating with enforcement disabled; those are separate release and dependency-authority changes.
