### PR TITLE
Harden Braid CI orchestration against false green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 # Braid CI — adapted from keel's six-tier verification stack.
 #
-# Portable structure: concurrency control, stack-position gate, change-scope,
-# build-once-share, cargo test --locked, cargo clippy --locked -- -D warnings, rustfmt.
+# Portable structure: concurrency control, fail-closed stack position,
+# immutable action pins, build-once-share, cargo test --locked,
+# cargo clippy --locked -- -D warnings, and rustfmt.
 # Keel-specific tiers (Buck2, Kani, loom, MC/DC, mutation, semantic review)
 # are not ported — Braid has no gate binary. They arrive when keel-ci-plan
 # gains a Braid target.
@@ -50,12 +51,12 @@ jobs:
           BASE: ${{ github.event.pull_request.base.ref }}
           REPO: ${{ github.repository }}
         run: |
-          set -u
+          set -euo pipefail
           if [ "$EVENT" != "pull_request" ]; then
             echo "OK   $EVENT carries no stack position; the tiers run."
             exit 0
           fi
-          blocker="$(gh pr list --repo "$REPO" --state open --head "$BASE" --json number,title --jq '.[0] | select(.) | "#\(.number) \(.title)"' 2>/dev/null || true)"
+          blocker="$(gh pr list --repo "$REPO" --state open --head "$BASE" --json number,title --jq '.[0] | select(.) | "#\(.number) \(.title)"')"
           if [ -z "$blocker" ]; then
             echo "OK   base '$BASE' has no open pull request — bottom of stack."
             exit 0
@@ -65,44 +66,17 @@ jobs:
           echo "     Merge $blocker first; this PR then becomes the bottom and runs." >&2
           exit 1
 
-  # ── Scope ─────────────────────────────────────────────────────────────────
-  scope:
-    name: Scope
+  # ── Orchestration policy ──────────────────────────────────────────────────
+  ci-policy:
+    name: CI policy
+    needs: [stack-position]
     runs-on: self-hosted
-    timeout-minutes: 5
-    outputs:
-      code_changed: ${{ steps.scope.outputs.code_changed }}
+    timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Resolve scope base ref
-        id: base
-        run: |
-          set -eu
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin "${{ github.base_ref }}"
-            echo "ref=origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=HEAD~1" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Decide code vs docs-only
-        id: scope
-        run: |
-          set -eu
-          base="${{ steps.base.outputs.ref }}"
-          changed="$(git diff --name-only "$base" -- \
-            '*.rs' '*.toml' '*.lock' '*.sh' \
-            '.github/workflows/*.yml' '.github/workflows/*.yaml' | head -1)"
-          if [ -n "$changed" ]; then
-            echo "code_changed=yes" >> "$GITHUB_OUTPUT"
-            echo "scope: code changed"
-          else
-            echo "code_changed=no" >> "$GITHUB_OUTPUT"
-            echo "scope: docs-only"
-          fi
+      - name: Refuse fail-open workflow structure
+        run: ./scripts/ci-policy-check.sh --self-test .github/workflows/ci.yml
 
   # ── Build ─────────────────────────────────────────────────────────────────
   #
@@ -114,11 +88,11 @@ jobs:
   # discipline into an enforced ceiling rather than a remembered fact.
   swallow-budget:
     name: Swallow budget
-    needs: [stack-position]
+    needs: [stack-position, ci-policy]
     runs-on: self-hosted
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Keep swallowed results at or below five
         run: |
@@ -129,14 +103,14 @@ jobs:
 
   build:
     name: Build
-    needs: [stack-position, scope, swallow-budget]
+    needs: [stack-position, ci-policy, swallow-budget]
     runs-on: self-hosted
     env:
       CARGO_TARGET_DIR: /Users/srinji/.braid-ci/targets/${{ github.run_id }}
       CARGO_BUILD_JOBS: "12"
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Clean shared target
         run: |
@@ -144,88 +118,69 @@ jobs:
           mkdir -p "$CARGO_TARGET_DIR"
 
       - name: Verify lockfile is up-to-date
-        if: needs.scope.outputs.code_changed == 'yes'
         run: |
           cargo metadata --locked >/dev/null || { echo 'Lockfile out of date: run cargo update --workspace and commit Cargo.lock' >&2; exit 1; }
 
       - name: Enforce dependency edge ownership
-        if: needs.scope.outputs.code_changed == 'yes'
         run: cargo run --locked -p lgwks_std_gate --bin lgwks-gate -- check .
 
       - name: Build all workspace targets
-        if: needs.scope.outputs.code_changed == 'yes'
         run: cargo test --workspace --all-targets --locked --no-run
-
-      - name: Build release bins (docs-only path)
-        if: needs.scope.outputs.code_changed == 'no'
-        run: cargo check --workspace --all-targets --locked
 
   # ── Format ────────────────────────────────────────────────────────────────
   fmt:
     name: Format
-    needs: [stack-position]
+    needs: [stack-position, ci-policy]
     runs-on: self-hosted
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check formatting
         run: cargo fmt --all -- --check
 
   # ── Tests ─────────────────────────────────────────────────────────────────
   tests:
     name: Tier 0 test
-    needs: [build, scope]
+    needs: [build]
     runs-on: self-hosted
     env:
       CARGO_TARGET_DIR: /Users/srinji/.braid-ci/targets/${{ github.run_id }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run all workspace tests
-        if: needs.scope.outputs.code_changed == 'yes'
         run: cargo test --workspace --all-targets --locked
 
       - name: Doc tests
-        if: needs.scope.outputs.code_changed == 'yes'
         run: cargo test --workspace --doc --locked
-
-      - name: Record docs-only N/A
-        if: needs.scope.outputs.code_changed != 'yes'
-        run: echo "scope docs-only — tests skipped (explicit N/A)"
 
   # ── Clippy ────────────────────────────────────────────────────────────────
   clippy:
     name: Tier 0 clippy
-    needs: [build, scope]
+    needs: [build]
     runs-on: self-hosted
     env:
       CARGO_TARGET_DIR: /Users/srinji/.braid-ci/targets/${{ github.run_id }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Clippy all workspace targets
-        if: needs.scope.outputs.code_changed == 'yes'
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
-
-      - name: Record docs-only N/A
-        if: needs.scope.outputs.code_changed != 'yes'
-        run: echo "scope docs-only — clippy skipped (explicit N/A)"
 
   lgwks-std-current-stable:
     name: lgwks-std current-stable Rust 1.98.0
-    needs: [scope, stack-position]
+    needs: [stack-position, ci-policy]
     runs-on: self-hosted
-    if: needs.scope.outputs.code_changed == 'yes'
     env:
       CARGO_TARGET_DIR: /Users/srinji/.braid-ci/targets/${{ github.run_id }}-std-stable
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Pin Rust 1.98.0
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.98.0"
           components: clippy
@@ -238,9 +193,8 @@ jobs:
 
   lgwks-std-msrv:
     name: lgwks-std MSRV
-    needs: [scope, stack-position]
+    needs: [stack-position, ci-policy]
     runs-on: self-hosted
-    if: needs.scope.outputs.code_changed == 'yes'
     env:
       CARGO_TARGET_DIR: /Users/srinji/.braid-ci/targets/${{ github.run_id }}-msrv
     strategy:
@@ -249,10 +203,10 @@ jobs:
         msrv: ["1.98.0"]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Pin MSRV
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "${{ matrix.msrv }}"
           components: ""
@@ -274,14 +228,13 @@ jobs:
 
   lgwks-std-contract-drift:
     name: lgwks-std contract drift checks
-    needs: [scope, stack-position]
+    needs: [stack-position, ci-policy]
     runs-on: self-hosted
-    if: needs.scope.outputs.code_changed == 'yes'
     env:
       CARGO_TARGET_DIR: /Users/srinji/.braid-ci/targets/${{ github.run_id }}-std-contract
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate std+ contract alignment
         run: |
@@ -323,14 +276,13 @@ jobs:
 
   lgwks-std-package-smoke:
     name: lgwks-std package smoke-test
-    needs: [scope, stack-position]
+    needs: [stack-position, ci-policy]
     runs-on: self-hosted
-    if: needs.scope.outputs.code_changed == 'yes'
     env:
       CARGO_TARGET_DIR: /Users/srinji/.braid-ci/targets/${{ github.run_id }}-std-package
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run package smoke test
         run: ./scripts/lgwks-std-package-smoke.sh
@@ -338,11 +290,11 @@ jobs:
   lgwks-std-consumption-contract:
     name: lgwks-std public consumption contract
     # Keep this job as an active regression gate for Braid consumption.
-    needs: [scope, stack-position]
+    needs: [stack-position, ci-policy]
     runs-on: self-hosted
-    if: needs.scope.outputs.code_changed == 'yes'
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Ensure no in-repo path fallback for lgwks_std consumers
         run: |
           set -eu
@@ -361,12 +313,11 @@ jobs:
 
   braid-contract-release:
     name: Braid contract release probe
-    needs: [scope, stack-position]
+    needs: [stack-position, ci-policy]
     runs-on: self-hosted
-    if: needs.scope.outputs.code_changed == 'yes'
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -387,14 +338,13 @@ jobs:
   # ── std+ feature matrix ────────────────────────────────────────────────
   lgwks-std-feature-matrix:
     name: lgwks-std feature matrix
-    needs: [scope, stack-position]
+    needs: [stack-position, ci-policy]
     runs-on: self-hosted
-    if: needs.scope.outputs.code_changed == 'yes'
     env:
       CARGO_TARGET_DIR: /Users/srinji/.braid-ci/targets/${{ github.run_id }}-std
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check all requested feature combinations
         run: |
@@ -410,10 +360,20 @@ jobs:
   # ── Cleanup ───────────────────────────────────────────────────────────────
   cleanup:
     name: Cleanup
-    needs: [tests, clippy]
+    needs: [stack-position, ci-policy, swallow-budget, build, fmt, tests, clippy, lgwks-std-current-stable, lgwks-std-msrv, lgwks-std-contract-drift, lgwks-std-package-smoke, lgwks-std-consumption-contract, braid-contract-release, lgwks-std-feature-matrix]
     runs-on: self-hosted
     if: always()
     timeout-minutes: 5
     steps:
       - name: Remove shared target directory
-        run: rm -rf "/Users/srinji/.braid-ci/targets/${{ github.run_id }}"
+        env:
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          case "$RUN_ID" in
+            ''|*[!0-9]*) echo "invalid run id: $RUN_ID" >&2; exit 1 ;;
+          esac
+          root="/Users/srinji/.braid-ci/targets"
+          for suffix in '' -std-stable -msrv -std-contract -std-package -std; do
+            rm -rf -- "$root/${RUN_ID:?}${suffix}"
+          done

--- a/.wwfd/local-ci.sh
+++ b/.wwfd/local-ci.sh
@@ -2,11 +2,11 @@
 #
 # local-ci.sh — Braid's local CI, at parity with .github/workflows/ci.yml.
 #
-# Mirrors every code-changed lane of the GitHub workflow step for step:
-# swallow budget, fmt, build, tests, doc tests, clippy, lgwks-std feature
+# Mirrors every GitHub workflow lane step for step: CI policy, swallow budget,
+# fmt, build, tests, doc tests, clippy, lgwks-std feature
 # matrix, MSRV checks, contract drift, package smoke, consumption contract,
 # deterministic registry export, and the locked tagged-Git consumer probe.
-# Stack-position and Scope are pull-request-runner concerns and are skipped;
+# Stack-position and run-owned target cleanup are pull-request-runner concerns;
 # a local receipt run is always full-scope.
 #
 # On a full pass it writes /Users/srinji/wwfd/state/local-ci-receipt.json,
@@ -54,17 +54,22 @@ if [[ -z "$BOOKMARKS" ]]; then
 fi
 echo "subject: $SUBJECT_SHA (bookmarks: $BOOKMARKS)"
 
-# ── Lane 1: swallow budget (ci.yml · swallow-budget) ─────────────────────────
+# ── Lane 1: orchestration policy (ci.yml · ci-policy) ────────────────────────
+
+run "CI policy and negative fixtures" \
+  ./scripts/ci-policy-check.sh --self-test .github/workflows/ci.yml
+
+# ── Lane 2: swallow budget (ci.yml · swallow-budget) ─────────────────────────
 
 count="$(grep -rc 'let _ = \|\.ok();' crates/ | awk -F: '{s+=$2} END{print s}')"
 echo "swallowed-results=$count ceiling=5"
 run "swallow budget ≤ 5" test "$count" -le 5
 
-# ── Lane 2: formatting (ci.yml · fmt) ────────────────────────────────────────
+# ── Lane 3: formatting (ci.yml · fmt) ────────────────────────────────────────
 
 run "cargo fmt --check" cargo fmt --all -- --check
 
-# ── Lane 3–5: build, tests, doc tests (ci.yml · build/tests) ─────────────────
+# ── Lane 4–6: build, tests, doc tests (ci.yml · build/tests) ─────────────────
 
 run "locked metadata"        locked_metadata
 run "owned dependency edges" cargo run --locked -p lgwks_std_gate --bin lgwks-gate -- check .
@@ -72,11 +77,11 @@ run "build all targets"      cargo test --workspace --all-targets --locked --no-
 run "workspace tests"        cargo test --workspace --all-targets --locked
 run "doc tests"              cargo test --workspace --doc --locked
 
-# ── Lane 6: clippy (ci.yml · clippy) ─────────────────────────────────────────
+# ── Lane 7: clippy (ci.yml · clippy) ─────────────────────────────────────────
 
 run "clippy -D warnings" cargo clippy --workspace --all-targets --locked -- -D warnings
 
-# ── Lane 7: lgwks-std feature matrix (ci.yml · lgwks-std-feature-matrix) ─────
+# ── Lane 8: lgwks-std feature matrix (ci.yml · lgwks-std-feature-matrix) ─────
 
 run "std no-default-features"  cargo test -p lgwks_std --no-default-features --all-targets
 run "std default features"     cargo test -p lgwks_std --all-targets
@@ -86,7 +91,7 @@ run "std json-only"            cargo test -p lgwks_std --features json --no-defa
 run "std wire-only"            cargo test -p lgwks_std --features wire --no-default-features --all-targets
 run "std all-features"         cargo test -p lgwks_std --all-features --all-targets
 
-# ── Lane 8: MSRV feature checks (ci.yml · lgwks-std-msrv) ────────────────────
+# ── Lane 9: MSRV feature checks (ci.yml · lgwks-std-msrv) ────────────────────
 
 STD_MANIFEST="crates/lgwks-std/Cargo.toml"
 run "msrv check no-default"    cargo check --manifest-path "$STD_MANIFEST" --all-targets --no-default-features
@@ -98,7 +103,7 @@ run "msrv check wire"          cargo check --manifest-path "$STD_MANIFEST" --all
 run "msrv check all"           cargo check --manifest-path "$STD_MANIFEST" --all-targets --all-features
 run "msrv check std-gate"      cargo check --manifest-path crates/lgwks-std-gate/Cargo.toml --all-targets
 
-# ── Lane 9: contract drift (ci.yml · lgwks-std-contract-drift) ───────────────
+# ── Lane 10: contract drift (ci.yml · lgwks-std-contract-drift) ──────────────
 
 run "contract drift" python3 - <<'PY'
 import re
@@ -134,11 +139,11 @@ if package["repository"] != "https://github.com/srinji-kaggss/Braid":
     raise SystemExit(f"Unexpected package repository URL: {package['repository']}")
 PY
 
-# ── Lane 10: package smoke (ci.yml · lgwks-std-package-smoke) ────────────────
+# ── Lane 11: package smoke (ci.yml · lgwks-std-package-smoke) ────────────────
 
 run "package smoke" ./scripts/lgwks-std-package-smoke.sh
 
-# ── Lane 11: consumption contract (ci.yml · lgwks-std-consumption-contract) ──
+# ── Lane 12: consumption contract (ci.yml · lgwks-std-consumption-contract) ──
 
 command -v rg >/dev/null 2>&1 || {
   echo "local-ci: rg required for the consumption-contract lane" >&2
@@ -156,7 +161,7 @@ run "version pin present" rg -q \
 run "local patch present" rg -q \
   '^lgwks_std\s*=\s*\{\s*path\s*=\s*"crates/lgwks-std"\s*\}' -g '*.toml' Cargo.toml
 
-# ── Lane 12: Braid contract release boundary ────────────────────────────────
+# ── Lane 13: Braid contract release boundary ────────────────────────────────
 
 release_probe_rejects_bad_revision() {
   if ./scripts/braid-release-probe.sh "file://$REPO_ROOT" not-a-commit; then

--- a/docs/STATE-2026-08-19.md
+++ b/docs/STATE-2026-08-19.md
@@ -1,5 +1,10 @@
 # Braid — what is actually here, 2026-08-19
 
+> Historical snapshot correction (2026-08-30): references below to vendored
+> Keel and an active Keel CI lane no longer describe the current checkout.
+> Issue #78 tracks the native hermetic migration; see
+> `docs/research/2026-08-30-ci-slop-and-orchestration-failures.md`.
+
 Review-lane assessment. Ledgers already in this repo — `spec/braid/DEBT_REGISTER.md`,
 `spec/braid/DECISIONS.md`, `spec/braid/MUTATION-LEDGER.md`, `docs/PARITY_AUDIT.md`
 — are honest and this file does not restate them. It records what a fresh
@@ -119,8 +124,8 @@ as the repo exists. The right column is the product.
 
 3. **The keel duplicate-concept gate (`A3`).** Killing the nine reimplementations
    is blocked on consumership *and* on a gate that does not exist. Keel is the
-   most complete tool in the estate and already runs in this repo's CI
-   (`braid.profile.json` binds its 20 evidence atoms; `keel/` is vendored).
+   most complete tool in the estate; this historical snapshot said it ran in
+   Braid CI, but that integration was later retired and is open again under #78.
    **This is the lever that makes the semantic contract binding before a runtime
    exists** — keel can refuse a duplicate concept at CI time in every repo, which
    is enforcement without adoption. It is the shortest path from "Braid is

--- a/docs/playbooks/PB-01-safety-floor-hardening.md
+++ b/docs/playbooks/PB-01-safety-floor-hardening.md
@@ -1,26 +1,23 @@
 # PB-01 — Finish the safety-assurance floor (U-SA closure + Lean conformance)
 
-**Objective**: take the already-wired Keel Tier-2 floor from "runs in CI" to "qualified
-and falsifiable" — every `braid-verify` stage mutation-proven, the seeded-slop red-team
-passing, and the Rust↔Lean semantic conformance check (D-SA5) built.
+**Objective**: restore the current native Keel Tier-2 floor as a hermetic,
+qualified, falsifiable release gate while preserving the existing verifier
+mutation and Rust↔Lean structural conformance evidence.
 
 **Why this is first**: everything else in the production arc (elaborator, runtime,
 deploy platform) is code an LLM will author. The floor is what makes that work
 trustworthy (T2/T11: the verifier is itself an attack surface authored by an LLM —
 qualify it, don't trust it). Debt register priority #1 concurs.
 
-## Current state (verified 2026-07-02 — correct the stale docs first)
+## Current state (corrected 2026-08-30)
 
-- `tier2-semantic` CI job EXISTS (`.github/workflows/ci.yml`), runs
-  `scripts/keel-floor.sh` → Keel `NotSlop` verdict via `braid.profile.json`;
-  Keel is vendored at `keel/`; evidence DAG lands in `.keel/`.
-- `spec/braid/DEBT_REGISTER.md` §D-SA still says "specified but not built" — **stale;
-  fix in this playbook's first PR**.
-- Risk imported from outside: the standalone `~/keel` repo's CI has been RED
-  (deterministic-floor issue, claimed by opus in coord since 2026-06-27). Braid
-  vendors its own copy, so Braid CI is insulated — but the vendored copy and `~/keel`
-  can drift. Establish which is authoritative before touching either (memory:
-  Keel+Braid are permanently co-owned; do not fork-fix silently — Prime Directive 3).
+- No `tier2-semantic` job exists in the current workflow. `keel/` is absent and
+  the retired Node adapter cannot run.
+- `scripts/keel-floor.sh` now calls only an explicitly installed native Keel
+  binary. It is diagnostic until #78 supplies a pinned clean distribution and
+  the blocking findings are remediated.
+- `scripts/ci-policy-check.sh` independently prevents known orchestration
+  false-greens; it is not a second semantic verdict engine.
 
 ## Deep-learning corpus (read → probe)
 
@@ -47,9 +44,9 @@ seed a failing test) and confirm exit ≠ 0 with the failed atom named.
 
 ## Execution steps
 
-1. **Truth-sync the docs** (small PR): update `DEBT_REGISTER.md` D-SA to "wired;
-   qualification residue open"; record vendored-keel provenance (which `~/keel`
-   commit) in `keel/README.md` so drift is detectable.
+1. **Truth-sync the docs**: keep D-SA open until a pinned native Keel artifact,
+   clean-run evidence bundle, and finding baseline are reproducible without a
+   sibling checkout. Never recreate the removed vendored copy.
 2. **U-SA AC-2, the red-team**: build 3 seeded-slop fixtures mirroring keel's
    `fixtures/known-bad/` discipline — (a) a re-derived primitive (copy `canon.rs`
    encode logic into a second crate), (b) an ungrounded claim (doc asserts a bound no

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -77,10 +77,10 @@ Done and green: IR + canonical encoding + CID (U1); 8-stage verifier (U3–U5);
 manifest + widening gate (U2/U6); SDK + CLI (U10/U6); U9 adversarial pass (4 findings
 closed, mutation-verified); D31 substrate/vocab split with **three** vocabularies
 (cms, js, and `braid-vocab-web` — merged PR #13, the browser's `web.*` moved home);
-`no_std+alloc` core (PR #12); `braid-v0.1` tag; **U-SA is BUILT** — `tier2-semantic`
-CI job runs Keel's `NotSlop` floor via `braid.profile.json` + vendored `keel/`
-(`scripts/keel-floor.sh`). Note: `spec/braid/DEBT_REGISTER.md` §D-SA still says
-"specified but not built" — that line is stale; trust the CI file.
+`no_std+alloc` core (PR #12); `braid-v0.1` tag. **U-SA's historical Node/profile
+integration is not a current gate**: native Keel migration and its blocking
+finding baseline are tracked by #78. The source orchestration policy is a
+separate fail-closed guard, not a second semantic verdict engine.
 
 Open (the production gap, in dependency order):
 1. **D-RUN** — nothing executes. A JVM with no V. → PB-02
@@ -123,9 +123,9 @@ PB-03; PB-05 rides on 02/03; PB-06 is continuous.**
 **In-repo (canonical):** `spec/braid/README.md` (reading order) · `PRD.md` ·
 `DECISIONS.md` D1–D32 (lock legend!) · `threat-model.md` T1–T16/R1–R3 · `units.md`
 U0–U10 · `U9-VERDICT.md` (per-threat file:line pins) · `SAFETY_ASSURANCE_CI_SPEC.md`
-(D32) · `DEBT_REGISTER.md` (D-SA line stale) · `docs/adr-088-…md` (doctrine + both
+(D32 historical design) · `DEBT_REGISTER.md` · `docs/adr-088-…md` (doctrine + both
 addenda) · `docs/authoring-cli.md` · `calibration/FLIGHT_HOURS.md` ·
-`braid.profile.json` + `keel/` (vendored floor).
+`braid.profile.json` (historical atom mapping) · issue #78 (native gate migration).
 
 **Kernel repo (`~/logic-os-kernel`):**
 `LOGIC_OS_AI_FIRST_LANGUAGE_STATE_FABRIC_SECURITY_RESEARCH_BASELINE.md` (§8 "Axiom"

--- a/docs/research/2026-08-30-ci-slop-and-orchestration-failures.md
+++ b/docs/research/2026-08-30-ci-slop-and-orchestration-failures.md
@@ -1,0 +1,109 @@
+# CI slop markers and orchestration failures
+
+Date: 2026-08-30  
+Tracking issue: #78  
+Scope: Braid's GitHub Actions workflow, local receipt gate, and current Keel seam
+
+## Result
+
+"Slop" is not a score and a marker is not a verdict. The useful automated
+boundary is a small set of failure shapes whose semantics are unambiguous:
+
+| Class | Blocking marker | Why it is load-bearing |
+|---|---|---|
+| Failure closure | `continue-on-error: true` or an executable `|| true` | A failing required check can be reported as success. |
+| Provenance | An external action referenced by a tag or branch | The executed action can change without a Braid source change. |
+| Coverage | A source-classifier skips required jobs | A green run may not have tested the changed gate or data. |
+| Liveness | A job has no positive timeout | A lost dependency or runner can occupy the orchestration graph indefinitely. |
+| Lifecycle | Cleanup does not wait for every producer or does not run after failure | Persistent self-hosted runners leak run-owned state into later evidence. |
+| Falsifiability | A policy has no known-bad fixture | Exit zero may mean the checker did not observe its target. |
+| Authority drift | Current docs describe a gate or dependency path that no longer exists | Reviewers reason about an imagined control plane rather than executed bytes. |
+
+`TODO`, function length, clone counts, and complexity are review signals, not
+automatic correctness failures. Treating every textual smell as a gate creates
+false positives and teaches developers to silence the scanner. A blocking
+marker must name the invariant it violates and have a negative fixture.
+
+## Braid findings
+
+The 2026-08-30 audit found five concrete orchestration defects:
+
+1. The stack-position lookup redirected diagnostics and appended `|| true`.
+   GitHub/API failure therefore looked identical to "no blocking PR".
+2. Every external action used a mutable `@v4` or `@stable` reference.
+3. The scope classifier omitted several control/data surfaces and allowed
+   required tests and lint to be skipped. The classifier itself had already
+   needed a repair in #94 after a shell/workflow change skipped its own lane.
+4. One job had no timeout.
+5. Cleanup waited for only `tests` and `clippy` and removed only the unsuffixed
+   target directory. Five run-owned suffixed target directories could remain on
+   the persistent runner.
+
+The assurance seam had separate authority drift. Current files repeatedly said
+that the Keel `NotSlop` floor ran in CI, but neither `.github/workflows/ci.yml`
+nor `.wwfd/local-ci.sh` invoked it. `scripts/keel-floor.sh` expected the removed
+Node entry point `keel/src/run.mjs`, while Keel is not present in a clean Braid
+checkout. The current Keel repository is private, so a clean unauthenticated
+consumer cannot fetch it as an implicit tool dependency. The installed native
+Keel binary was therefore used only as a diagnostic: on Braid main
+`3a89e608f50c232cbf8ef26600d662b9c3a76375` it returned `NO-GO` with 454
+findings over 210 files. That is debt evidence, not a release gate result.
+
+## Implemented policy
+
+`scripts/ci-policy-check.sh` now rejects the five workflow failure shapes above
+and proves the checker with six negative fixtures: mutable action, continued
+error, swallowed shell failure, missing timeout, early cleanup, and scope skip.
+The workflow runs this policy before build work.
+
+The workflow also:
+
+- pins `actions/checkout` and `dtolnay/rust-toolchain` to full 40-character
+  commit identifiers;
+- runs the full Braid gate for every change instead of maintaining an
+  incomplete source classifier;
+- makes stack lookup failure block the graph;
+- gives every job a timeout; and
+- makes cleanup wait for every job and delete the six exact run-owned target
+  directories.
+
+This does not close #78. Current Keel distribution, the finding baseline,
+offline evidence export, and release-time mutation/U9 receipts remain open.
+The obsolete adapter is made explicit rather than advertised as green.
+
+## Primary sources
+
+- GitHub documents that a failed or skipped dependency skips downstream jobs,
+  that `continue-on-error` permits a step failure without failing the job, and
+  that job/step timeouts are explicit workflow controls:
+  <https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax>
+- GitHub documents full commit SHAs as the immutable action reference and
+  provides a repository setting that can require them:
+  <https://docs.github.com/en/actions/how-tos/create-and-publish-actions/manage-custom-actions>
+  and
+  <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository>
+- GitHub recommends ephemeral self-hosted runners because they provide a clean
+  environment per job and reduce leakage from previous jobs:
+  <https://docs.github.com/en/actions/reference/runners/self-hosted-runners>
+- NIST SP 800-204D requires automated checks over all artifacts in a change and
+  confidence in the source of CI tools:
+  <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204D.pdf>
+- NIST's DevSecOps reference model requires pipeline evidence and self-contained
+  test environments that are decommissioned after each iteration:
+  <https://pages.nist.gov/nccoe-devsecops/notational-reference-model.html>
+- Google's testing guidance identifies improper cleanup, prior-run state,
+  missing timeouts, and race/order assumptions as sources of flaky evidence:
+  <https://testing.googleblog.com/2021/03/test-flakiness-one-of-main-challenges.html>
+- Van Deursen et al.'s original test-smell work establishes that test code has
+  its own failure patterns; later empirical work also warns that static smell
+  detectors have false positives, supporting the marker-versus-verdict split:
+  <https://www.researchgate.net/publication/2534882_Refactoring_Test_Code>
+  and <https://pure.tudelft.nl/ws/portalfiles/portal/82718732/main.pdf>
+
+## Falsifiers
+
+This policy is wrong if a negative fixture above is accepted, if a legitimate
+immutable action form is rejected, if cleanup can start before a target producer
+finishes, or if a change can still produce a successful run without executing
+the full workspace tests and lint. GitHub's terminal job graph remains the
+independent integration proof; the source policy cannot prove runner behavior.

--- a/scripts/ci-policy-check.sh
+++ b/scripts/ci-policy-check.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Fail-closed structural policy for Braid's GitHub Actions workflow.
+#
+# This is intentionally a small source-level policy check, not a second CI
+# engine. GitHub remains authoritative for workflow semantics; this script
+# rejects the local failure shapes that have already produced false confidence
+# in Braid: mutable action refs, swallowed shell failures, conditional scope
+# skips, unbounded jobs, and cleanup that can run before producers finish.
+
+set -euo pipefail
+
+MAX_WORKFLOW_BYTES=524288
+
+fail() {
+  echo "ci-policy: $*" >&2
+  exit 1
+}
+
+job_ids() {
+  awk '
+    $0 == "jobs:" { in_jobs = 1; next }
+    in_jobs && /^[^ ]/ { exit }
+    in_jobs && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+      line = $0
+      sub(/^  /, "", line)
+      sub(/:[[:space:]]*$/, "", line)
+      print line
+    }
+  ' "$1"
+}
+
+missing_timeout_jobs() {
+  awk '
+    function finish_job() {
+      if (job != "" && !has_timeout) print job
+    }
+    $0 == "jobs:" { in_jobs = 1; next }
+    in_jobs && /^[^ ]/ { finish_job(); job = ""; exit }
+    in_jobs && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+      finish_job()
+      job = $0
+      sub(/^  /, "", job)
+      sub(/:[[:space:]]*$/, "", job)
+      has_timeout = 0
+      next
+    }
+    in_jobs && job != "" && /^    timeout-minutes:[[:space:]]*[1-9][0-9]*[[:space:]]*$/ {
+      has_timeout = 1
+    }
+    END { finish_job() }
+  ' "$1"
+}
+
+cleanup_value() {
+  local workflow="$1"
+  local key="$2"
+  awk -v key="$key" '
+    $0 == "  cleanup:" { in_cleanup = 1; next }
+    in_cleanup && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
+    in_cleanup && index($0, "    " key ":") == 1 {
+      line = $0
+      sub("^    " key ":[[:space:]]*", "", line)
+      print line
+      exit
+    }
+  ' "$workflow"
+}
+
+check_workflow() {
+  local workflow="$1"
+  local bytes action_count missing cleanup_needs cleanup_if normalized_needs job shell_or
+
+  [[ -f "$workflow" ]] || fail "workflow not found: $workflow"
+
+  bytes="$(wc -c < "$workflow" | tr -d '[:space:]')"
+  [[ "$bytes" =~ ^[0-9]+$ ]] || fail "could not measure workflow bytes"
+  (( bytes <= MAX_WORKFLOW_BYTES )) ||
+    fail "workflow is $bytes bytes; ceiling is $MAX_WORKFLOW_BYTES"
+
+  action_count=0
+  while IFS= read -r action_ref; do
+    [[ -n "$action_ref" ]] || continue
+    action_count=$((action_count + 1))
+    if [[ "$action_ref" == ./* || "$action_ref" == docker://* ]]; then
+      continue
+    fi
+    if [[ ! "$action_ref" =~ ^[^[:space:]@]+/[^[:space:]@]+@[0-9a-f]{40}([[:space:]]+#.*)?$ ]]; then
+      fail "external action is not pinned to a full commit SHA: $action_ref"
+    fi
+  done < <(
+    awk '
+      /^[[:space:]]*-[[:space:]]+uses:[[:space:]]*/ {
+        line = $0
+        sub(/^[[:space:]]*-[[:space:]]+uses:[[:space:]]*/, "", line)
+        print line
+      }
+    ' "$workflow"
+  )
+  (( action_count > 0 )) || fail "workflow contains no action references"
+
+  if grep -En '^[[:space:]]*continue-on-error:[[:space:]]*true([[:space:]]*(#.*)?)?$' "$workflow"; then
+    fail "continue-on-error true makes a required step fail open"
+  fi
+  shell_or='||'
+  if awk -v needle="$shell_or true" '
+    /^[[:space:]]*#/ { next }
+    index($0, needle) { print NR ":" $0; found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "$workflow"; then
+    fail "shell failure is swallowed with $shell_or true"
+  fi
+  if grep -En '(needs\.scope|code_changed|docs-only)' "$workflow"; then
+    fail "scope-based skips are forbidden; every change runs the full gate"
+  fi
+
+  missing="$(missing_timeout_jobs "$workflow")"
+  [[ -z "$missing" ]] || fail "jobs missing a positive timeout: ${missing//$'\n'/, }"
+
+  cleanup_needs="$(cleanup_value "$workflow" needs)"
+  [[ "$cleanup_needs" =~ ^\[.*\]$ ]] ||
+    fail "cleanup needs must be an explicit inline list"
+  normalized_needs="$(printf '%s' "$cleanup_needs" | sed -E 's/^\[//; s/\]$//; s/[[:space:]]//g')"
+  while IFS= read -r job; do
+    [[ "$job" == cleanup ]] && continue
+    case ",$normalized_needs," in
+      *",$job,"*) ;;
+      *) fail "cleanup does not wait for job: $job" ;;
+    esac
+  done < <(job_ids "$workflow")
+
+  cleanup_if="$(cleanup_value "$workflow" if)"
+  [[ "$cleanup_if" == "always()" || "$cleanup_if" == '${{ always() }}' ]] ||
+    fail "cleanup must run with if: always()"
+
+  echo "ci-policy: OK actions=$action_count jobs=$(job_ids "$workflow" | wc -l | tr -d '[:space:]') bytes=$bytes"
+}
+
+expect_reject() {
+  local name="$1"
+  local fixture="$2"
+  if (check_workflow "$fixture") >/dev/null 2>&1; then
+    fail "negative fixture was accepted: $name"
+  fi
+  echo "ci-policy: rejected $name"
+}
+
+self_test() {
+  local workflow="$1"
+  local work good fixture shell_or
+
+  check_workflow "$workflow"
+  work="$(mktemp -d)"
+  trap 'rm -rf "$work"' RETURN
+  good="$work/good.yml"
+
+  printf '%s\n' \
+    'name: policy-fixture' \
+    'jobs:' \
+    '  build:' \
+    '    runs-on: self-hosted' \
+    '    timeout-minutes: 5' \
+    '    steps:' \
+    '      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' \
+    '  cleanup:' \
+    '    needs: [build]' \
+    '    runs-on: self-hosted' \
+    '    timeout-minutes: 5' \
+    '    if: always()' \
+    '    steps:' \
+    '      - run: echo clean' > "$good"
+  check_workflow "$good" >/dev/null
+
+  fixture="$work/mutable-action.yml"
+  sed 's/@3d3c42e5aac5ba805825da76410c181273ba90b1/@v7/' "$good" > "$fixture"
+  expect_reject mutable-action "$fixture"
+
+  fixture="$work/continue-on-error.yml"
+  awk '{ print; if ($0 ~ /- run: echo clean/) print "        continue-on-error: true" }' \
+    "$good" > "$fixture"
+  expect_reject continue-on-error "$fixture"
+
+  fixture="$work/swallowed-shell.yml"
+  cp "$good" "$fixture"
+  shell_or='||'
+  printf '      - run: false %s true\n' "$shell_or" >> "$fixture"
+  expect_reject swallowed-shell "$fixture"
+
+  fixture="$work/missing-timeout.yml"
+  awk '!removed && /timeout-minutes:/ { removed = 1; next } { print }' "$good" > "$fixture"
+  expect_reject missing-timeout "$fixture"
+
+  fixture="$work/early-cleanup.yml"
+  sed 's/needs: \[build\]/needs: []/' "$good" > "$fixture"
+  expect_reject early-cleanup "$fixture"
+
+  fixture="$work/scope-skip.yml"
+  cp "$good" "$fixture"
+  printf '%s\n' '    if: needs.scope.outputs.code_changed == '\''yes'\''' >> "$fixture"
+  expect_reject scope-skip "$fixture"
+
+  echo "ci-policy: self-test OK (6 negative fixtures)"
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  [[ $# -eq 2 ]] || fail "usage: $0 --self-test <workflow>"
+  self_test "$2"
+else
+  [[ $# -eq 1 ]] || fail "usage: $0 <workflow>"
+  check_workflow "$1"
+fi

--- a/scripts/keel-floor.sh
+++ b/scripts/keel-floor.sh
@@ -1,51 +1,36 @@
 #!/usr/bin/env bash
 # Braid U-SA — run Keel safety-assurance floor against the workspace.
 #
-# Produces the Tier-2 semantic verdict: reads Tier-1 evidence (cargo test,
-# clippy, etc.) and evaluates the NotSlop concept via Keel's engine.
+# Runs the current native Keel control plane against this checkout. The old
+# profile adapter used `keel/src/run.mjs`; that entry point no longer exists.
+# This command fails explicitly when the native binary is unavailable instead
+# of falling back to a sibling source tree or advertising stale evidence.
 #
-# Usage:  scripts/keel-floor.sh [--concept <id>]
-#         (defaults to NotSlop gate concept)
+# Usage:  scripts/keel-floor.sh
 #
-# Requires: node (>=22), cargo, keel vendored at keel/ (or KEEL_ROOT).
+# Requires: a separately installed native `keel` binary (or KEEL_BIN).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-KEEL="${KEEL_ROOT:-$ROOT/keel}"
-PROFILE="$ROOT/braid.profile.json"
+KEEL_BIN="${KEEL_BIN:-}"
 
-if [ ! -f "$KEEL/src/run.mjs" ]; then
-  echo "Keel not found at $KEEL (set KEEL_ROOT to override)" >&2
-  exit 2
+if [[ $# -ne 0 ]]; then
+  echo "usage: $0" >&2
+  exit 64
 fi
 
-if [ ! -f "$PROFILE" ]; then
-  echo "braid.profile.json not found at $PROFILE" >&2
-  exit 2
+if [[ -z "$KEEL_BIN" ]]; then
+  if command -v keel >/dev/null 2>&1; then
+    KEEL_BIN="$(command -v keel)"
+  fi
+fi
+if [[ -z "$KEEL_BIN" || ! -x "$KEEL_BIN" ]]; then
+  echo "native Keel is unavailable; install it or set KEEL_BIN" >&2
+  echo "issue #78 tracks a hermetic Braid assurance distribution" >&2
+  exit 127
 fi
 
-CONCEPT="${1:-}"
-if [ "$CONCEPT" = "--concept" ] && [ -n "${2:-}" ]; then
-  CONCEPT_FLAG=(--concept "$2")
-  shift 2
-else
-  CONCEPT_FLAG=()
-fi
-
-# Serialize the crossing by default. Keel's verdict is a pure function of
-# CONTENT (concurrency "changes throughput, NEVER the verdict" — concurrency.mjs),
-# but the profile binds 12 atoms to distinct `cargo` invocations (test, clippy,
-# check, fmt). Run concurrently they contend on the one shared `target/` build
-# dir, and on a cold cache one cargo can clobber another mid-build → a spurious
-# non-zero exit → a false NO-GO that does not reproduce on a warm cache. The
-# dedicated `build·test·lint` CI job runs the same tools serially and is green;
-# serializing here matches that and makes the gate deterministic. Overridable.
-export KEEL_CONCURRENCY="${KEEL_CONCURRENCY:-1}"
-
-echo "Keel safety-assurance floor (profile: $PROFILE)"
-echo "  keel:        $KEEL"
-echo "  concept:     ${CONCEPT_FLAG[1]:-NotSlop (default)}"
-echo "  concurrency: $KEEL_CONCURRENCY (serial by default — deterministic cargo)"
-echo ""
-
-node "$KEEL/src/run.mjs" --profile "$PROFILE" "${CONCEPT_FLAG[@]+"${CONCEPT_FLAG[@]}"}"
+echo "Keel native assurance scan"
+echo "  binary: $KEEL_BIN"
+echo "  target: $ROOT"
+exec "$KEEL_BIN" "$ROOT"

--- a/spec/braid/DEBT_REGISTER.md
+++ b/spec/braid/DEBT_REGISTER.md
@@ -17,8 +17,10 @@
   capabilities, `TypeTag::Opaque`, 2 vocabularies (CMS + JS proof-of-concept).
 - ✅ **Publishability** — `braid-v0.1` git tag cut; `braid-capability`
   crates.io-ready; the rest `cargo add --git`.
-- ✅ **Tier-2 safety-assurance CI** (U-SA, D32) — `braid.profile.json` binds
-  Keel's 20 atoms (gate `NotSlop`); `keel/` vendored; the gate runs in CI.
+- 🔴 **Tier-2 safety-assurance CI** (U-SA, D32, #78) — the historical
+  `braid.profile.json` mapping remains, but `keel/` and its Node entry point are
+  gone and no current Keel verdict runs in CI. Native Keel exposes a blocking
+  finding baseline; hermetic distribution and evidence remain open.
 - ✅ **Real language frontends** (U11, D31, D33) — the JS expression proof and
   bounded native `braid-elaborate-dsl` Capsule authoring surface
   compiles a JS expression subset (literals + `+`) into admitted capsules via
@@ -149,14 +151,13 @@ non-goal), no docs generator, no `braid test` harness for capsules yet, and the
 manifest is JS-expression-only (no intents/anchors).
 **Closes**: U13 (project build — done); PRD §5 P4+ (the rest).
 
-### D-SA — Tier-2 safety-assurance floor *(BUILT — U-SA landed)*
-✅ **Closed.** The "stop slop" semantic floor is no longer just a spec: `U-SA`
-landed (commit `6f74c82` + the Keel-vendoring `ae83171`). `braid.profile.json`
-binds Keel's 20 evidence atoms to Braid's Tier-1 tools (gate concept `NotSlop`),
-`keel/` is vendored (schema + engine), and `.github/workflows/ci.yml` runs the
-Keel gate in CI. The design rationale stays in `SAFETY_ASSURANCE_CI_SPEC.md`.
-**Remaining**: the Lean⇄verifier conformance check (tracked separately as
-D-SEMANTICS / U15), not the Keel wiring itself.
+### D-SA — Tier-2 safety-assurance floor *(REGRESSED — #78)*
+🔴 **Open.** U-SA originally landed a Node/profile integration, but its runtime
+and vendored source are no longer present. Current CI does not run Keel, and the
+native scanner is not yet a hermetic pinned tool in Braid. The atom mapping,
+seeded fixtures, mutation ledger, and structural Lean mapping remain useful
+evidence; they do not prove that the current gate executed. #78 owns the native
+tool pin, clean-run evidence bundle, finding remediation, and release ritual.
 
 ### D-SEMANTICS — The verifier's stage semantics are not machine-checked against the Lean predicates
 D22 says Lean is the unforked proof oracle; the Rust verifier implements

--- a/spec/braid/KEEL-RECONCILIATION.md
+++ b/spec/braid/KEEL-RECONCILIATION.md
@@ -1,13 +1,11 @@
 # Keel ↔ Braid Reconciliation
 
-> **Provenance**: Braid's safety-assurance CI layer (U-SA, D32) is Keel, bound
-> via `braid.profile.json`. Keel itself is **not** checked into this repo —
-> see `chore: reference keel via pinned git-clone-at-CI-time, not a checked-in
-> copy (#20)`: a vendored `keel/` copy had drifted from its source twice, so
-> CI now clones Keel at a pinned branch instead of trusting a local copy. This
-> note documents the reconciliation *about* Keel; it deliberately does not
-> live under a `keel/` path in this repo, to avoid recreating the drift #20
-> removed.
+> **Current provenance (2026-08-30)**: `braid.profile.json` records the
+> historical U-SA/D32 mapping, but the old Node profile adapter is not an active
+> CI lane. Keel is **not** checked into this repo, current CI does not clone it,
+> and `scripts/keel-floor.sh` now refuses unless a native `keel` binary is
+> explicitly installed. Issue #78 owns the hermetic distribution and evidence
+> migration. This note deliberately does not recreate a drifting `keel/` copy.
 
 ## Purpose
 

--- a/spec/braid/README.md
+++ b/spec/braid/README.md
@@ -80,9 +80,10 @@ surface; Braid adds zero authority.
 - **U9 adversarial pass landed** — 4 findings closed (T3, T4, T12, R3); verdict
   at `U9-VERDICT.md`. **D31 global-IR refactor landed** — substrate/vocabulary
   split, string-tagged capabilities, `TypeTag::Opaque`; vocabularies CMS + JS +
-  web. **U-SA Keel safety-assurance CI landed** — `braid.profile.json` binds
-  Keel's 20 atoms (gate `NotSlop`); the gate runs in CI and is deterministic
-  (serialized — `scripts/keel-floor.sh`). **v0 (U0–U10) is complete.**
+  web. **U-SA's historical Keel profile is not a current CI gate** — the Node
+  adapter was retired, native Keel reports blocking debt, and #78 owns the
+  hermetic migration. **v0 substrate behavior exists; assurance release
+  repeatability remains open.**
 - **Post-v0 frontier (this session, all merged to `main`):**
   - **U11** — `braid-elaborate-js`, the first real language frontend: JS *text*
     compiles into an admitted capsule via the one verifier ("renders JS useless"

--- a/spec/braid/SAFETY_ASSURANCE_CI_SPEC.md
+++ b/spec/braid/SAFETY_ASSURANCE_CI_SPEC.md
@@ -1,10 +1,11 @@
 # Braid Safety-Assurance CI — Specification (D32)
 
-> **Status**: **BUILT (U-SA landed).** This remains the design rationale; the
-> implementation is live — `braid.profile.json` binds Keel's atoms (gate
-> `NotSlop`), `keel/` is vendored, and `.github/workflows/ci.yml` runs the gate
-> (serialized for determinism via `scripts/keel-floor.sh`). The remaining
-> open item is the Lean⇄verifier conformance check (tracked as U15/D-SEMANTICS).
+> **Status (corrected 2026-08-30)**: this remains the historical U-SA/D32
+> design rationale, not a current green gate. `keel/` is absent, the Node entry
+> point was retired, and neither GitHub nor local CI runs a Keel verdict.
+> `scripts/keel-floor.sh` invokes only an explicitly installed native Keel
+> binary, which currently exposes blocking debt. Issue #78 owns hermetic tool
+> distribution, offline evidence, remediation, and release-gate migration.
 > **Authority**: Director session 2026-06-23 ("adopt a CI framework that meets
 > the strictest standards semantically similar to IEC61508 and ISO26262 and
 > DO-178… designed like an ISO standard with the end goal: stop slop").
@@ -161,27 +162,27 @@ surface. The qualification obligations:
 ## 6. The CI pipeline (the wiring)
 
 ```yaml
-# .github/workflows/ci.yml (extended)
+# Structural outline only. The executable source of truth is
+# .github/workflows/ci.yml; scripts/ci-policy-check.sh rejects mutable refs,
+# skipped required lanes, missing timeouts, and early cleanup.
 jobs:
-  tier1-operational:        # existing: fmt, clippy, test, cli-loop, demo-port
-  tier2-semantic:           # NEW
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with: { node-version: 22 }
-      - uses: dtolnay/rust-toolchain@stable
-        with: { components: clippy, rustfmt }
-      - run: cargo test --workspace          # produces Tier-1 evidence
-      - run: ./scripts/cli-loop.sh           # produces Tier-1 evidence
-      - name: Keel semantic floor
-        run: node keel/run.mjs --profile braid.profile.json
-      - uses: actions/upload-artifact@v4
-        with: { name: braid-ci-evidence, path: .ci-runs/ }
+  stack:                    # fail closed on pull-request topology
+  ci-policy:                # reject false-green workflow structure
+    needs: [stack]
+  build:                    # every change runs the full build
+    needs: [ci-policy]
+  test:                     # every change runs all tests and doc tests
+    needs: [build]
+  clippy:                   # every change runs all-target clippy
+    needs: [build]
+  cleanup:                  # waits for every preceding job under always()
+    if: always()
 ```
 
-The Tier-2 job runs Keel with the Braid profile, which reads the Tier-1 evidence
-(produced by the step before it) and emits the verdict. The verdict is
+Native Keel is intentionally not represented as a green CI job here. Issue #78
+owns its hermetic distribution and the remediation needed before its verdict can
+become release authority. Until then, `scripts/keel-floor.sh` is an explicit
+diagnostic adapter and fails if the native binary is unavailable.
 content-addressed (keel `docs/01`); the evidence bundle is uploaded for
 reconstruction (the calculator test).
 


### PR DESCRIPTION
Based on main at `3a89e608`. Advances #78.

## The gap

Braid's documented assurance floor was not the floor GitHub actually executed. The workflow could turn an API failure into "no stack blocker", external actions used mutable refs, path classification could skip required lanes, one job had no timeout, and cleanup could run before five run-owned target directories were finished. The documented Keel command also targeted a deleted Node adapter.

That means a green run could describe orchestration success without proving that the intended work ran.

## The fix

- Run the complete Braid gate for every change.
- Fail closed when stack-position lookup fails.
- Pin every external action to an immutable commit SHA, including Checkout
  `v7.0.1` on its declared Node 24 runtime.
- Give every job a positive timeout.
- Make cleanup wait for every prior job and remove all six exact run-owned target directories under `always()`.
- Add a small source-policy checker and six black-box negative fixtures.
- Replace the dead Keel adapter with an explicit native `keel` invocation and truth-sync the assurance documentation.

I rejected expanding the source classifier. Every new workflow, script, or data extension would reopen another skip hole, while this repository's required gate is fast enough to run for every change.

## Real user path

Green path:

```text
$ ./scripts/ci-policy-check.sh --self-test .github/workflows/ci.yml
ci-policy: OK actions=13 jobs=15 bytes=15747
ci-policy: self-test OK (6 negative fixtures)
exit 0
```

Red path:

```text
$ PATH=/usr/bin:/bin KEEL_BIN= ./scripts/keel-floor.sh
native Keel is unavailable; install it or set KEEL_BIN
issue #78 tracks a hermetic Braid assurance distribution
exit 127
```

The policy self-test also injects each prohibited workflow shape and requires a nonzero result before accepting the checker.

## Proof of teeth

| Mutation | Required result |
|---|---|
| Mutable external action ref | rejected |
| `continue-on-error: true` | rejected |
| Executable shell failure swallow | rejected |
| Job without a timeout | rejected |
| Cleanup before all jobs | rejected |
| Scope-based required-lane skip | rejected |

## The documented Keel gate did not exist

The old adapter expected `keel/src/run.mjs`, but the current Keel is native and not hermetically distributed to Braid CI. This change makes that absence explicit rather than preserving a stale success claim. Native Keel remains diagnostic until #78 establishes a reproducible distribution and closes the existing findings.

## Full CI, run locally at `3b8dcead8d5d8a26e5a72ff14c6097416544af10`

| Evidence | Result |
|---|---|
| `.wwfd/local-ci.sh` | 32/32 steps green |
| CI policy self-test | 6/6 negative fixtures rejected |
| Release verdict | `admit` |
| Registry SHA-256 | `1fac13b0e2798ef3540052a1e9ce0468b3c0fc943d6beb472494554edc1c98e5` |
| Registry CID | `afaa7dcc9ab2f7d1530da72306c7d821c573f8aa9eda2b5c6e463f121f634acd` |
| Capsule CID | `ccedc469e6b0513720969ce1a4f169f53365eeadbc853042c411b44c1f15b71f` |
| Consumer lock SHA-256 | `c0aeda7f6a8941dced115397d191c664532f0f5d895a0f1db09ed4b433abbbba` |

## What is still not done

- #78 remains open: current native Keel reports 456 findings across 212 files on this branch, and its binary is not yet a hermetic CI input.
- The signed release tag tracked by #75 is not cut. It should not precede this CI fix.
- Downstream consumer convergence in #76 remains blocked on a ratified release.
