### PR TITLE
refactor: unify Braid around one ProgramGraph with CFG/DAG projections

### DIFF
--- a/crates/braid-ir/src/graph.rs
+++ b/crates/braid-ir/src/graph.rs
@@ -1,0 +1,426 @@
+//! Unified program graph kernel.
+//!
+//! This module introduces one semantic graph over operations and typed edges.
+//! Existing `Braid` and `FlowSpec` remain compatibility forms during migration;
+//! this kernel does not change their wire encodings or CIDs.
+
+use crate::term::TypeTag;
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NodeId(String);
+
+impl NodeId {
+    pub fn new(value: impl Into<String>) -> Result<Self, GraphError> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(GraphError::InvalidNodeId);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum GraphNodeKind {
+    InvokeTerm { term: String },
+    InvokeCapsule { cid: [u8; 32] },
+    Choice,
+    Join,
+    TerminalSuccess,
+    TerminalFailure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct GraphNode {
+    pub id: NodeId,
+    pub kind: GraphNodeKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct OutputPort {
+    pub node: NodeId,
+    pub port: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct InputPort {
+    pub node: NodeId,
+    pub port: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CompletionClass {
+    Success,
+    Satisfied,
+    Failure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum GraphEdge {
+    Data {
+        from: OutputPort,
+        to: InputPort,
+        value_type: TypeTag,
+    },
+    Control {
+        from: NodeId,
+        to: NodeId,
+        on: Vec<CompletionClass>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProgramGraph {
+    nodes: Vec<GraphNode>,
+    edges: Vec<GraphEdge>,
+    outputs: Vec<OutputPort>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControlFlowGraph {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyDag {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GraphError {
+    InvalidNodeId,
+    DuplicateNode { node: String },
+    MissingEndpoint { node: String },
+    SelfEdge { node: String },
+    DuplicateEdge,
+    ControlCycle,
+    DataCycle,
+}
+
+impl ProgramGraph {
+    pub fn new(
+        mut nodes: Vec<GraphNode>,
+        mut edges: Vec<GraphEdge>,
+        mut outputs: Vec<OutputPort>,
+    ) -> Result<Self, GraphError> {
+        nodes.sort();
+        edges.sort();
+        outputs.sort();
+
+        validate_unique_nodes(&nodes)?;
+        validate_endpoints(&nodes, &edges, &outputs)?;
+        validate_edges(&edges)?;
+        reject_cycle(&nodes, &edges, EdgeClass::Control)?;
+        reject_cycle(&nodes, &edges, EdgeClass::Data)?;
+
+        Ok(Self {
+            nodes,
+            edges,
+            outputs,
+        })
+    }
+
+    pub fn nodes(&self) -> &[GraphNode] {
+        &self.nodes
+    }
+
+    pub fn edges(&self) -> &[GraphEdge] {
+        &self.edges
+    }
+
+    pub fn outputs(&self) -> &[OutputPort] {
+        &self.outputs
+    }
+
+    pub fn cfg(&self) -> ControlFlowGraph {
+        let edges = self
+            .edges
+            .iter()
+            .filter(|edge| matches!(edge, GraphEdge::Control { .. }))
+            .cloned()
+            .collect();
+        ControlFlowGraph {
+            nodes: self.nodes.clone(),
+            edges,
+        }
+    }
+
+    pub fn dag(&self) -> DependencyDag {
+        let edges = self
+            .edges
+            .iter()
+            .filter(|edge| matches!(edge, GraphEdge::Data { .. }))
+            .cloned()
+            .collect();
+        DependencyDag {
+            nodes: self.nodes.clone(),
+            edges,
+        }
+    }
+}
+
+fn validate_unique_nodes(nodes: &[GraphNode]) -> Result<(), GraphError> {
+    let mut previous: Option<&NodeId> = None;
+    for node in nodes {
+        if previous == Some(&node.id) {
+            return Err(GraphError::DuplicateNode {
+                node: node.id.as_str().into(),
+            });
+        }
+        previous = Some(&node.id);
+    }
+    Ok(())
+}
+
+fn validate_endpoints(
+    nodes: &[GraphNode],
+    edges: &[GraphEdge],
+    outputs: &[OutputPort],
+) -> Result<(), GraphError> {
+    let ids: BTreeSet<NodeId> = nodes.iter().map(|node| node.id.clone()).collect();
+    for edge in edges {
+        match edge {
+            GraphEdge::Data { from, to, .. } => {
+                ensure_endpoint(&ids, &from.node)?;
+                ensure_endpoint(&ids, &to.node)?;
+                if from.node == to.node {
+                    return Err(GraphError::SelfEdge {
+                        node: from.node.as_str().into(),
+                    });
+                }
+            }
+            GraphEdge::Control { from, to, .. } => {
+                ensure_endpoint(&ids, from)?;
+                ensure_endpoint(&ids, to)?;
+                if from == to {
+                    return Err(GraphError::SelfEdge {
+                        node: from.as_str().into(),
+                    });
+                }
+            }
+        }
+    }
+    for output in outputs {
+        ensure_endpoint(&ids, &output.node)?;
+    }
+    Ok(())
+}
+
+fn ensure_endpoint(ids: &BTreeSet<NodeId>, node: &NodeId) -> Result<(), GraphError> {
+    if ids.contains(node) {
+        Ok(())
+    } else {
+        Err(GraphError::MissingEndpoint {
+            node: node.as_str().into(),
+        })
+    }
+}
+
+fn validate_edges(edges: &[GraphEdge]) -> Result<(), GraphError> {
+    for pair in edges.windows(2) {
+        if pair[0] == pair[1] {
+            return Err(GraphError::DuplicateEdge);
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum EdgeClass {
+    Control,
+    Data,
+}
+
+fn reject_cycle(
+    nodes: &[GraphNode],
+    edges: &[GraphEdge],
+    class: EdgeClass,
+) -> Result<(), GraphError> {
+    let mut indegree: BTreeMap<NodeId, usize> =
+        nodes.iter().map(|node| (node.id.clone(), 0usize)).collect();
+    let mut adjacency: BTreeMap<NodeId, Vec<NodeId>> = BTreeMap::new();
+
+    for edge in edges {
+        let endpoints = match (class, edge) {
+            (EdgeClass::Control, GraphEdge::Control { from, to, .. }) => {
+                Some((from.clone(), to.clone()))
+            }
+            (EdgeClass::Data, GraphEdge::Data { from, to, .. }) => {
+                Some((from.node.clone(), to.node.clone()))
+            }
+            _ => None,
+        };
+        if let Some((from, to)) = endpoints {
+            adjacency.entry(from).or_default().push(to.clone());
+            *indegree.get_mut(&to).expect("endpoint validated") += 1;
+        }
+    }
+
+    let mut ready: BTreeSet<NodeId> = indegree
+        .iter()
+        .filter_map(|(node, degree)| (*degree == 0).then_some(node.clone()))
+        .collect();
+    let mut visited = 0usize;
+
+    while let Some(node) = ready.pop_first() {
+        visited += 1;
+        if let Some(next) = adjacency.get(&node) {
+            for target in next {
+                let degree = indegree.get_mut(target).expect("endpoint validated");
+                *degree -= 1;
+                if *degree == 0 {
+                    ready.insert(target.clone());
+                }
+            }
+        }
+    }
+
+    if visited == nodes.len() {
+        Ok(())
+    } else {
+        match class {
+            EdgeClass::Control => Err(GraphError::ControlCycle),
+            EdgeClass::Data => Err(GraphError::DataCycle),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn node(id: &str) -> GraphNode {
+        GraphNode {
+            id: NodeId::new(id).unwrap(),
+            kind: GraphNodeKind::Join,
+        }
+    }
+
+    #[test]
+    fn deterministic_ordering_is_insertion_independent() {
+        let a = node("a");
+        let b = node("b");
+        let edge = GraphEdge::Control {
+            from: a.id.clone(),
+            to: b.id.clone(),
+            on: vec![CompletionClass::Success],
+        };
+        let left = ProgramGraph::new(vec![b.clone(), a.clone()], vec![edge.clone()], vec![]).unwrap();
+        let right = ProgramGraph::new(vec![a, b], vec![edge], vec![]).unwrap();
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn duplicate_nodes_fail_closed() {
+        let err = ProgramGraph::new(vec![node("a"), node("a")], vec![], vec![]).unwrap_err();
+        assert!(matches!(err, GraphError::DuplicateNode { .. }));
+    }
+
+    #[test]
+    fn missing_endpoint_fails_closed() {
+        let edge = GraphEdge::Control {
+            from: NodeId::new("a").unwrap(),
+            to: NodeId::new("missing").unwrap(),
+            on: vec![CompletionClass::Success],
+        };
+        let err = ProgramGraph::new(vec![node("a")], vec![edge], vec![]).unwrap_err();
+        assert!(matches!(err, GraphError::MissingEndpoint { .. }));
+    }
+
+    #[test]
+    fn duplicate_edges_fail_closed() {
+        let edge = GraphEdge::Control {
+            from: NodeId::new("a").unwrap(),
+            to: NodeId::new("b").unwrap(),
+            on: vec![CompletionClass::Success],
+        };
+        let err = ProgramGraph::new(
+            vec![node("a"), node("b")],
+            vec![edge.clone(), edge],
+            vec![],
+        )
+        .unwrap_err();
+        assert_eq!(err, GraphError::DuplicateEdge);
+    }
+
+    #[test]
+    fn control_cycle_fails_closed() {
+        let e1 = GraphEdge::Control {
+            from: NodeId::new("a").unwrap(),
+            to: NodeId::new("b").unwrap(),
+            on: vec![CompletionClass::Success],
+        };
+        let e2 = GraphEdge::Control {
+            from: NodeId::new("b").unwrap(),
+            to: NodeId::new("a").unwrap(),
+            on: vec![CompletionClass::Success],
+        };
+        let err = ProgramGraph::new(vec![node("a"), node("b")], vec![e1, e2], vec![])
+            .unwrap_err();
+        assert_eq!(err, GraphError::ControlCycle);
+    }
+
+    #[test]
+    fn data_cycle_fails_closed() {
+        let e1 = GraphEdge::Data {
+            from: OutputPort {
+                node: NodeId::new("a").unwrap(),
+                port: 0,
+            },
+            to: InputPort {
+                node: NodeId::new("b").unwrap(),
+                port: 0,
+            },
+            value_type: TypeTag::Int,
+        };
+        let e2 = GraphEdge::Data {
+            from: OutputPort {
+                node: NodeId::new("b").unwrap(),
+                port: 0,
+            },
+            to: InputPort {
+                node: NodeId::new("a").unwrap(),
+                port: 0,
+            },
+            value_type: TypeTag::Int,
+        };
+        let err = ProgramGraph::new(vec![node("a"), node("b")], vec![e1, e2], vec![])
+            .unwrap_err();
+        assert_eq!(err, GraphError::DataCycle);
+    }
+
+    #[test]
+    fn cfg_and_dag_are_disjoint_views() {
+        let control = GraphEdge::Control {
+            from: NodeId::new("a").unwrap(),
+            to: NodeId::new("b").unwrap(),
+            on: vec![CompletionClass::Success],
+        };
+        let data = GraphEdge::Data {
+            from: OutputPort {
+                node: NodeId::new("a").unwrap(),
+                port: 0,
+            },
+            to: InputPort {
+                node: NodeId::new("b").unwrap(),
+                port: 0,
+            },
+            value_type: TypeTag::Int,
+        };
+        let graph = ProgramGraph::new(vec![node("a"), node("b")], vec![control, data], vec![])
+            .unwrap();
+        assert_eq!(graph.cfg().edges.len(), 1);
+        assert_eq!(graph.dag().edges.len(), 1);
+        assert!(matches!(graph.cfg().edges[0], GraphEdge::Control { .. }));
+        assert!(matches!(graph.dag().edges[0], GraphEdge::Data { .. }));
+    }
+}

--- a/crates/braid-ir/src/graph.rs
+++ b/crates/braid-ir/src/graph.rs
@@ -314,7 +314,8 @@ mod tests {
             to: b.id.clone(),
             on: vec![CompletionClass::Success],
         };
-        let left = ProgramGraph::new(vec![b.clone(), a.clone()], vec![edge.clone()], vec![]).unwrap();
+        let left =
+            ProgramGraph::new(vec![b.clone(), a.clone()], vec![edge.clone()], vec![]).unwrap();
         let right = ProgramGraph::new(vec![a, b], vec![edge], vec![]).unwrap();
         assert_eq!(left, right);
     }
@@ -343,12 +344,8 @@ mod tests {
             to: NodeId::new("b").unwrap(),
             on: vec![CompletionClass::Success],
         };
-        let err = ProgramGraph::new(
-            vec![node("a"), node("b")],
-            vec![edge.clone(), edge],
-            vec![],
-        )
-        .unwrap_err();
+        let err = ProgramGraph::new(vec![node("a"), node("b")], vec![edge.clone(), edge], vec![])
+            .unwrap_err();
         assert_eq!(err, GraphError::DuplicateEdge);
     }
 
@@ -364,8 +361,7 @@ mod tests {
             to: NodeId::new("a").unwrap(),
             on: vec![CompletionClass::Success],
         };
-        let err = ProgramGraph::new(vec![node("a"), node("b")], vec![e1, e2], vec![])
-            .unwrap_err();
+        let err = ProgramGraph::new(vec![node("a"), node("b")], vec![e1, e2], vec![]).unwrap_err();
         assert_eq!(err, GraphError::ControlCycle);
     }
 
@@ -393,8 +389,7 @@ mod tests {
             },
             value_type: TypeTag::Int,
         };
-        let err = ProgramGraph::new(vec![node("a"), node("b")], vec![e1, e2], vec![])
-            .unwrap_err();
+        let err = ProgramGraph::new(vec![node("a"), node("b")], vec![e1, e2], vec![]).unwrap_err();
         assert_eq!(err, GraphError::DataCycle);
     }
 
@@ -416,8 +411,8 @@ mod tests {
             },
             value_type: TypeTag::Int,
         };
-        let graph = ProgramGraph::new(vec![node("a"), node("b")], vec![control, data], vec![])
-            .unwrap();
+        let graph =
+            ProgramGraph::new(vec![node("a"), node("b")], vec![control, data], vec![]).unwrap();
         assert_eq!(graph.cfg().edges.len(), 1);
         assert_eq!(graph.dag().edges.len(), 1);
         assert!(matches!(graph.cfg().edges[0], GraphEdge::Control { .. }));

--- a/crates/braid-ir/src/lib.rs
+++ b/crates/braid-ir/src/lib.rs
@@ -6,6 +6,10 @@
 //! closed registry shape, capsule artifact, compact admission algebra, and the
 //! registry-scoped token projection used after independent verification.
 //!
+//! `graph` is the migration kernel for converging the historical intra-capsule
+//! `Braid` DAG and inter-capsule `FlowSpec` graph onto one semantic node/edge
+//! model. It does not change legacy wire bytes or CIDs.
+//!
 //! //why no serde/ciborium: the canonical byte form is a *security surface*
 //! (admission hashes it). A third-party serializer's normalization choices
 //! would become unauditable parts of the trust base; the subset we need is
@@ -31,6 +35,7 @@ pub mod braid;
 pub mod canon;
 pub mod capsule;
 pub mod cid;
+pub mod graph;
 pub mod term;
 pub mod token;
 pub mod value;
@@ -42,6 +47,11 @@ pub use crate::braid::{Braid, Strand};
 pub use crate::canon::{CanonError, decode_strict, encode};
 pub use crate::capsule::{Capsule, ConfirmPolicy, IR_VERSION};
 pub use crate::cid::{CAPSULE_DOMAIN, Cid, REGISTRY_DOMAIN};
+pub use crate::graph::{
+    CompletionClass as GraphCompletionClass, ControlFlowGraph, DependencyDag, GraphEdge,
+    GraphError, GraphNode, GraphNodeKind, InputPort as GraphInputPort, NodeId,
+    OutputPort as GraphOutputPort, ProgramGraph,
+};
 pub use crate::term::{
     EffectClass, Exposure, TermRegistry, TermSpec, TypeTag, TypeTagError, type_tag_node_count,
     type_tag_to_text, validate_type_tag,

--- a/crates/braid-ir/src/term.rs
+++ b/crates/braid-ir/src/term.rs
@@ -17,7 +17,7 @@ use core::str::FromStr;
 
 /// The closed type universe of strand wiring. No interpretable-code type
 /// exists (T1) and no float type exists (T8) — by construction, not by check.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TypeTag {
     Bool,
     /// Fixed-point integer (term-declared scaling).

--- a/spec/braid/CANDIDATE-ARCHITECTURE.md
+++ b/spec/braid/CANDIDATE-ARCHITECTURE.md
@@ -1,0 +1,191 @@
+# Braid Candidate Architecture — Unified ProgramGraph
+
+**Status:** candidate for ratification in the unified-graph refactor PR.
+**Scope:** replace competing graph authorities with one canonical graph kernel while preserving existing capsule, flow, verifier, and vocabulary semantics during migration.
+
+## 1. Problem
+
+Braid currently has two independent graph ontologies:
+
+1. `braid-ir::Braid` / `Strand` — an intra-capsule topologically ordered DAG of term invocations.
+2. `braid-flow-ir::FlowSpec` / `FlowNode` / `FlowEdge` — an inter-capsule orchestration graph with control, choice, data, and terminal semantics.
+
+The planner then re-derives predecessor/reachability structure from `FlowEdge` and `Choice` arms, while `braid-run` separately interprets `Strand.inputs`. As a result, “the graph” is not one object with one ownership model. Structure, control flow, dataflow, and effect scheduling are split between crates.
+
+The failure mode is architectural drift: two representations can each be locally valid while disagreeing about the actual program dependency structure.
+
+## 2. Decision
+
+Braid shall have exactly one canonical graph kernel: `ProgramGraph`.
+
+`ProgramGraph` is neutral to authoring syntax and execution host. It contains stable nodes and explicit typed edges. Existing capsule and flow forms become projections/adapters over this kernel during migration.
+
+The kernel exposes two deterministic graph views:
+
+- **CFG** — control-flow graph: ordering, branching, completion-conditioned transitions, terminals.
+- **DAG** — dependency graph: typed value flow plus declared resource/effect dependencies.
+
+Neither CFG nor DAG is a second wire format. Both are deterministic views over the same `ProgramGraph` bytes/data.
+
+## 3. Canonical entities
+
+```text
+ProgramGraph
+  nodes: Node[]
+  edges: Edge[]
+  roots: Port[]
+  outputs: Port[]
+
+Node
+  id: NodeId
+  op: Operation
+  guard: Predicate?
+  policy: NodePolicy
+
+Operation
+  InvokeTerm(term_id)
+  InvokeCapsule(cid)
+  Choice
+  Join
+  Terminal(outcome)
+
+Edge
+  Data { from: OutputPort, to: InputPort, type }
+  Control { from: NodeId, to: NodeId, on: CompletionSet }
+  Resource { from: NodeId, to: NodeId, resource: ResourceKey, access: AccessKind }
+```
+
+`Resource` edges are derived from declared system access contracts, not hand-authored scheduling hints.
+
+## 4. Invariants
+
+### G1 — one node identity domain
+Every executable/control node has one stable `NodeId` inside one graph. Array position is never semantic identity.
+
+### G2 — CFG is explicit
+Control dependencies are represented as control edges. Choice successors are not hidden inside node payloads without corresponding CFG edges.
+
+### G3 — data DAG is explicit
+All value dependencies are typed edges. An invocation may not obtain an upstream value not represented by a data edge.
+
+### G4 — resource dependencies are declared
+Effectful systems declare resource access. Conflicts are derived mechanically:
+
+- Read + Read: independent.
+- Read + Write: ordered/conflicting.
+- Write + Write: ordered/conflicting.
+- Append semantics are registry-defined and may be commutative only when explicitly declared.
+
+### G5 — graph views are deterministic
+For identical canonical graph bytes, CFG and DAG projections are byte/order stable.
+
+### G6 — no hidden scheduler semantics
+Planner/runtime may select or execute nodes, but may not invent dependency edges that are absent from the canonical graph/access declarations.
+
+### G7 — one verifier family
+Existing independent decoding/admission remains mandatory, but `braid-verify` and `braid-flow-verify` must converge onto verification of the same graph kernel rather than indefinitely validating sibling graph models.
+
+### G8 — effects return receipts
+A host call for an effectful operation must eventually return a typed effect receipt that binds operation, resource/object identity, attempt, and result. A returned value alone is insufficient evidence of an external mutation.
+
+## 5. Crate target
+
+Target dependency direction:
+
+```text
+braid-capability
+      ↓
+braid-ir
+  └── ProgramGraph + type/value/CID/term registry
+      ↓
+braid-verify
+      ↓
+braid-plan
+      ↓
+braid-run
+
+frontends/vocabularies/render/project
+      ↓
+  adapters only
+```
+
+Temporary migration crates (`braid-flow-ir`, `braid-flow-verify`, `braid-flow-plan`) may remain until their APIs are projected onto the kernel, but they are not long-term authorities.
+
+## 6. CFG projection
+
+`ProgramGraph::cfg()` returns only control edges and node kinds relevant to control.
+
+Properties:
+
+- explicit entry roots;
+- explicit terminal nodes;
+- branch targets represented as edges;
+- completion class on transitions;
+- cycle policy is explicit: v0 remains acyclic unless a future version introduces bounded loops as a first-class operation.
+
+## 7. DAG projection
+
+`ProgramGraph::dag()` returns dependencies that constrain execution:
+
+1. data edges;
+2. resource-conflict edges derived from declared access;
+3. mandatory control-predecessor edges where execution cannot legally occur before control release.
+
+The DAG is the source for deterministic scheduling waves. CFG answers “where may control go?” DAG answers “what must be available/ordered before this node can execute?”
+
+## 8. Candidate system contract
+
+```text
+SystemContract
+  reads: ResourceKey[]
+  writes: ResourceKey[]
+  appends: ResourceKey[]
+  consumes: EventType[]
+  emits: EventType[]
+  capability: Capability?
+  effect: EffectClass
+  idempotency: IdempotencyClass
+  receipt: ReceiptType?
+```
+
+For pure terms, all resource/effect fields are empty/None.
+
+## 9. Migration
+
+### Phase A — kernel introduced
+- Add `ProgramGraph`, `NodeId`, typed `GraphEdge`, CFG/DAG projections.
+- No wire change to existing Capsule/Flow yet.
+- Add adapters from `Braid` and `FlowSpec` into `ProgramGraph`.
+
+### Phase B — verifier convergence
+- `braid-verify` verifies kernel structural/type/effect invariants.
+- `braid-flow-verify` becomes compatibility verification over the same kernel projection.
+
+### Phase C — planner/runtime convergence
+- Planner consumes CFG/DAG from `ProgramGraph`; no hand-built predecessor reconstruction.
+- Runtime executes DAG waves or deterministic sequential fallback from the same projection.
+
+### Phase D — canonical wire migration
+- Introduce a versioned ProgramGraph wire only after compatibility KATs and migration vectors exist.
+- Old capsule/flow bytes remain decodeable as versioned legacy forms.
+
+### Phase E — delete duplicate authorities
+- Remove legacy graph validation/planning code only after exact differential fixtures prove equivalence for supported semantics.
+
+## 10. Non-goals
+
+- No `bevy_ecs` dependency.
+- No new database.
+- No new capability system.
+- No new canonical serializer in this refactor.
+- No claim that parallel execution is safe until resource contracts are implemented and exercised.
+- No silent reinterpretation of existing CIDs.
+
+## 11. Success criterion
+
+A reviewer can point to one canonical object and answer all four questions without opening a second graph model:
+
+1. What operations exist?
+2. Where can control flow?
+3. What data/resources does each operation depend on?
+4. What effects can occur and under what authority?

--- a/spec/braid/PLAN-UNIFIED-GRAPH.md
+++ b/spec/braid/PLAN-UNIFIED-GRAPH.md
@@ -1,0 +1,110 @@
+# One Refactor Plan — Unified ProgramGraph
+
+**Branch:** `refactor/unified-program-graph`
+**Rule:** one migration spine, no parallel architecture.
+
+## Objective
+
+Collapse Braid's duplicated graph semantics into one kernel that deterministically exposes:
+
+- a **CFG** for legal control transitions;
+- a **DAG** for execution dependencies;
+- later, resource/effect conflict edges from declared access contracts.
+
+## Current duplication to remove
+
+1. `braid-ir::Braid` stores intra-capsule term DAG by topological index.
+2. `braid-flow-ir::FlowSpec` stores inter-capsule nodes, data edges, After edges, and hidden Choice successors.
+3. `braid-flow-plan` rebuilds a predecessor graph from Flow edges + Choice arms.
+4. `braid-run` separately walks Strand indices.
+5. Two verifier families validate sibling graph shapes.
+
+## Refactor sequence
+
+### 1. Introduce kernel in `braid-ir`
+Create `graph.rs` with:
+- `NodeId`
+- `GraphNode`
+- `GraphNodeKind`
+- `GraphPort`
+- `GraphEdge::{Data, Control}`
+- `ProgramGraph`
+- `ControlFlowGraph`
+- `DependencyDag`
+
+M1 deliberately excludes resource edges from canonical state until access vocabulary is ratified. The type layout leaves a single extension point rather than inventing semantics.
+
+### 2. Make graph validation one pass family
+Kernel validation checks:
+- unique IDs;
+- endpoints exist;
+- no self edges;
+- no duplicate semantic edges;
+- v0 CFG acyclic;
+- data DAG acyclic;
+- stable canonical ordering of projected nodes/edges.
+
+### 3. Add legacy Braid adapter
+`impl From<&Braid> for ProgramGraph` or an explicit fallible conversion:
+- strand `i` -> `NodeId(i)`;
+- each `inputs[slot]` -> Data edge producer → consumer slot;
+- outputs retained as graph outputs.
+
+No existing `Braid`, Capsule bytes, CIDs, or verifier behavior changes in this step.
+
+### 4. Add Flow adapter
+Map:
+- `FlowNode` -> GraphNode;
+- Data -> Data edge;
+- After -> Control edge;
+- Choice arms/otherwise -> explicit Control edges.
+
+This is the key elimination of hidden topology.
+
+### 5. Differential fixtures
+For existing fixtures:
+- old validation result vs kernel adapter validation result;
+- old predecessor relations vs `cfg()`/`dag()` relations;
+- insertion-order permutations produce identical views.
+
+### 6. Converge verification
+Move graph structural checks behind one kernel verification API. Independent byte decoders remain separate, but once decoded they target the same semantic graph.
+
+### 7. Converge planning
+Delete the hand-built predecessor reconstruction in `braid-flow-plan`. Planner consumes `ProgramGraph::cfg()` and `ProgramGraph::dag()`.
+
+### 8. Converge execution
+`braid-run` consumes dependency DAG ordering. Sequential execution remains the initial policy. Parallel waves are forbidden until resource access contracts are implemented and exercised.
+
+### 9. Add resource/effect contracts
+After kernel convergence, extend registry/system descriptors with stable resource keys and access modes. Derive conflict edges into DAG. Host effects return typed receipts.
+
+### 10. Versioned wire migration
+Only after adapters and KATs prove semantics:
+- define ProgramGraph canonical bytes;
+- bump appropriate graph IR version;
+- preserve legacy decoders;
+- delete Flow/Braid as authorities after downstream migration.
+
+## Hard stop conditions
+
+Stop/refuse expansion if this branch starts doing any of the following:
+
+- rewriting vocabulary crates;
+- replacing the canonical serializer;
+- adding a graph database;
+- adding an ECS dependency;
+- changing existing Capsule/Flow CIDs;
+- parallel execution before resource contracts;
+- moving unrelated `lgwks_std`/bot code.
+
+## Merge gate for this PR
+
+This PR is mergeable only if it delivers M0+M1 as a coherent architectural seam:
+
+- candidate architecture, PRD, and this single plan;
+- graph kernel added to `braid-ir`;
+- deterministic CFG/DAG projections;
+- unit tests for uniqueness, endpoint validity, duplicate edge rejection, CFG cycle rejection, DAG cycle rejection, and deterministic ordering;
+- no existing wire/CID changes;
+- follow-up migration work explicitly remains unclaimed.

--- a/spec/braid/PRD-UNIFIED-GRAPH.md
+++ b/spec/braid/PRD-UNIFIED-GRAPH.md
@@ -1,0 +1,100 @@
+# PRD — Unified Program Graph
+
+**Status:** candidate
+**Owner:** Braid
+**Primary objective:** replace competing graph authorities with one canonical program graph that deterministically yields a pristine CFG and execution DAG.
+
+## Product requirement
+
+Braid must represent a program once and derive control flow, data dependencies, resource conflicts, scheduling, rendering, and verification from that same representation.
+
+## Users
+
+- AI author: emits a bounded graph/data artifact and receives typed refusals.
+- Human reviewer: audits CFG/DAG/effect/resource views without reading executor code.
+- Verifier: independently proves structural, type, capability, effect, taint, and bounds invariants.
+- Planner/runtime: consume graph projections; they do not reconstruct hidden topology.
+
+## Functional requirements
+
+### R1 — one canonical node domain
+All operations use stable `NodeId`; list position is serialization order only.
+
+### R2 — explicit control graph
+Branches, joins, terminals, and completion-conditioned ordering are CFG edges.
+
+### R3 — explicit dependency graph
+Typed value edges are first-class. Resource/effect ordering is derived from declared access contracts.
+
+### R4 — deterministic projections
+`cfg()` and `dag()` are stable for equal graph content and do not depend on insertion/hash-map order.
+
+### R5 — bounded construction
+Node/edge/port/resource counts and identifiers are bounded before expensive allocation or graph traversal.
+
+### R6 — fail-closed validation
+Unknown node kinds, edge kinds, ports, resource access kinds, completion classes, and graph versions refuse.
+
+### R7 — legacy compatibility
+Current `Braid` and `FlowSpec` remain readable during migration. Their adapters must produce the same graph every time and must not change existing CIDs.
+
+### R8 — one scheduling source
+Planner and runtime use the DAG projection. No second predecessor map or hidden dependency reconstruction is allowed after migration.
+
+### R9 — one control source
+Choice targets and terminal reachability are represented in CFG edges rather than only embedded node payloads.
+
+### R10 — effect/resource contracts
+Term/system metadata gains stable resource-qualified read/write/append declarations before parallel scheduling is enabled.
+
+### R11 — typed receipts
+Effectful execution eventually yields receipts bound to node, effect, resource/object, attempt, and result.
+
+### R12 — human renderability
+Renderer exports at least:
+- canonical node/edge manifest;
+- CFG DOT;
+- DAG DOT;
+- resource/effect matrix;
+- widening diff.
+
+## Non-functional requirements
+
+- `no_std` compatible kernel where existing substrate requires it.
+- No unsafe code.
+- No new third-party graph runtime required.
+- No hidden ambient authority.
+- O(V+E) projection/validation target for ordinary graph passes.
+- Deterministic ordering via stable IDs/BTree collections or explicit sort.
+
+## Acceptance scenarios
+
+1. Legacy three-strand capsule converts to one `ProgramGraph`; DAG edges exactly match strand input dependencies.
+2. Flow choice converts to CFG branch edges; branch targets are visible without parsing node internals.
+3. Same graph built in different insertion orders renders identical CFG/DAG sequences.
+4. Data cycle is rejected.
+5. Control cycle is rejected in graph version 0.
+6. Missing source/target node is rejected.
+7. Duplicate node ID is rejected.
+8. Duplicate semantic edge is rejected.
+9. A write/read conflict over one resource yields an ordering dependency once resource contracts land.
+10. Two read-only systems over the same resource remain independent.
+11. Existing capsule and flow CIDs are unchanged by adding the compatibility kernel.
+12. Planner no longer contains its own topology reconstruction after migration.
+13. Runtime cannot call an effectful host operation without the graph/registry-declared effect contract.
+14. Renderer derives CFG/DAG from the same graph object consumed by verification.
+
+## Delivery phases
+
+- **M0:** candidate architecture + PRD + migration plan.
+- **M1:** canonical graph kernel and deterministic CFG/DAG projections.
+- **M2:** Braid adapter and differential tests.
+- **M3:** Flow adapter and differential tests.
+- **M4:** verifier convergence.
+- **M5:** planner convergence.
+- **M6:** runtime/resource contracts + receipts.
+- **M7:** versioned canonical ProgramGraph wire and legacy authority deletion.
+
+## Definition of done
+
+There is one graph kernel in Braid and every graph-aware crate either consumes it or is explicitly a temporary compatibility adapter scheduled for deletion. No runtime/verifier/planner independently re-derives topology from a different model.


### PR DESCRIPTION
## Summary

This PR begins a major architectural reset for Braid around **one semantic graph kernel** instead of maintaining separate intra-capsule and inter-capsule graph authorities.

Today Braid has:

- `braid-ir::Braid` / `Strand` for intra-capsule DAGs;
- `braid-flow-ir::FlowSpec` / `FlowNode` / `FlowEdge` for orchestration;
- planner code that reconstructs predecessor topology from Flow edges + Choice arms;
- runtime code that independently walks Strand indices;
- separate verifier families around the sibling models.

That duplication is the core source of architectural drift.

## Candidate architecture

This PR introduces `braid-ir::ProgramGraph` as the migration kernel:

- stable `NodeId` identity;
- explicit `GraphNode` / `GraphNodeKind`;
- explicit typed `GraphEdge::{Data, Control}`;
- deterministic `cfg()` projection;
- deterministic `dag()` projection;
- fail-closed checks for duplicate nodes/edges, missing endpoints, self edges, CFG cycles, and data cycles.

**CFG** answers where control may flow.
**DAG** answers which data dependencies constrain execution.

Resource/effect conflict edges are deliberately deferred until the shared access vocabulary is ratified; this PR does **not** pretend parallel execution is safe yet.

## Documents added

- `spec/braid/CANDIDATE-ARCHITECTURE.md`
- `spec/braid/PRD-UNIFIED-GRAPH.md`
- `spec/braid/PLAN-UNIFIED-GRAPH.md`

These are one architecture, one PRD, and one migration plan—not parallel proposals.

## Code added

- `crates/braid-ir/src/graph.rs`
- exports from `braid-ir/src/lib.rs`

The graph kernel is intentionally in `braid-ir` so planners, verifiers, runtimes, renderers, and adapters converge toward one semantic owner.

## Explicitly not done in this PR

This is M0+M1 only.

Not claimed:

- no conversion of existing `Braid` or `FlowSpec` yet;
- no verifier convergence yet;
- no planner/runtime migration yet;
- no resource-access scheduling yet;
- no new ProgramGraph canonical wire;
- no change to existing Capsule/Flow bytes or CIDs;
- no parallel execution claim;
- no deletion of legacy graph types.

## Next migration order

1. Braid → ProgramGraph adapter + differential tests.
2. FlowSpec → ProgramGraph adapter with Choice targets emitted as explicit CFG edges.
3. Converge verifier structural checks onto ProgramGraph.
4. Delete planner predecessor reconstruction and consume CFG/DAG directly.
5. Move runtime ordering to DAG projection.
6. Add resource-qualified read/write/append contracts + effect receipts.
7. Only then define a versioned ProgramGraph wire and retire duplicate graph authorities.

## Evidence state

- **Planned:** full convergence described in `PLAN-UNIFIED-GRAPH.md`.
- **Present in code:** ProgramGraph kernel + deterministic CFG/DAG projections + local unit tests in the new module.
- **Exercised on exact commit:** not independently exercised by this review session; GitHub-side source edits only.
- **Independent evidence:** none yet.
- **Safe to merge:** requires CI/build/test review before merge; this PR should remain reviewable as an architectural seam, not be treated as completed convergence.

## Scope budget

This PR intentionally avoids vocabulary changes, serializer changes, new dependencies, database work, ECS runtimes, and unrelated `lgwks_std`/bot work.