### PR TITLE
Make the release probe use authenticated Git transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,9 @@ jobs:
         run: |
           set -eu
           base="${{ steps.base.outputs.ref }}"
-          changed="$(git diff --name-only "$base" -- '*.rs' '*.toml' '*.lock' | head -1)"
+          changed="$(git diff --name-only "$base" -- \
+            '*.rs' '*.toml' '*.lock' '*.sh' \
+            '.github/workflows/*.yml' '.github/workflows/*.yaml' | head -1)"
           if [ -n "$changed" ]; then
             echo "code_changed=yes" >> "$GITHUB_OUTPUT"
             echo "scope: code changed"

--- a/scripts/braid-release-probe.sh
+++ b/scripts/braid-release-probe.sh
@@ -38,7 +38,8 @@ if grep -Rq '__BRAID_' "$PROBE_DIR"; then
   exit 1
 fi
 
-CARGO_TARGET_DIR="$PROBE_DIR/target" \
+CARGO_NET_GIT_FETCH_WITH_CLI="${CARGO_NET_GIT_FETCH_WITH_CLI:-true}" \
+  CARGO_TARGET_DIR="$PROBE_DIR/target" \
   cargo run --locked --manifest-path "$PROBE_DIR/Cargo.toml"
 
 if command -v sha256sum >/dev/null 2>&1; then


### PR DESCRIPTION
The release probe now works against Braid's actual GitHub URL under the repository's authenticated Git configuration.

## Gap

PR #93 proved the locked consumer with a local Git URL, but the first post-merge public-URL probe failed before dependency resolution. Cargo's embedded Git client observed the local HTTPS-to-SSH rewrite and could not use the existing Git authentication. A green local-file probe was therefore not sufficient release evidence.

## Fix

`scripts/braid-release-probe.sh` now defaults Cargo to the Git CLI transport while still honoring an explicit caller override. Git is already intrinsic to a Git-sourced contract; this adds no library dependency and lets Cargo use the same credential and URL configuration as the operator's working Git client.

The CI scope classifier now treats shell scripts and workflow YAML as code. A release-gate change can no longer take the docs-only path and skip its own verification lane.

Rejected alternative: document a one-off environment variable. That would leave the canonical release command broken on the machine that must run it and make success depend on remembered shell state.

## Regression proof

- Exact GitHub merge source `https://github.com/srinji-kaggss/Braid.git` at `df45d01413b658a6afea6fb0c0e4bbb8661d932a`: locked consumer compiled; registry CID and capsule CID matched; verdict admit.
- Full local CI: 31/31 lanes green.
- Exact local SHA: `4ca3f086962a3bbd6a974b07bc108c316f0c2ecb`.

Advances #75.

Still not done: this fix must pass GitHub CI and merge before tag promotion. No tag or crates.io release is created here.
